### PR TITLE
DynaFlow config lazy loading

### DIFF
--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowProvider.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowProvider.java
@@ -7,6 +7,8 @@
 package com.powsybl.dynaflow;
 
 import com.google.auto.service.AutoService;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.powsybl.computation.*;
 import com.powsybl.dynaflow.json.DynaFlowConfigSerializer;
 import com.powsybl.iidm.export.Exporters;
@@ -34,18 +36,19 @@ import static com.powsybl.dynaflow.DynaFlowConstants.IIDM_FILENAME;
 public class DynaFlowProvider implements LoadFlowProvider {
 
     private static final String WORKING_DIR_PREFIX = "dynaflow_";
-    private final ExecutionEnvironment env;
-    private final Command versionCmd;
-    private final DynaFlowConfig config;
+
+    private final Supplier<DynaFlowConfig> configSupplier;
 
     public DynaFlowProvider() {
-        this(DynaFlowConfig.fromPropertyFile());
+        this(DynaFlowConfig::fromPropertyFile);
     }
 
-    public DynaFlowProvider(DynaFlowConfig config) {
-        this.config = Objects.requireNonNull(config, "Config is null");
-        this.env = new ExecutionEnvironment(config.createEnv(), WORKING_DIR_PREFIX, config.isDebug());
-        this.versionCmd = getVersionCommand();
+    public DynaFlowProvider(Supplier<DynaFlowConfig> configSupplier) {
+        this.configSupplier = Suppliers.memoize(Objects.requireNonNull(configSupplier, "Config supplier is null"));
+    }
+
+    DynaFlowConfig getConfig() {
+        return configSupplier.get();
     }
 
     private static void writeIIDM(Path workingDir, Network network) {
@@ -54,25 +57,25 @@ public class DynaFlowProvider implements LoadFlowProvider {
         Exporters.export("XIIDM", network, params, workingDir.resolve(IIDM_FILENAME));
     }
 
-    private String getProgram() {
+    private static String getProgram(DynaFlowConfig config) {
         return config.getHomeDir().resolve("dynaflow-launcher.sh").toString();
     }
 
-    public Command getCommand() {
+    public static Command getCommand(DynaFlowConfig config) {
         List<String> args = Arrays.asList("--iidm", IIDM_FILENAME, "--config", CONFIG_FILENAME);
 
         return new SimpleCommandBuilder()
                 .id("dynaflow_lf")
-                .program(getProgram())
+                .program(getProgram(config))
                 .args(args)
                 .build();
     }
 
-    public Command getVersionCommand() {
+    public static Command getVersionCommand(DynaFlowConfig config) {
         List<String> args = Collections.singletonList("--version");
         return new SimpleCommandBuilder()
                 .id("dynaflow_version")
-                .program(getProgram())
+                .program(getProgram(config))
                 .args(args)
                 .build();
     }
@@ -95,8 +98,8 @@ public class DynaFlowProvider implements LoadFlowProvider {
         return "0.1";
     }
 
-    private CommandExecution createCommandExecution() {
-        Command cmd = getCommand();
+    private static CommandExecution createCommandExecution(DynaFlowConfig config) {
+        Command cmd = getCommand(config);
         return new CommandExecution(cmd, 1, 0);
     }
 
@@ -107,6 +110,9 @@ public class DynaFlowProvider implements LoadFlowProvider {
         Objects.requireNonNull(workingStateId);
         Objects.requireNonNull(parameters);
         DynaFlowParameters dynaFlowParameters = getParametersExt(parameters);
+        DynaFlowConfig config = Objects.requireNonNull(configSupplier.get());
+        ExecutionEnvironment env = new ExecutionEnvironment(config.createEnv(), WORKING_DIR_PREFIX, config.isDebug());
+        Command versionCmd = getVersionCommand(config);
         DynaFlowUtil.checkDynaFlowVersion(env, computationManager, versionCmd);
         return computationManager.execute(env, new AbstractExecutionHandler<LoadFlowResult>() {
             @Override
@@ -115,7 +121,7 @@ public class DynaFlowProvider implements LoadFlowProvider {
 
                 writeIIDM(workingDir, network);
                 DynaFlowConfigSerializer.serialize(parameters, dynaFlowParameters, workingDir, workingDir.resolve(CONFIG_FILENAME));
-                return Collections.singletonList(createCommandExecution());
+                return Collections.singletonList(createCommandExecution(config));
             }
 
             @Override

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowProvider.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowProvider.java
@@ -47,10 +47,6 @@ public class DynaFlowProvider implements LoadFlowProvider {
         this.configSupplier = Suppliers.memoize(Objects.requireNonNull(configSupplier, "Config supplier is null"));
     }
 
-    DynaFlowConfig getConfig() {
-        return configSupplier.get();
-    }
-
     private static void writeIIDM(Path workingDir, Network network) {
         Properties params = new Properties();
         params.setProperty(XMLExporter.VERSION, IidmXmlVersion.V_1_0.toString("."));

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowProviderTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowProviderTest.java
@@ -39,12 +39,14 @@ import static org.junit.Assert.assertNotNull;
 public class DynaFlowProviderTest {
     private FileSystem fileSystem;
     private String homeDir;
+    private DynaFlowConfig config;
     private DynaFlowProvider provider;
 
     @Before
     public void setUp() {
         fileSystem = Jimfs.newFileSystem(Configuration.unix());
         homeDir = "/home/dynaflow";
+        config = DynaFlowConfig.fromPropertyFile();
         provider = new DynaFlowProvider();
     }
 
@@ -53,7 +55,7 @@ public class DynaFlowProviderTest {
         Path pathHomeDir = fileSystem.getPath(homeDir);
         String program = pathHomeDir.resolve("dynaflow-launcher.sh").toString();
 
-        String versionCommand = provider.getVersionCommand().toString(0);
+        String versionCommand = DynaFlowProvider.getVersionCommand(config).toString(0);
         String expectedVersionCommand = "[" + program + ", --version]";
 
         assertEquals(expectedVersionCommand, versionCommand);
@@ -63,7 +65,7 @@ public class DynaFlowProviderTest {
     public void checkExecutionCommand() {
         String program = fileSystem.getPath(homeDir).resolve("dynaflow-launcher.sh").toString();
 
-        String executionCommand = provider.getCommand().toString(0);
+        String executionCommand = DynaFlowProvider.getCommand(config).toString(0);
         String expectedExecutionCommand = "[" + program + ", --iidm, " + IIDM_FILENAME + ", --config, " + CONFIG_FILENAME + "]";
         assertEquals(expectedExecutionCommand, executionCommand);
     }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Platform config is read at LoadFlowProvider construction. So if multiple LoadFlowProvider are in the classpath and not the DynaFlow one is used to run a load flow, we encounter an exception from DynaFlowProvider if no config.yml is available in the ~/.itools.


**What is the new behavior (if this is a feature change)?**
Platform config is now lazy loaded, so loaded at first execution.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
