### PR TITLE
Add plugin to send javadoc to sonatype

### DIFF
--- a/dynawaltz-dsl/pom.xml
+++ b/dynawaltz-dsl/pom.xml
@@ -30,6 +30,10 @@
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Javadoc is generated in dynawalz-dsl but is not sent during deploy. Adding this plugin ensures that the javadoc is sent.


**Other information**:
Commit to add to release 1.0.0
