### PR TITLE
Remove prefix when modelId is not defined

### DIFF
--- a/src/main/groovy/com/powsybl/dynawo/simulator/LoadAlphaBetaGroovyExtension.groovy
+++ b/src/main/groovy/com/powsybl/dynawo/simulator/LoadAlphaBetaGroovyExtension.groovy
@@ -59,7 +59,7 @@ class LoadAlphaBetaGroovyExtension implements DynamicModelGroovyExtension {
                 throw new DslException("'parameterSetId' field is not set")
             }
 
-            String modelId = loadAlphaBetaSpec.modelId ? loadAlphaBetaSpec.modelId : 'BBM_' + loadAlphaBetaSpec.staticId
+            String modelId = loadAlphaBetaSpec.modelId ? loadAlphaBetaSpec.modelId : loadAlphaBetaSpec.staticId
             consumer.accept(new LoadAlphaBeta(modelId, loadAlphaBetaSpec.staticId, loadAlphaBetaSpec.parameterSetId))
         }
     }

--- a/src/test/java/com/powsybl/dynawo/simulator/DynawoGroovyDynamicModelsSupplierTest.java
+++ b/src/test/java/com/powsybl/dynawo/simulator/DynawoGroovyDynamicModelsSupplierTest.java
@@ -73,8 +73,8 @@ public class DynawoGroovyDynamicModelsSupplierTest {
     private void validateLoad(DynamicModel dynamicModel) {
         assertEquals(LoadAlphaBeta.class, dynamicModel.getClass());
         LoadAlphaBeta loadAlphaBetaImpl = (LoadAlphaBeta) dynamicModel;
-        if (network.getIdentifiable(loadAlphaBetaImpl.getId()) instanceof Load) {
-            assertEquals("LOAD", loadAlphaBetaImpl.getStaticId());
+        if (network.getIdentifiable(loadAlphaBetaImpl.getStaticId()) instanceof Load) {
+            assertEquals("LOAD", loadAlphaBetaImpl.getId());
             assertEquals("default", loadAlphaBetaImpl.getParameterSetId());
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The modelId is defined by the prefix "BBM_" + staticId when it's not specified by the user.


**What is the new behavior (if this is a feature change)?**
The modelId is defined by the staticId when it's not specified by the user.

