### PR TITLE
Move DynawoCurveGroovyExtension into th dynawo package

### DIFF
--- a/src/main/groovy/com/powsybl/dynawo/DynawoCurveGroovyExtension.groovy
+++ b/src/main/groovy/com/powsybl/dynawo/DynawoCurveGroovyExtension.groovy
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.dynawo.dynamicmodels
+package com.powsybl.dynawo
 
 import com.google.auto.service.AutoService
 import com.powsybl.dsl.DslException

--- a/src/test/java/com/powsybl/dynawo/DynawoGroovyCurvesSupplierTest.java
+++ b/src/test/java/com/powsybl/dynawo/DynawoGroovyCurvesSupplierTest.java
@@ -15,7 +15,6 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 
-import com.powsybl.dynawo.dynamicmodels.DynawoCurveGroovyExtension;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
The curve extension is misplaced: currently the class is in the dynamicmodel package, whereas it's not a dynamic model.


**What is the new behavior (if this is a feature change)?**
The class has been moved to the dynawo package


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
