### PR TITLE
DynaflowProvider: added files for provider

### DIFF
--- a/src/main/java/com/powsybl/dynaflow/DynaflowProvider.java
+++ b/src/main/java/com/powsybl/dynaflow/DynaflowProvider.java
@@ -49,7 +49,7 @@ public class DynaflowProvider implements LoadFlowProvider {
         this.versionCmd = getVersionCommand();
     }
 
-    static private void writeIIDM(Path workingDir, Network network) {
+    private static void writeIIDM(Path workingDir, Network network) {
         Properties params = new Properties();
         params.setProperty(XMLExporter.VERSION, IidmXmlVersion.V_1_0.toString("."));
         Exporters.export("XIIDM", network, params, workingDir.resolve(IIDM_FILENAME));

--- a/src/main/java/com/powsybl/dynaflow/DynaflowProvider.java
+++ b/src/main/java/com/powsybl/dynaflow/DynaflowProvider.java
@@ -11,7 +11,6 @@ import com.powsybl.computation.*;
 import com.powsybl.dynaflow.json.DynaflowConfigSerializer;
 import com.powsybl.iidm.export.Exporters;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.util.Networks;
 import com.powsybl.iidm.xml.IidmXmlVersion;
 import com.powsybl.iidm.xml.XMLExporter;
 import com.powsybl.loadflow.LoadFlowParameters;
@@ -100,7 +99,7 @@ public class DynaflowProvider implements LoadFlowProvider {
 
     private CommandExecution createCommandExecution(Network network, Path workingDir) {
         Command cmd = getCommand(workingDir);
-        return new CommandExecution(cmd, 1, 0, Networks.getExecutionTags(network));
+        return new CommandExecution(cmd, 1, 0);
     }
 
     @Override

--- a/src/main/java/com/powsybl/dynaflow/DynaflowProvider.java
+++ b/src/main/java/com/powsybl/dynaflow/DynaflowProvider.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+jklM1 * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.dynaflow;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.computation.*;
+import com.powsybl.dynaflow.json.DynaflowConfigSerializer;
+import com.powsybl.iidm.export.Exporters;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.util.Networks;
+import com.powsybl.iidm.xml.IidmXmlVersion;
+import com.powsybl.iidm.xml.XMLExporter;
+import com.powsybl.loadflow.LoadFlowParameters;
+import com.powsybl.loadflow.LoadFlowProvider;
+import com.powsybl.loadflow.LoadFlowResult;
+import com.powsybl.loadflow.LoadFlowResultImpl;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+import static com.powsybl.dynaflow.DynaflowConstants.CONFIG_FILENAME;
+import static com.powsybl.dynaflow.DynaflowConstants.IIDM_FILENAME;
+
+/**
+ *
+ * @author Guillaume Pernin <guillaume.pernin at rte-france.com>
+ */
+@AutoService(LoadFlowProvider.class)
+public class DynaflowProvider implements LoadFlowProvider {
+
+    private final ExecutionEnvironment env;
+    private final Command versionCmd;
+    private final DynaflowConfig config;
+    private static final String WORKING_DIR_PREFIX = "dynaflow_";
+
+    public DynaflowProvider() {
+        this(DynaflowConfig.fromPropertyFile());
+    }
+
+    public DynaflowProvider(DynaflowConfig config) {
+        Objects.requireNonNull(config, "The Config is Null");
+        this.config = config;
+        this.env = new ExecutionEnvironment(config.createEnv(), WORKING_DIR_PREFIX, config.isDebug());
+        this.versionCmd = getVersionCommand();
+    }
+
+    private void writeIIDM(Path workingDir, Network network) {
+        Properties params = new Properties();
+        params.setProperty(XMLExporter.VERSION, IidmXmlVersion.V_1_0.toString("."));
+        Exporters.export("XIIDM", network, params, workingDir.resolve(IIDM_FILENAME));
+    }
+
+    private String getProgram() {
+        return config.getHomeDir().resolve("dynaflow-launcher.sh").toString();
+    }
+
+    public Command getCommand(Path workingDir) {
+        String iidmPath = workingDir.resolve(IIDM_FILENAME).toString();
+        String configPath = workingDir.resolve(CONFIG_FILENAME).toString();
+        List<String> args = Arrays.asList("--iidm", iidmPath, "--config", configPath);
+
+        return new SimpleCommandBuilder()
+                .id("dynaflow_lf")
+                .program(getProgram())
+                .args(args)
+                .build();
+    }
+
+    public Command getVersionCommand() {
+        List<String> args = Collections.singletonList("--version");
+        return new SimpleCommandBuilder()
+                .id("dynaflow_version")
+                .program(getProgram())
+                .args(args)
+                .build();
+    }
+
+    static DynaflowParameters getParametersExt(LoadFlowParameters parameters) {
+        DynaflowParameters parametersExt = parameters.getExtension(DynaflowParameters.class);
+        if (parametersExt == null) {
+            parametersExt = new DynaflowParameters();
+        }
+        return parametersExt;
+    }
+
+    @Override
+    public String getName() {
+        return "DynaFlow";
+    }
+
+    @Override
+    public String getVersion() {
+        return "0.1";
+    }
+
+    private CommandExecution createCommandExecution(Network network, Path workingDir) {
+        Command cmd = getCommand(workingDir);
+        return new CommandExecution(cmd, 1, 0, Networks.getExecutionTags(network));
+    }
+
+    @Override
+    public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingStateId, LoadFlowParameters parameters) {
+        Objects.requireNonNull(network);
+        Objects.requireNonNull(computationManager);
+        Objects.requireNonNull(workingStateId);
+        Objects.requireNonNull(parameters);
+        DynaflowParameters dynaflowParameters = getParametersExt(parameters);
+        DynaflowUtil.checkDynaflowVersion(env, computationManager, versionCmd);
+        return computationManager.execute(env, new AbstractExecutionHandler<LoadFlowResult>() {
+            @Override
+            public List<CommandExecution> before(Path workingDir) throws IOException {
+                network.getVariantManager().setWorkingVariant(workingStateId);
+
+                writeIIDM(workingDir, network);
+                DynaflowConfigSerializer.serialize(parameters, dynaflowParameters, workingDir.resolve(CONFIG_FILENAME));
+                return Collections.singletonList(createCommandExecution(network, workingDir));
+            }
+
+            @Override
+            public LoadFlowResult after(Path workingDir, ExecutionReport report) throws IOException {
+                super.after(workingDir, report);
+                network.getVariantManager().setWorkingVariant(workingStateId);
+
+                Map<String, String> metrics = new HashMap<>();
+                String logs = null;
+                return new LoadFlowResultImpl(true, metrics, logs);
+            }
+        });
+    }
+}

--- a/src/main/java/com/powsybl/dynaflow/DynaflowProvider.java
+++ b/src/main/java/com/powsybl/dynaflow/DynaflowProvider.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2020, RTE (http://www.rte-france.com)
-jklM1 * This Source Code Form is subject to the terms of the Mozilla Public
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
@@ -34,23 +34,22 @@ import static com.powsybl.dynaflow.DynaflowConstants.IIDM_FILENAME;
 @AutoService(LoadFlowProvider.class)
 public class DynaflowProvider implements LoadFlowProvider {
 
+    private static final String WORKING_DIR_PREFIX = "dynaflow_";
     private final ExecutionEnvironment env;
     private final Command versionCmd;
     private final DynaflowConfig config;
-    private static final String WORKING_DIR_PREFIX = "dynaflow_";
 
     public DynaflowProvider() {
         this(DynaflowConfig.fromPropertyFile());
     }
 
     public DynaflowProvider(DynaflowConfig config) {
-        Objects.requireNonNull(config, "The Config is Null");
-        this.config = config;
+        this.config = Objects.requireNonNull(config, "Config is null");
         this.env = new ExecutionEnvironment(config.createEnv(), WORKING_DIR_PREFIX, config.isDebug());
         this.versionCmd = getVersionCommand();
     }
 
-    private void writeIIDM(Path workingDir, Network network) {
+    static private void writeIIDM(Path workingDir, Network network) {
         Properties params = new Properties();
         params.setProperty(XMLExporter.VERSION, IidmXmlVersion.V_1_0.toString("."));
         Exporters.export("XIIDM", network, params, workingDir.resolve(IIDM_FILENAME));
@@ -81,7 +80,7 @@ public class DynaflowProvider implements LoadFlowProvider {
                 .build();
     }
 
-    static DynaflowParameters getParametersExt(LoadFlowParameters parameters) {
+    private static DynaflowParameters getParametersExt(LoadFlowParameters parameters) {
         DynaflowParameters parametersExt = parameters.getExtension(DynaflowParameters.class);
         if (parametersExt == null) {
             parametersExt = new DynaflowParameters();

--- a/src/test/java/com/powsybl/dynaflow/AbstractLocalCommandExecutor.java
+++ b/src/test/java/com/powsybl/dynaflow/AbstractLocalCommandExecutor.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.dynaflow;
+
+import com.powsybl.computation.local.LocalCommandExecutor;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+/**
+ *
+ * @author Guillaume Pernin <guillaume.pernin at rte-france.com>
+ */
+abstract class AbstractLocalCommandExecutor implements LocalCommandExecutor {
+    @Override
+    public void stop(Path workingDir) {
+
+    }
+
+    @Override
+    public void stopForcibly(Path workingDir) {
+
+    }
+
+    void copyFile(String source, Path target) throws IOException {
+        try (InputStream is = getClass().getResourceAsStream(source)) {
+            Files.copy(is, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+}

--- a/src/test/java/com/powsybl/dynaflow/AbstractLocalCommandExecutor.java
+++ b/src/test/java/com/powsybl/dynaflow/AbstractLocalCommandExecutor.java
@@ -19,17 +19,18 @@ import java.nio.file.StandardCopyOption;
  * @author Guillaume Pernin <guillaume.pernin at rte-france.com>
  */
 abstract class AbstractLocalCommandExecutor implements LocalCommandExecutor {
+
     @Override
     public void stop(Path workingDir) {
-
+        // Nothing to do
     }
 
     @Override
     public void stopForcibly(Path workingDir) {
-
+        // Nothing to do
     }
 
-    void copyFile(String source, Path target) throws IOException {
+    protected void copyFile(String source, Path target) throws IOException {
         try (InputStream is = getClass().getResourceAsStream(source)) {
             Files.copy(is, target, StandardCopyOption.REPLACE_EXISTING);
         }

--- a/src/test/java/com/powsybl/dynaflow/DynaflowProviderTest.java
+++ b/src/test/java/com/powsybl/dynaflow/DynaflowProviderTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.dynaflow;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.powsybl.commons.config.InMemoryPlatformConfig;
+import com.powsybl.computation.ComputationManager;
+import com.powsybl.computation.local.LocalCommandExecutor;
+import com.powsybl.computation.local.LocalComputationConfig;
+import com.powsybl.computation.local.LocalComputationManager;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.loadflow.LoadFlow;
+import com.powsybl.loadflow.LoadFlowParameters;
+import com.powsybl.loadflow.LoadFlowResult;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ForkJoinPool;
+
+import static com.powsybl.dynaflow.DynaflowConstants.CONFIG_FILENAME;
+import static com.powsybl.dynaflow.DynaflowConstants.IIDM_FILENAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Guillaume Pernin <guillaume.pernin at rte-france.com>
+ */
+public class DynaflowProviderTest {
+    private InMemoryPlatformConfig platformConfig;
+    private FileSystem fileSystem;
+    private String homeDir;
+    private DynaflowProvider provider;
+
+    @Before
+    public void setUp() {
+        fileSystem = Jimfs.newFileSystem(Configuration.unix());
+        platformConfig = new InMemoryPlatformConfig(fileSystem);
+        homeDir = "/home/dynaflow";
+        provider = new DynaflowProvider();
+    }
+
+    @Test
+    public void checkVersionCommand() {
+        Path pathHomeDir = fileSystem.getPath(homeDir);
+        String program = pathHomeDir.resolve("dynaflow-launcher.sh").toString();
+
+        String versionCommand = provider.getVersionCommand().toString(0);
+        String expectedVersionCommand = "[" + program + ", --version]";
+
+        assertEquals(expectedVersionCommand, versionCommand);
+    }
+
+    @Test
+    public void checkExecutionCommand() {
+
+        Path workingDir = fileSystem.getPath("tmp").resolve("dynaflow");
+        String program = fileSystem.getPath(homeDir).resolve("dynaflow-launcher.sh").toString();
+        String iidmPath = workingDir.resolve(IIDM_FILENAME).toString();
+        String configPath = workingDir.resolve(CONFIG_FILENAME).toString();
+
+        String executionCommand = provider.getCommand(workingDir).toString(0);
+        String expectedExecutionCommand = "[" + program + ", --iidm, " + iidmPath +
+                ", --config, " + configPath + "]";
+        assertEquals(expectedExecutionCommand, executionCommand);
+    }
+
+    private class LocalCommandExecutorMock implements LocalCommandExecutor {
+
+        private String stdOutFileRef;
+
+        public LocalCommandExecutorMock(String stdoutFileRef) {
+            this.stdOutFileRef = stdoutFileRef;
+        }
+
+        @Override
+        public int execute(String program, List<String> args, Path outFile, Path errFile, Path workingDir, Map<String, String> env) {
+            try {
+                copyFile(stdOutFileRef, errFile);
+
+                return 0;
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public void stop(Path workingDir) {
+
+        }
+
+        @Override
+        public void stopForcibly(Path workingDir) {
+
+        }
+
+        private void copyFile(String source, Path target) throws IOException {
+            try (InputStream is = getClass().getResourceAsStream(source)) {
+                Files.copy(is, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        }
+    }
+
+    @Test
+    public void test() throws Exception {
+        Network network = Network.create("test", "test");
+
+        LoadFlow.Runner dynaflowSimulation = LoadFlow.find();
+        LoadFlowParameters params = LoadFlowParameters.load();
+
+        assertEquals("DynaFlow", dynaflowSimulation.getName());
+        assertEquals("0.1", dynaflowSimulation.getVersion());
+
+        LocalCommandExecutor commandExecutor = new DynaflowProviderTest.LocalCommandExecutorMock("/dynaflow/dynaflow_version.out");
+        ComputationManager computationManager = new LocalComputationManager(new LocalComputationConfig(fileSystem.getPath("/working-dir"), 1), commandExecutor, ForkJoinPool.commonPool());
+        LoadFlowResult result = dynaflowSimulation.run(network, computationManager, params);
+        assertNotNull(result);
+    }
+}

--- a/src/test/java/com/powsybl/dynaflow/DynaflowProviderTest.java
+++ b/src/test/java/com/powsybl/dynaflow/DynaflowProviderTest.java
@@ -26,6 +26,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ForkJoinPool;
 
 import static com.powsybl.dynaflow.DynaflowConstants.CONFIG_FILENAME;
@@ -63,24 +64,22 @@ public class DynaflowProviderTest {
 
     @Test
     public void checkExecutionCommand() {
-
         Path workingDir = fileSystem.getPath("tmp").resolve("dynaflow");
         String program = fileSystem.getPath(homeDir).resolve("dynaflow-launcher.sh").toString();
         String iidmPath = workingDir.resolve(IIDM_FILENAME).toString();
         String configPath = workingDir.resolve(CONFIG_FILENAME).toString();
 
         String executionCommand = provider.getCommand(workingDir).toString(0);
-        String expectedExecutionCommand = "[" + program + ", --iidm, " + iidmPath +
-                ", --config, " + configPath + "]";
+        String expectedExecutionCommand = "[" + program + ", --iidm, " + iidmPath + ", --config, " + configPath + "]";
         assertEquals(expectedExecutionCommand, executionCommand);
     }
 
-    private class LocalCommandExecutorMock extends AbstractLocalCommandExecutor {
+    private static class LocalCommandExecutorMock extends AbstractLocalCommandExecutor {
 
-        private String stdOutFileRef;
+        private final String stdOutFileRef;
 
         public LocalCommandExecutorMock(String stdoutFileRef) {
-            this.stdOutFileRef = stdoutFileRef;
+            this.stdOutFileRef = Objects.requireNonNull(stdoutFileRef);
         }
 
         @Override

--- a/src/test/java/com/powsybl/dynaflow/DynaflowProviderTest.java
+++ b/src/test/java/com/powsybl/dynaflow/DynaflowProviderTest.java
@@ -78,7 +78,7 @@ public class DynaflowProviderTest {
         assertEquals(expectedExecutionCommand, executionCommand);
     }
 
-    private class LocalCommandExecutorMock implements LocalCommandExecutor {
+    private class LocalCommandExecutorMock extends AbstractLocalCommandExecutor {
 
         private String stdOutFileRef;
 
@@ -96,22 +96,6 @@ public class DynaflowProviderTest {
                 throw new UncheckedIOException(e);
             }
         }
-
-        @Override
-        public void stop(Path workingDir) {
-
-        }
-
-        @Override
-        public void stopForcibly(Path workingDir) {
-
-        }
-
-        private void copyFile(String source, Path target) throws IOException {
-            try (InputStream is = getClass().getResourceAsStream(source)) {
-                Files.copy(is, target, StandardCopyOption.REPLACE_EXISTING);
-            }
-        }
     }
 
     @Test
@@ -124,7 +108,7 @@ public class DynaflowProviderTest {
         assertEquals("DynaFlow", dynaflowSimulation.getName());
         assertEquals("0.1", dynaflowSimulation.getVersion());
 
-        LocalCommandExecutor commandExecutor = new DynaflowProviderTest.LocalCommandExecutorMock("/dynaflow/dynaflow_version.out");
+        LocalCommandExecutor commandExecutor = new LocalCommandExecutorMock("/dynaflow/dynaflow_version.out");
         ComputationManager computationManager = new LocalComputationManager(new LocalComputationConfig(fileSystem.getPath("/working-dir"), 1), commandExecutor, ForkJoinPool.commonPool());
         LoadFlowResult result = dynaflowSimulation.run(network, computationManager, params);
         assertNotNull(result);

--- a/src/test/java/com/powsybl/dynaflow/DynaflowProviderTest.java
+++ b/src/test/java/com/powsybl/dynaflow/DynaflowProviderTest.java
@@ -21,12 +21,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.FileSystem;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ForkJoinPool;

--- a/src/test/java/com/powsybl/dynaflow/DynaflowVersionCheckTest.java
+++ b/src/test/java/com/powsybl/dynaflow/DynaflowVersionCheckTest.java
@@ -8,7 +8,10 @@ package com.powsybl.dynaflow;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import com.powsybl.computation.*;
+import com.powsybl.computation.Command;
+import com.powsybl.computation.ComputationManager;
+import com.powsybl.computation.ExecutionEnvironment;
+import com.powsybl.computation.SimpleCommandBuilder;
 import com.powsybl.computation.local.LocalCommandExecutor;
 import com.powsybl.computation.local.LocalComputationConfig;
 import com.powsybl.computation.local.LocalComputationManager;
@@ -18,12 +21,9 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.FileSystem;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ForkJoinPool;

--- a/src/test/java/com/powsybl/dynaflow/DynaflowVersionCheckTest.java
+++ b/src/test/java/com/powsybl/dynaflow/DynaflowVersionCheckTest.java
@@ -26,6 +26,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ForkJoinPool;
 
 import static org.junit.Assert.assertFalse;
@@ -44,12 +45,12 @@ public class DynaflowVersionCheckTest {
             .program("dummy")
             .build();
 
-    private class LocalCommandExecutorMock extends AbstractLocalCommandExecutor {
+    private static class LocalCommandExecutorMock extends AbstractLocalCommandExecutor {
 
-        private String stdOutFileRef;
+        private final String stdOutFileRef;
 
         public LocalCommandExecutorMock(String stdoutFileRef) {
-            this.stdOutFileRef = stdoutFileRef;
+            this.stdOutFileRef = Objects.requireNonNull(stdoutFileRef);
         }
 
         @Override

--- a/src/test/java/com/powsybl/dynaflow/DynaflowVersionCheckTest.java
+++ b/src/test/java/com/powsybl/dynaflow/DynaflowVersionCheckTest.java
@@ -44,7 +44,7 @@ public class DynaflowVersionCheckTest {
             .program("dummy")
             .build();
 
-    private class LocalCommandExecutorMock implements LocalCommandExecutor {
+    private class LocalCommandExecutorMock extends AbstractLocalCommandExecutor {
 
         private String stdOutFileRef;
 
@@ -60,22 +60,6 @@ public class DynaflowVersionCheckTest {
                 return 0;
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
-            }
-        }
-
-        @Override
-        public void stop(Path workingDir) {
-
-        }
-
-        @Override
-        public void stopForcibly(Path workingDir) {
-
-        }
-
-        private void copyFile(String source, Path target) throws IOException {
-            try (InputStream is = getClass().getResourceAsStream(source)) {
-                Files.copy(is, target, StandardCopyOption.REPLACE_EXISTING);
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Guillaume Pernin <guillaume.pernin@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
You can not launch dynaflowLauncher from powsybl.


**What is the new behavior (if this is a feature change)?**
With the provider file added, the method run can call dynaflowLauncher with the proper arguments, an iidm file and a configuration file.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
To test the provider is not an easy task, the way it is tested now is by creating a LocalCommandExecutor as it is done in the test of version check. I have not found an other way to create the file required by the checkDynaflowVersion function called in the run method. 
Of course there may be other way to test this and I remain open to suggestion.
(if any of the questions/checkboxes don't apply, please delete them entirely)
