### PR TITLE
Add classifier to generate javadoc instead of groovydoc

### DIFF
--- a/dynawaltz-dsl/pom.xml
+++ b/dynawaltz-dsl/pom.xml
@@ -20,6 +20,10 @@
     <name>DynaWaltz DSL</name>
     <description>DSL for DynaWaltz</description>
 
+    <properties>
+        <groovydoc.classifier>javadoc</groovydoc.classifier>
+    </properties>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Add classifier property to generate javadoc instead of groovydoc (Sonatype issue)

i *(What changes might users need to make in their application due to this PR?)*


**Other information**:
Commit to report into release 1.0.0
