### PR TITLE
DynaFlow: remove unused config parameters VSCAsGenerators and LCCAsLoads

### DIFF
--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowParameters.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowParameters.java
@@ -22,15 +22,11 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
     public static final boolean DEFAULT_SVC_REGULATION_ON = false;
     public static final boolean DEFAULT_SHUNT_REGULATION_ON = false;
     public static final boolean DEFAULT_AUTOMATIC_SLACK_BUS_ON = false;
-    public static final boolean DEFAULT_VSC_AS_GENERATORS = true;
-    public static final boolean DEFAULT_LCC_AS_LOADS = true;
     public static final double DEFAULT_DSO_VOLTAGE_LEVEL = 45.0;
 
     private boolean svcRegulationOn = DEFAULT_SVC_REGULATION_ON;
     private boolean shuntRegulationOn = DEFAULT_SHUNT_REGULATION_ON;
     private boolean automaticSlackBusOn = DEFAULT_AUTOMATIC_SLACK_BUS_ON;
-    private boolean vscAsGenerators = DEFAULT_VSC_AS_GENERATORS;
-    private boolean lccAsLoads = DEFAULT_LCC_AS_LOADS;
     private double dsoVoltageLevel = DEFAULT_DSO_VOLTAGE_LEVEL;
 
     public boolean getSvcRegulationOn() {
@@ -60,24 +56,6 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
         return this;
     }
 
-    public boolean getVscAsGenerators() {
-        return vscAsGenerators;
-    }
-
-    public DynaFlowParameters setVscAsGenerators(boolean vscAsGenerators) {
-        this.vscAsGenerators = vscAsGenerators;
-        return this;
-    }
-
-    public boolean getLccAsLoads() {
-        return lccAsLoads;
-    }
-
-    public DynaFlowParameters setLccAsLoads(boolean lccAsLoads) {
-        this.lccAsLoads = lccAsLoads;
-        return this;
-    }
-
     public double getDsoVoltageLevel() {
         return dsoVoltageLevel;
     }
@@ -99,8 +77,6 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
                 .put("svcRegulationOn", svcRegulationOn)
                 .put("shuntRegulationON", shuntRegulationOn)
                 .put("automaticSlackBusON", automaticSlackBusOn)
-                .put("vscAsGenerators", vscAsGenerators)
-                .put("lccAsLoads", lccAsLoads)
                 .put("dsoVoltageLevel", dsoVoltageLevel);
 
         return immutableMapBuilder.build().toString();
