### PR TITLE
Fix compilation with java 8: the order was not predictable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <logback.version>1.1.8</logback.version>
         <xmlunit.version>2.3.0</xmlunit.version>
 
-        <powsyblcore.version>3.8.0-SNAPSHOT</powsyblcore.version>
+        <powsyblcore.version>3.9.0-SNAPSHOT</powsyblcore.version>
     </properties>
 
     <build>

--- a/src/main/java/com/powsybl/dynawo/dynamicmodels/OmegaRef.java
+++ b/src/main/java/com/powsybl/dynawo/dynamicmodels/OmegaRef.java
@@ -98,6 +98,10 @@ public class OmegaRef extends AbstractBlackBoxModel {
             writer.writeAttribute("id", getParameterSetId());
 
             long count = 0;
+            // Black box models returned by the context should follow the same order
+            // of the dynamic models supplier returned by the dynamic models supplier.
+            // The dynamic models are declared in the DYD following the order of dynamic models supplier.
+            // The OmegaRef parameters index the weight of each generator according to that declaration order.
             for (AbstractBlackBoxModel model : context.getBlackBoxModels()) {
                 if (model instanceof OmegaRef) {
                     AbstractBlackBoxModel generatorModel = context.getBlackBoxModel(((OmegaRef) model).getGeneratorDynamicModelId());

--- a/src/main/java/com/powsybl/dynawo/xml/DynawoXmlContext.java
+++ b/src/main/java/com/powsybl/dynawo/xml/DynawoXmlContext.java
@@ -13,6 +13,7 @@ import com.powsybl.dynawo.dynamicmodels.AbstractBlackBoxModel;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -26,9 +27,7 @@ public class DynawoXmlContext {
 
     private final Map<String, AtomicInteger> counters = new HashMap<>();
 
-    private final List<AbstractBlackBoxModel> blackBoxModels;
-
-    private final Map<String, AbstractBlackBoxModel> blackBoxModelsById;
+    private final Map<String, AbstractBlackBoxModel> blackBoxModels;
 
     public DynawoXmlContext(DynawoContext context) {
         this.context = Objects.requireNonNull(context);
@@ -36,8 +35,7 @@ public class DynawoXmlContext {
         this.blackBoxModels = context.getDynamicModels().stream()
                 .filter(AbstractBlackBoxModel.class::isInstance)
                 .map(AbstractBlackBoxModel.class::cast)
-                .collect(Collectors.toList());
-        this.blackBoxModelsById = this.blackBoxModels.stream().collect(Collectors.toMap(b -> b.getDynamicModelId(), b -> b));
+                .collect(Collectors.toMap(AbstractBlackBoxModel::getDynamicModelId, Function.identity(), (o1, o2) -> o1, LinkedHashMap::new));
     }
 
     public String getParFile() {
@@ -53,12 +51,12 @@ public class DynawoXmlContext {
         return increment ? counter.getAndIncrement() : counter.get();
     }
 
-    public List<AbstractBlackBoxModel> getBlackBoxModels() {
-        return Collections.unmodifiableList(blackBoxModels);
+    public Collection<AbstractBlackBoxModel> getBlackBoxModels() {
+        return blackBoxModels.values();
     }
 
     public AbstractBlackBoxModel getBlackBoxModel(String dynamicModelId) {
-        return blackBoxModelsById.get(dynamicModelId);
+        return blackBoxModels.get(dynamicModelId);
     }
 
     public DynawoParametersDatabase getParametersDatabase() {

--- a/src/main/java/com/powsybl/dynawo/xml/DynawoXmlContext.java
+++ b/src/main/java/com/powsybl/dynawo/xml/DynawoXmlContext.java
@@ -11,11 +11,9 @@ import com.powsybl.dynawo.dynamicmodels.AbstractBlackBoxModel;
 import com.powsybl.dynawo.DynawoParametersDatabase;
 
 import java.nio.file.Paths;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -37,7 +35,7 @@ public class DynawoXmlContext {
         this.blackBoxModels = context.getDynamicModels().stream()
                 .filter(AbstractBlackBoxModel.class::isInstance)
                 .map(AbstractBlackBoxModel.class::cast)
-                .collect(Collectors.toMap(AbstractBlackBoxModel::getDynamicModelId, value -> value));
+                .collect(Collectors.toMap(AbstractBlackBoxModel::getDynamicModelId, Function.identity(), (o1, o2) -> o1, TreeMap::new));
     }
 
     public String getParFile() {

--- a/src/main/java/com/powsybl/dynawo/xml/DynawoXmlContext.java
+++ b/src/main/java/com/powsybl/dynawo/xml/DynawoXmlContext.java
@@ -7,13 +7,12 @@
 package com.powsybl.dynawo.xml;
 
 import com.powsybl.dynawo.DynawoContext;
-import com.powsybl.dynawo.dynamicmodels.AbstractBlackBoxModel;
 import com.powsybl.dynawo.DynawoParametersDatabase;
+import com.powsybl.dynawo.dynamicmodels.AbstractBlackBoxModel;
 
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -27,7 +26,9 @@ public class DynawoXmlContext {
 
     private final Map<String, AtomicInteger> counters = new HashMap<>();
 
-    private final Map<String, AbstractBlackBoxModel> blackBoxModels;
+    private final List<AbstractBlackBoxModel> blackBoxModels;
+
+    private final Map<String, AbstractBlackBoxModel> blackBoxModelsById;
 
     public DynawoXmlContext(DynawoContext context) {
         this.context = Objects.requireNonNull(context);
@@ -35,7 +36,8 @@ public class DynawoXmlContext {
         this.blackBoxModels = context.getDynamicModels().stream()
                 .filter(AbstractBlackBoxModel.class::isInstance)
                 .map(AbstractBlackBoxModel.class::cast)
-                .collect(Collectors.toMap(AbstractBlackBoxModel::getDynamicModelId, Function.identity(), (o1, o2) -> o1, TreeMap::new));
+                .collect(Collectors.toList());
+        this.blackBoxModelsById = this.blackBoxModels.stream().collect(Collectors.toMap(b -> b.getDynamicModelId(), b -> b));
     }
 
     public String getParFile() {
@@ -51,12 +53,12 @@ public class DynawoXmlContext {
         return increment ? counter.getAndIncrement() : counter.get();
     }
 
-    public Collection<AbstractBlackBoxModel> getBlackBoxModels() {
-        return blackBoxModels.values();
+    public List<AbstractBlackBoxModel> getBlackBoxModels() {
+        return Collections.unmodifiableList(blackBoxModels);
     }
 
     public AbstractBlackBoxModel getBlackBoxModel(String dynamicModelId) {
-        return blackBoxModels.get(dynamicModelId);
+        return blackBoxModelsById.get(dynamicModelId);
     }
 
     public DynawoParametersDatabase getParametersDatabase() {

--- a/src/test/resources/ieee14-currentlimitautomaton/dynawo-inputs/ieee14bus.par
+++ b/src/test/resources/ieee14-currentlimitautomaton/dynawo-inputs/ieee14bus.par
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dyn:parametersSet xmlns:dyn="http://www.rte-france.com/dynawo">
     <dyn:set id="OMEGA_REF">
-        <dyn:par type="DOUBLE" name="weight_gen_0" value="9281.25"/>
-        <dyn:par type="DOUBLE" name="weight_gen_1" value="6539.400000000001"/>
-        <dyn:par type="DOUBLE" name="weight_gen_2" value="7056.0"/>
-        <dyn:par type="DOUBLE" name="weight_gen_3" value="687.0"/>
-        <dyn:par type="DOUBLE" name="weight_gen_4" value="398.00000000000006"/>
+        <dyn:par type="DOUBLE" name="weight_gen_0" value="6539.400000000001"/>
+        <dyn:par type="DOUBLE" name="weight_gen_1" value="7056.0"/>
+        <dyn:par type="DOUBLE" name="weight_gen_2" value="9281.25"/>
+        <dyn:par type="DOUBLE" name="weight_gen_3" value="398.00000000000006"/>
+        <dyn:par type="DOUBLE" name="weight_gen_4" value="687.0"/>
         <dyn:par type="INT" name="nbGen" value="5"/>
     </dyn:set>
 </dyn:parametersSet>

--- a/src/test/resources/ieee14-disconnectline/dynawo-inputs/ieee14bus.par
+++ b/src/test/resources/ieee14-disconnectline/dynawo-inputs/ieee14bus.par
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dyn:parametersSet xmlns:dyn="http://www.rte-france.com/dynawo">
     <dyn:set id="OMEGA_REF">
-        <dyn:par type="DOUBLE" name="weight_gen_0" value="9281.25"/>
-        <dyn:par type="DOUBLE" name="weight_gen_1" value="6539.400000000001"/>
-        <dyn:par type="DOUBLE" name="weight_gen_2" value="7056.0"/>
-        <dyn:par type="DOUBLE" name="weight_gen_3" value="687.0"/>
-        <dyn:par type="DOUBLE" name="weight_gen_4" value="398.00000000000006"/>
+        <dyn:par type="DOUBLE" name="weight_gen_0" value="6539.400000000001"/>
+        <dyn:par type="DOUBLE" name="weight_gen_1" value="7056.0"/>
+        <dyn:par type="DOUBLE" name="weight_gen_2" value="9281.25"/>
+        <dyn:par type="DOUBLE" name="weight_gen_3" value="398.00000000000006"/>
+        <dyn:par type="DOUBLE" name="weight_gen_4" value="687.0"/>
         <dyn:par type="INT" name="nbGen" value="5"/>
     </dyn:set>
 </dyn:parametersSet>

--- a/src/test/resources/ieee14-macroconnects/dynawo-inputs/ieee14bus.par
+++ b/src/test/resources/ieee14-macroconnects/dynawo-inputs/ieee14bus.par
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dyn:parametersSet xmlns:dyn="http://www.rte-france.com/dynawo">
     <dyn:set id="OMEGA_REF">
-        <dyn:par type="DOUBLE" name="weight_gen_0" value="9281.25"/>
-        <dyn:par type="DOUBLE" name="weight_gen_1" value="6539.400000000001"/>
-        <dyn:par type="DOUBLE" name="weight_gen_2" value="7056.0"/>
-        <dyn:par type="DOUBLE" name="weight_gen_3" value="687.0"/>
-        <dyn:par type="DOUBLE" name="weight_gen_4" value="398.00000000000006"/>
+        <dyn:par type="DOUBLE" name="weight_gen_0" value="6539.400000000001"/>
+        <dyn:par type="DOUBLE" name="weight_gen_1" value="7056.0"/>
+        <dyn:par type="DOUBLE" name="weight_gen_2" value="9281.25"/>
+        <dyn:par type="DOUBLE" name="weight_gen_3" value="398.00000000000006"/>
+        <dyn:par type="DOUBLE" name="weight_gen_4" value="687.0"/>
         <dyn:par type="INT" name="nbGen" value="5"/>
     </dyn:set>
 </dyn:parametersSet>

--- a/src/test/resources/ieee57-disconnectgenerator/dynawo-inputs/ieee57bus.par
+++ b/src/test/resources/ieee57-disconnectgenerator/dynawo-inputs/ieee57bus.par
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dyn:parametersSet xmlns:dyn="http://www.rte-france.com/dynawo">
     <dyn:set id="OMEGA_REF">
-        <dyn:par type="DOUBLE" name="weight_gen_0" value="6539.400000000001"/>
+        <dyn:par type="DOUBLE" name="weight_gen_0" value="8741.52"/>
         <dyn:par type="DOUBLE" name="weight_gen_1" value="8741.52"/>
         <dyn:par type="DOUBLE" name="weight_gen_2" value="9281.25"/>
         <dyn:par type="DOUBLE" name="weight_gen_3" value="6539.400000000001"/>
         <dyn:par type="DOUBLE" name="weight_gen_4" value="6048.0"/>
-        <dyn:par type="DOUBLE" name="weight_gen_5" value="8741.52"/>
+        <dyn:par type="DOUBLE" name="weight_gen_5" value="6539.400000000001"/>
         <dyn:par type="DOUBLE" name="weight_gen_6" value="9281.25"/>
         <dyn:par type="INT" name="nbGen" value="7"/>
     </dyn:set>

--- a/src/test/resources/ieee57-disconnectgenerator/dynawo-inputs/ieee57bus.par
+++ b/src/test/resources/ieee57-disconnectgenerator/dynawo-inputs/ieee57bus.par
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dyn:parametersSet xmlns:dyn="http://www.rte-france.com/dynawo">
     <dyn:set id="OMEGA_REF">
-        <dyn:par type="DOUBLE" name="weight_gen_0" value="8741.52"/>
-        <dyn:par type="DOUBLE" name="weight_gen_1" value="8741.52"/>
-        <dyn:par type="DOUBLE" name="weight_gen_2" value="9281.25"/>
-        <dyn:par type="DOUBLE" name="weight_gen_3" value="6539.400000000001"/>
-        <dyn:par type="DOUBLE" name="weight_gen_4" value="6048.0"/>
-        <dyn:par type="DOUBLE" name="weight_gen_5" value="6539.400000000001"/>
+        <dyn:par type="DOUBLE" name="weight_gen_0" value="6048.0"/>
+        <dyn:par type="DOUBLE" name="weight_gen_1" value="6539.400000000001"/>
+        <dyn:par type="DOUBLE" name="weight_gen_2" value="8741.52"/>
+        <dyn:par type="DOUBLE" name="weight_gen_3" value="8741.52"/>
+        <dyn:par type="DOUBLE" name="weight_gen_4" value="6539.400000000001"/>
+        <dyn:par type="DOUBLE" name="weight_gen_5" value="9281.25"/>
         <dyn:par type="DOUBLE" name="weight_gen_6" value="9281.25"/>
         <dyn:par type="INT" name="nbGen" value="7"/>
     </dyn:set>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The compilation fails with Java 8 due to an unpredictable order in the DynawoContext.


**What is the new behavior (if this is a feature change)?**
We now use a `TreeMap` to have a predictable order of the dynamic models


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