@@ -119,8 +95,6 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
                     .ifPresent(config -> parameters.setSvcRegulationOn(config.getBooleanProperty("svcRegulationOn", DEFAULT_SVC_REGULATION_ON))
                             .setShuntRegulationOn(config.getBooleanProperty("shuntRegulationOn", DEFAULT_SHUNT_REGULATION_ON))
                             .setAutomaticSlackBusOn(config.getBooleanProperty("automaticSlackBusOn", DEFAULT_AUTOMATIC_SLACK_BUS_ON))
-                            .setVscAsGenerators(config.getBooleanProperty("vscAsGenerators", DEFAULT_VSC_AS_GENERATORS))
-                            .setLccAsLoads(config.getBooleanProperty("lccAsLoads", DEFAULT_LCC_AS_LOADS))
                             .setDsoVoltageLevel(config.getDoubleProperty("dsoVoltageLevel", DEFAULT_DSO_VOLTAGE_LEVEL)));
 
             return parameters;

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/json/DynaFlowConfigSerializer.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/json/DynaFlowConfigSerializer.java
@@ -45,8 +45,6 @@ public final class DynaFlowConfigSerializer {
             jsonGenerator.writeBooleanField("SVCRegulationOn", dynaFlowParameters.getSvcRegulationOn());
             jsonGenerator.writeBooleanField("ShuntRegulationOn", dynaFlowParameters.getShuntRegulationOn());
             jsonGenerator.writeBooleanField("AutomaticSlackBusOn", dynaFlowParameters.getAutomaticSlackBusOn());
-            jsonGenerator.writeBooleanField("VSCAsGenerators", dynaFlowParameters.getVscAsGenerators());
-            jsonGenerator.writeBooleanField("LCCAsLoads", dynaFlowParameters.getLccAsLoads());
             jsonGenerator.writeNumberField("DsoVoltageLevel", dynaFlowParameters.getDsoVoltageLevel());
             jsonGenerator.writeBooleanField("InfiniteReactiveLimits", lfParameters.isNoGeneratorReactiveLimits());
             jsonGenerator.writeBooleanField("PSTRegulationOn", lfParameters.isPhaseShifterRegulationOn());

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowParametersTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowParametersTest.java
@@ -49,16 +49,12 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         boolean svcRegulationOn = true;
         boolean shuntRegulationOn = false;
         boolean automaticSlackBusOn = true;
-        boolean vscAsGenerators = false;
-        boolean lccAsLoads = true;
         double dsoVoltageLevel = 87.32;
 
         MapModuleConfig moduleConfig = platformConfig.createModuleConfig("dynaflow-default-parameters");
         moduleConfig.setStringProperty("svcRegulationOn", Boolean.toString(svcRegulationOn));
         moduleConfig.setStringProperty("shuntRegulationOn", Boolean.toString(shuntRegulationOn));
         moduleConfig.setStringProperty("automaticSlackBusOn", Boolean.toString(automaticSlackBusOn));
-        moduleConfig.setStringProperty("vscAsGenerators", Boolean.toString(vscAsGenerators));
-        moduleConfig.setStringProperty("lccAsLoads", Boolean.toString(lccAsLoads));
         moduleConfig.setStringProperty("dsoVoltageLevel", Double.toString(dsoVoltageLevel));
 
         DynaFlowParameters.DynaFlowConfigLoader configLoader = new DynaFlowParameters.DynaFlowConfigLoader();
@@ -67,8 +63,6 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         assertEquals(svcRegulationOn, parameters.getSvcRegulationOn());
         assertEquals(shuntRegulationOn, parameters.getShuntRegulationOn());
         assertEquals(automaticSlackBusOn, parameters.getAutomaticSlackBusOn());
-        assertEquals(vscAsGenerators, parameters.getVscAsGenerators());
-        assertEquals(lccAsLoads, parameters.getLccAsLoads());
     }
 
     @Test
@@ -80,9 +74,6 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         assertEquals(DynaFlowParameters.DEFAULT_SVC_REGULATION_ON, parametersExt.getSvcRegulationOn());
         assertEquals(DynaFlowParameters.DEFAULT_SHUNT_REGULATION_ON, parametersExt.getShuntRegulationOn());
         assertEquals(DynaFlowParameters.DEFAULT_AUTOMATIC_SLACK_BUS_ON, parametersExt.getAutomaticSlackBusOn());
-        assertEquals(DynaFlowParameters.DEFAULT_VSC_AS_GENERATORS, parametersExt.getVscAsGenerators());
-        assertEquals(DynaFlowParameters.DEFAULT_LCC_AS_LOADS, parametersExt.getLccAsLoads());
-
     }
 
     @Test
@@ -92,8 +83,6 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         String expectedString = "{svcRegulationOn=" + DynaFlowParameters.DEFAULT_SVC_REGULATION_ON +
                 ", shuntRegulationON=" + DynaFlowParameters.DEFAULT_SHUNT_REGULATION_ON +
                 ", automaticSlackBusON=" + DynaFlowParameters.DEFAULT_AUTOMATIC_SLACK_BUS_ON +
-                ", vscAsGenerators=" + DynaFlowParameters.DEFAULT_VSC_AS_GENERATORS +
-                ", lccAsLoads=" + DynaFlowParameters.DEFAULT_LCC_AS_LOADS +
                 ", dsoVoltageLevel=" + DynaFlowParameters.DEFAULT_DSO_VOLTAGE_LEVEL + "}";
         assertEquals(expectedString, parametersExt.toString());
 
@@ -109,8 +98,6 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         dynaFlowParameters.setSvcRegulationOn(true);
         dynaFlowParameters.setShuntRegulationOn(false);
         dynaFlowParameters.setAutomaticSlackBusOn(true);
-        dynaFlowParameters.setVscAsGenerators(false);
-        dynaFlowParameters.setLccAsLoads(true);
         dynaFlowParameters.setDsoVoltageLevel(32.4);
         lfParameters.addExtension(DynaFlowParameters.class, dynaFlowParameters);
 

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/json/JsonDynaFlowParametersSerializerTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/json/JsonDynaFlowParametersSerializerTest.java
@@ -33,8 +33,6 @@ public class JsonDynaFlowParametersSerializerTest extends AbstractConverterTest 
         assertTrue(dynaFlowParameters.getSvcRegulationOn());
         assertFalse(dynaFlowParameters.getShuntRegulationOn());
         assertTrue(dynaFlowParameters.getAutomaticSlackBusOn());
-        assertFalse(dynaFlowParameters.getVscAsGenerators());
-        assertTrue(dynaFlowParameters.getLccAsLoads());
         double expectedDsoVoltageLevelValue = 987.6;
         assertEquals(expectedDsoVoltageLevelValue, dynaFlowParameters.getDsoVoltageLevel(), 0);
 
@@ -54,8 +52,6 @@ public class JsonDynaFlowParametersSerializerTest extends AbstractConverterTest 
         params.setSvcRegulationOn(true);
         params.setShuntRegulationOn(false);
         params.setAutomaticSlackBusOn(true);
-        params.setVscAsGenerators(false);
-        params.setLccAsLoads(true);
         params.setDsoVoltageLevel(54.23);
 
         parameters.addExtension(DynaFlowParameters.class, params);

--- a/dynaflow/src/test/resources/com/powsybl/config/test/config.yml
+++ b/dynaflow/src/test/resources/com/powsybl/config/test/config.yml
@@ -6,8 +6,6 @@ dynaflow:
   debug: false
 
 dynaflow-default-parameters:
-  lccAsLoads: false
-  vscAsGenerators: false
   svcRegulationOn: true
 
 load-flow-default-parameters:

--- a/dynaflow/src/test/resources/config.json
+++ b/dynaflow/src/test/resources/config.json
@@ -10,8 +10,6 @@
       "svcRegulationOn": true,
       "shuntRegulationOn": false,
       "automaticSlackBusOn": true,
-      "vscAsGenerators": false,
-      "lccAsLoads": true,
       "dsoVoltageLevel": 987.6
     }
   }

--- a/dynaflow/src/test/resources/dynaflow_default_serialization.json
+++ b/dynaflow/src/test/resources/dynaflow_default_serialization.json
@@ -16,8 +16,6 @@
       "svcRegulationOn" : true,
       "shuntRegulationOn" : false,
       "automaticSlackBusOn" : true,
-      "vscAsGenerators" : false,
-      "lccAsLoads" : true,
       "dsoVoltageLevel" : 54.23
     }
   }

--- a/dynaflow/src/test/resources/params.json
+++ b/dynaflow/src/test/resources/params.json
@@ -3,8 +3,6 @@
     "SVCRegulationOn" : true,
     "ShuntRegulationOn" : false,
     "AutomaticSlackBusOn" : true,
-    "VSCAsGenerators" : false,
-    "LCCAsLoads" : true,
     "DsoVoltageLevel" : 32.4,
     "InfiniteReactiveLimits" : true,
     "PSTRegulationOn" : false,


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Parameters `VSCAsGenerators` and `LCCAsLoads` are no longer used by DynaFlow. They will not be written to the config file exchanged to invoke DynaFlow. 


**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
