### PR TITLE
Build security analysis results from Dynawo final state output networks

### DIFF
--- a/dynaflow/pom.xml
+++ b/dynaflow/pom.xml
@@ -99,6 +99,11 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-contingency-dsl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysis.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysis.java
@@ -171,7 +171,7 @@ public class DynaFlowSecurityAnalysis {
                 network.getVariantManager().setWorkingVariant(workingVariantId);
 
                 // If the results have already been prepared, just read them ...
-                Path saOutput = workingDir.resolve("outputs").resolve(SECURITY_ANALISIS_RESULTS_FILENAME);
+                Path saOutput = workingDir.resolve(DYNAFLOW_OUTPUT_FOLDER).resolve(SECURITY_ANALISIS_RESULTS_FILENAME);
                 if (Files.exists(saOutput)) {
                     return new SecurityAnalysisReport(SecurityAnalysisResultDeserializer.read(saOutput));
                 } else {

--- a/dynaflow/src/test/resources/SmallBusBranch/dynaflow-inputs/contingencies.json
+++ b/dynaflow/src/test/resources/SmallBusBranch/dynaflow-inputs/contingencies.json
@@ -1,0 +1,11 @@
+{
+  "version" : "1.0",
+  "name" : "",
+  "contingencies" : [ {
+    "id" : "contingency1",
+    "elements" : [ {
+      "id" : "_0483e594-c766-11e1-8775-005056c00008",
+      "type" : "LINE"
+    } ]
+  } ]
+}

--- a/dynaflow/src/test/resources/SmallBusBranch/dynaflow-inputs/powsybl_dynaflow.xiidm
+++ b/dynaflow/src/test/resources/SmallBusBranch/dynaflow-inputs/powsybl_dynaflow.xiidm
@@ -1,0 +1,2372 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_2" id="urn:uuid:2399cbd2-9a39-11e0-aa80-0800200c9a66_EU" caseDate="2030-01-02T09:00:00.000Z" forecastDistance="7993438" sourceFormat="CGMES">
+    <iidm:property name="CGMESModelDetail" value="bus-branch"/>
+    <iidm:substation id="_047c929a-c766-11e1-8775-005056c00008" name="Godrics Hollow" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0460f448-c766-11e1-8775-005056c00008" name="GOD132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045a1670-c766-11e1-8775-005056c00008" name="Jay" v="126.706635" angle="-16.31623"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14.0" q0="8.0" bus="_045a1670-c766-11e1-8775-005056c00008" connectableBus="_045a1670-c766-11e1-8775-005056c00008" p="14.0" q="8.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04819ba1-c766-11e1-8775-005056c00008" name="Nurmengard" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0476c639-c766-11e1-8775-005056c00008" name="NUR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04483c26-c766-11e1-8775-005056c00008" name="Madison" v="128.132538" angle="-14.5066376"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62.0" q0="13.0" bus="_04483c26-c766-11e1-8775-005056c00008" connectableBus="_04483c26-c766-11e1-8775-005056c00008" p="62.0" q="13.0"></iidm:load>
+            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9.0" q0="0.0" bus="_04483c26-c766-11e1-8775-005056c00008" connectableBus="_04483c26-c766-11e1-8775-005056c00008" p="9.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04542302-c766-11e1-8775-005056c00008" name="Gringotts" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0450eeb4-c766-11e1-8775-005056c00008" name="GRI132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04549837-c766-11e1-8775-005056c00008" name="Torrey" v="126.06" angle="-14.6406355"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20.0" maxP="80.0" ratedS="100.0" voltageRegulatorOn="true" targetP="48.0" targetV="126.06" targetQ="0.0" bus="_04549837-c766-11e1-8775-005056c00008" connectableBus="_04549837-c766-11e1-8775-005056c00008" p="-48.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_b97aee41-3115-4cfd-9071-b52fb44d0b66"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_5005c073-28d1-4a7d-b257-649dec43ec73"/>
+                <iidm:minMaxReactiveLimits minQ="-30.0" maxQ="85.0"/>
+            </iidm:generator>
+            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113.0" q0="32.0" bus="_04549837-c766-11e1-8775-005056c00008" connectableBus="_04549837-c766-11e1-8775-005056c00008" p="113.0" q="32.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045de701-c766-11e1-8775-005056c00008" name="Needlehole" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04808a33-c766-11e1-8775-005056c00008" name="NEE132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047ba835-c766-11e1-8775-005056c00008" name="Darrah" v="123.719063" angle="-8.168152"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68.0" q0="36.0" bus="_047ba835-c766-11e1-8775-005056c00008" connectableBus="_047ba835-c766-11e1-8775-005056c00008" p="68.0" q="36.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0472f5a8-c766-11e1-8775-005056c00008" name="Dale" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0467d214-c766-11e1-8775-005056c00008" name="DAL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04845ac5-c766-11e1-8775-005056c00008" name="Smythe" v="130.725067" angle="2.296253"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5.0" q0="3.0" bus="_04845ac5-c766-11e1-8775-005056c00008" connectableBus="_04845ac5-c766-11e1-8775-005056c00008" p="5.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047a48a3-c766-11e1-8775-005056c00008" name="Hogsmeade" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047e675c-c766-11e1-8775-005056c00008" name="HOG132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045b9d15-c766-11e1-8775-005056c00008" name="Sunnysde" v="125.9138" angle="-14.74322"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84.0" q0="18.0" bus="_045b9d15-c766-11e1-8775-005056c00008" connectableBus="_045b9d15-c766-11e1-8775-005056c00008" p="84.0" q="18.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046f4c23-c766-11e1-8775-005056c00008" name="Barad-dûr" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047dcb11-c766-11e1-8775-005056c00008" name="BAR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0486f2d6-c766-11e1-8775-005056c00008" name="Bellefnt" v="126.403" angle="-8.388306"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68.0" q0="27.0" bus="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus="_0486f2d6-c766-11e1-8775-005056c00008" p="68.0" q="27.0"></iidm:load>
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" bPerSection="1.378E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="126.403" targetDeadband="1.0" bus="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus="_0486f2d6-c766-11e1-8775-005056c00008" q="-11.0086479">
+                <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047a6fb6-c766-11e1-8775-005056c00008" name="Waymoot" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04740714-c766-11e1-8775-005056c00008" name="WAY132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04550d63-c766-11e1-8775-005056c00008" name="Fieldale" v="126.066" angle="-11.6781759"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39.0" q0="30.0" bus="_04550d63-c766-11e1-8775-005056c00008" connectableBus="_04550d63-c766-11e1-8775-005056c00008" p="39.0" q="30.0"></iidm:load>
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" bPerSection="6.88E-5" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1.0" bus="_04550d63-c766-11e1-8775-005056c00008" connectableBus="_04550d63-c766-11e1-8775-005056c00008" q="-5.46706724">
+                <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0488eea9-c766-11e1-8775-005056c00008" name="Upbourn" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047147f4-c766-11e1-8775-005056c00008" name="UPB132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04862f81-c766-11e1-8775-005056c00008" name="Muskngum1" v="138.599991" angle="-2.44860148"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_047f0391-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200.0" maxP="400.0" ratedS="500.0" voltageRegulatorOn="true" targetP="392.0" targetV="138.599991" targetQ="0.0" bus="_04862f81-c766-11e1-8775-005056c00008" connectableBus="_04862f81-c766-11e1-8775-005056c00008" p="-392.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_d9948603-709f-41dd-a0ff-2ebda091255a"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_23727856-fd9b-4124-a981-4e862148f3bb"/>
+                <iidm:minMaxReactiveLimits minQ="-150.0" maxQ="450.0"/>
+            </iidm:generator>
+            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39.0" q0="18.0" bus="_04862f81-c766-11e1-8775-005056c00008" connectableBus="_04862f81-c766-11e1-8775-005056c00008" p="39.0" q="18.0"></iidm:load>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_0463da78-c766-11e1-8775-005056c00008" name="UPB220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0458ddf2-c766-11e1-8775-005056c00008" name="Muskngum2" v="221.1" angle="-2.31989479"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200.0" maxP="400.0" ratedS="500.0" voltageRegulatorOn="true" targetP="391.0" targetV="221.1" targetQ="0.0" bus="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus="_0458ddf2-c766-11e1-8775-005056c00008" p="-391.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_12b01822-ca11-4cf8-a6b4-2f8ff805ca20"/>
+                <iidm:minMaxReactiveLimits minQ="-150.0" maxQ="450.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0.0" x="6.44688" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus1="_0458ddf2-c766-11e1-8775-005056c00008" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" bus2="_04862f81-c766-11e1-8775-005056c00008" connectableBus2="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.06951871657754"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9389671361502347"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8849557522123894"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8368200836820083"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7936507936507936"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7547169811320755"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7194244604316546"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6872852233676976"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6578947368421053"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6309148264984227"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6060606060606061"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5830903790087463"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_069c77f0-1cf0-491a-ae17-8f71e0c7cc0b" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_a7b7f7b8-4ee3-45f5-ba3e-edb3678e0866" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_85b581c6-1005-4dc0-a758-ad5cfa9b05c4" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_981fee8c-aaa5-4946-b2d2-292bb3a4e7df" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_04773b6b-c766-11e1-8775-005056c00008" name="Fornost Erain" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046b2d70-c766-11e1-8775-005056c00008" name="FOR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0474f17a-c766-11e1-8775-005056c00008" name="Adams" v="126.359306" angle="-17.8946"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18.0" q0="3.0" bus="_0474f17a-c766-11e1-8775-005056c00008" connectableBus="_0474f17a-c766-11e1-8775-005056c00008" p="18.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04887979-c766-11e1-8775-005056c00008" name="The Wall" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0475b4c0-c766-11e1-8775-005056c00008" name="THE132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04597a36-c766-11e1-8775-005056c00008" name="Claytor" v="133.319992" angle="-5.7111764"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0.0" maxP="160.0" ratedS="200.0" voltageRegulatorOn="true" targetP="40.0" targetV="133.319992" targetQ="0.0" bus="_04597a36-c766-11e1-8775-005056c00008" connectableBus="_04597a36-c766-11e1-8775-005056c00008" p="-40.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_e56da2eb-bb6a-4133-953c-40073c5bc5f4"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_d41be6b4-155e-4c8f-b46b-16b50c49f0f4"/>
+                <iidm:minMaxReactiveLimits minQ="-60.0" maxQ="170.0"/>
+            </iidm:generator>
+            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23.0" q0="16.0" bus="_04597a36-c766-11e1-8775-005056c00008" connectableBus="_04597a36-c766-11e1-8775-005056c00008" p="23.0" q="16.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04795e41-c766-11e1-8775-005056c00008" name="Havens of the Falas" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045d23b4-c766-11e1-8775-005056c00008" name="HAV132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04725962-c766-11e1-8775-005056c00008" name="N.Newark" v="130.323" angle="-14.23693"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53.0" q0="22.0" bus="_04725962-c766-11e1-8775-005056c00008" connectableBus="_04725962-c766-11e1-8775-005056c00008" p="53.0" q="22.0"></iidm:load>
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.323" targetDeadband="1.0" bus="_04725962-c766-11e1-8775-005056c00008" connectableBus="_04725962-c766-11e1-8775-005056c00008" q="-9.748864">
+                <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047e404a-c766-11e1-8775-005056c00008" name="Minas Anor" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048433b5-c766-11e1-8775-005056c00008" name="MNA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0472a783-c766-11e1-8775-005056c00008" name="Hillsbro" v="131.421951" angle="-9.167447"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12.0" q0="0.0" bus="_0472a783-c766-11e1-8775-005056c00008" connectableBus="_0472a783-c766-11e1-8775-005056c00008" p="12.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0449c2ca-c766-11e1-8775-005056c00008" name="Avallonë" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045e8349-c766-11e1-8775-005056c00008" name="AVA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046bf0cb-c766-11e1-8775-005056c00008" name="S.Kenton" v="129.64537" angle="-18.6851273"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18.0" q0="7.0" bus="_046bf0cb-c766-11e1-8775-005056c00008" connectableBus="_046bf0cb-c766-11e1-8775-005056c00008" p="18.0" q="7.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0468bc71-c766-11e1-8775-005056c00008" name="Vale of Arryn" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0484f70a-c766-11e1-8775-005056c00008" name="VLA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04689561-c766-11e1-8775-005056c00008" name="Hazard" v="129.887009" angle="1.19663978"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21.0" q0="10.0" bus="_04689561-c766-11e1-8775-005056c00008" connectableBus="_04689561-c766-11e1-8775-005056c00008" p="21.0" q="10.0"></iidm:load>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_04555b88-c766-11e1-8775-005056c00008" name="VALE33KV" nominalV="33.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04505279-c766-11e1-8775-005056c00008" name="Pinevlle" v="33.495" angle="1.43515372"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_047fc6e6-c766-11e1-8775-005056c00008" name="Pinevlle SM" energySource="THERMAL" minP="0.0" maxP="40.0" ratedS="50.0" voltageRegulatorOn="true" targetP="4.0" targetV="33.495" targetQ="0.0" bus="_04505279-c766-11e1-8775-005056c00008" connectableBus="_04505279-c766-11e1-8775-005056c00008" p="-4.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_9a6bdb3c-346d-4426-8127-5f6cbf0150b2"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_98f667da-02d1-4a31-b826-44314a1fbbfe"/>
+                <iidm:minMaxReactiveLimits minQ="-15.0" maxQ="45.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.3079691875" x="2.25858593125" g="0.0" b="-0.0040863184" ratedU1="132.0" ratedU2="33.0" bus1="_04689561-c766-11e1-8775-005056c00008" connectableBus1="_04689561-c766-11e1-8775-005056c00008" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" bus2="_04505279-c766-11e1-8775-005056c00008" connectableBus2="_04505279-c766-11e1-8775-005056c00008" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="31" loadTapChangingCapabilities="false">
+                <iidm:step r="-78.46097048774399" x="-78.46097048774399" g="364.2734712959033" b="364.2734712959033" rho="0.4641016"/>
+                <iidm:step r="-76.77098544465856" x="-76.77098544465856" g="330.4960925559595" b="330.4960925559595" rho="0.48196488000000004"/>
+                <iidm:step r="-75.01718104710143" x="-75.01718104710143" g="300.2750858041092" b="300.2750858041092" rho="0.49982816"/>
+                <iidm:step r="-73.19955729507262" x="-73.19955729507262" g="273.1281647135425" b="273.1281647135425" rho="0.5176914400000001"/>
+                <iidm:step r="-71.31811418857215" x="-71.31811418857215" g="248.65210975826625" b="248.65210975826625" rho="0.53555472"/>
+                <iidm:step r="-69.37285172760001" x="-69.37285172760001" g="226.5077084898438" b="226.5077084898438" rho="0.553418"/>
+                <iidm:step r="-67.36376991215616" x="-67.36376991215616" g="206.40793906293555" b="206.40793906293555" rho="0.57128128"/>
+                <iidm:step r="-65.29086874224063" x="-65.29086874224063" g="188.10862264852744" b="188.10862264852744" rho="0.58914456"/>
+                <iidm:step r="-63.15414821785343" x="-63.15414821785343" g="171.40097232995538" b="171.40097232995538" rho="0.6070078400000001"/>
+                <iidm:step r="-60.953608338994556" x="-60.953608338994556" g="156.1056111616768" b="156.1056111616768" rho="0.62487112"/>
+                <iidm:step r="-58.689249105664" x="-58.689249105664" g="142.0677374172608" b="142.0677374172608" rho="0.6427344"/>
+                <iidm:step r="-56.36107051786177" x="-56.36107051786177" g="129.1531923140571" b="129.1531923140571" rho="0.66059768"/>
+                <iidm:step r="-53.96907257558784" x="-53.96907257558784" g="117.24524269951107" b="117.24524269951107" rho="0.67846096"/>
+                <iidm:step r="-51.51325527884223" x="-51.51325527884223" g="106.24193390397649" b="106.24193390397649" rho="0.69632424"/>
+                <iidm:step r="-48.99361862762495" x="-48.99361862762495" g="96.05390013838502" b="96.05390013838502" rho="0.7141875200000001"/>
+                <iidm:step r="-46.410162621936" x="-46.410162621936" g="86.60254423711527" b="86.60254423711527" rho="0.7320508"/>
+                <iidm:step r="-43.762887261775354" x="-43.762887261775354" g="77.81851722275475" b="77.81851722275475" rho="0.7499140799999999"/>
+                <iidm:step r="-41.05179254714304" x="-41.05179254714304" g="69.64044255285229" b="69.64044255285229" rho="0.76777736"/>
+                <iidm:step r="-38.276878478039045" x="-38.276878478039045" g="62.01384106022605" b="62.01384106022605" rho="0.78564064"/>
+                <iidm:step r="-35.438145054463355" x="-35.438145054463355" g="54.89022129918419" b="54.89022129918419" rho="0.80350392"/>
+                <iidm:step r="-32.53559227641599" x="-32.53559227641599" g="48.2263068397802" b="48.2263068397802" rho="0.8213672000000001"/>
+                <iidm:step r="-29.569220143896956" x="-29.569220143896956" g="41.9833774442222" b="41.9833774442222" rho="0.83923048"/>
+                <iidm:step r="-26.53902865690624" x="-26.53902865690624" g="36.12670533984335" b="36.12670533984335" rho="0.85709376"/>
+                <iidm:step r="-23.445017815443848" x="-23.445017815443848" g="30.6250712186483" b="30.6250712186483" rho="0.8749570400000001"/>
+                <iidm:step r="-20.287187619509762" x="-20.287187619509762" g="25.45034733271443" b="25.45034733271443" rho="0.8928203200000001"/>
+                <iidm:step r="-17.06553806910399" x="-17.06553806910399" g="20.57713726209933" b="20.57713726209933" rho="0.9106836"/>
+                <iidm:step r="-13.780069164226571" x="-13.780069164226571" g="15.982463718828566" b="15.982463718828566" rho="0.92854688"/>
+                <iidm:step r="-10.430780904877434" x="-10.430780904877434" g="11.64549720345327" b="11.64549720345327" rho="0.94641016"/>
+                <iidm:step r="-7.017673291056637" x="-7.017673291056637" g="7.5473195169912355" b="7.5473195169912355" rho="0.96427344"/>
+                <iidm:step r="-3.5407463227641656" x="-3.5407463227641656" g="3.670717103630028" b="3.670717103630028" rho="0.9821367199999999"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="3.604565677235838" x="3.604565677235838" g="-3.479157171958336" b="-3.479157171958336" rho="1.01786328"/>
+                <iidm:step r="7.272950708943382" x="7.272950708943382" g="-6.779855183322592" b="-6.779855183322592" rho="1.03572656"/>
+                <iidm:step r="11.005155095122543" x="11.005155095122543" g="-9.914093706451743" b="-9.914093706451743" rho="1.0535898399999999"/>
+                <iidm:step r="14.801178835773431" x="14.801178835773431" g="-12.892880531259154" b="-12.892880531259154" rho="1.07145312"/>
+                <iidm:step r="18.661021930895984" x="18.661021930895984" g="-15.726328348801433" b="-15.726328348801433" rho="1.0893164"/>
+                <iidm:step r="22.584684380490238" x="22.584684380490238" g="-18.423740693731116" b="-18.423740693731116" rho="1.10717968"/>
+                <iidm:step r="26.572166184556178" x="26.572166184556178" g="-20.993688411566747" b="-20.993688411566747" rho="1.12504296"/>
+                <iidm:step r="30.62346734309378" x="30.62346734309378" g="-23.444077826121855" b="-23.444077826121855" rho="1.14290624"/>
+                <iidm:step r="34.73858785610307" x="34.73858785610307" g="-25.78221162092249" b="-25.78221162092249" rho="1.16076952"/>
+                <iidm:step r="38.91752772358399" x="38.91752772358399" g="-28.01484331122096" b="-28.01484331122096" rho="1.1786328"/>
+                <iidm:step r="43.16028694553664" x="43.16028694553664" g="-30.148226066322692" b="-30.148226066322692" rho="1.19649608"/>
+                <iidm:step r="47.466865521960955" x="47.466865521960955" g="-32.18815654211632" b="-32.18815654211632" rho="1.21435936"/>
+                <iidm:step r="51.83726345285697" x="51.83726345285697" g="-34.140014298236885" b="-34.140014298236885" rho="1.23222264"/>
+                <iidm:step r="56.27148073822465" x="56.27148073822465" g="-36.0087973009527" b="-36.0087973009527" rho="1.25008592"/>
+                <iidm:step r="60.76951737806397" x="60.76951737806397" g="-37.799153949787" b="-37.799153949787" rho="1.2679491999999999"/>
+                <iidm:step r="65.33137337237503" x="65.33137337237503" g="-39.51541201150582" b="-39.51541201150582" rho="1.28581248"/>
+                <iidm:step r="69.95704872115776" x="69.95704872115776" g="-41.161604798123854" b="-41.161604798123854" rho="1.30367576"/>
+                <iidm:step r="74.64654342441217" x="74.64654342441217" g="-42.74149488490709" b="-42.74149488490709" rho="1.32153904"/>
+                <iidm:step r="79.39985748213824" x="79.39985748213824" g="-44.25859562906487" b="-44.25859562906487" rho="1.33940232"/>
+                <iidm:step r="84.21699089433596" x="84.21699089433596" g="-45.716190719151165" b="-45.716190719151165" rho="1.3572655999999998"/>
+                <iidm:step r="89.09794366100547" x="89.09794366100547" g="-47.11735195848069" b="-47.11735195848069" rho="1.37512888"/>
+                <iidm:step r="94.04271578214653" x="94.04271578214653" g="-48.46495546255347" b="-48.46495546255347" rho="1.39299216"/>
+                <iidm:step r="99.05130725775935" x="99.05130725775935" g="-49.76169643010378" b="-49.76169643010378" rho="1.41085544"/>
+                <iidm:step r="104.12371808784383" x="104.12371808784383" g="-51.01010262954087" b="-51.01010262954087" rho="1.42871872"/>
+                <iidm:step r="109.25994827240002" x="109.25994827240002" g="-52.21254672689349" b="-52.21254672689349" rho="1.446582"/>
+                <iidm:step r="114.45999781142788" x="114.45999781142788" g="-53.371257567609966" b="-53.371257567609966" rho="1.46444528"/>
+                <iidm:step r="119.72386670492732" x="119.72386670492732" g="-54.48833051245521" b="-54.48833051245521" rho="1.4823085599999999"/>
+                <iidm:step r="125.05155495289854" x="125.05155495289854" g="-55.5657369170681" b="-55.5657369170681" rho="1.50017184"/>
+                <iidm:step r="130.44306255534144" x="130.44306255534144" g="-56.60533283531382" b="-56.60533283531382" rho="1.51803512"/>
+                <iidm:step r="135.898389512256" x="135.898389512256" g="-57.60886701822754" b="-57.60886701822754" rho="1.5358984"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_580d3b53-5508-4d8d-97cc-4ea463e0cdb9" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_a867e68a-58d1-49cb-955f-bb8e59cf2a11" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="8747.0">
+                <iidm:temporaryLimit name="_1a7f23f9-e2c0-46a6-a93c-687f2209e33d" acceptableDuration="900" value="10059.0"/>
+                <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_045beb3a-c766-11e1-8775-005056c00008" name="Minas Tirith" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048a9c58-c766-11e1-8775-005056c00008" name="MNT132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04555b87-c766-11e1-8775-005056c00008" name="NwCarlsl" v="133.2002" angle="-14.585494"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9.0" q0="0.0" bus="_04555b87-c766-11e1-8775-005056c00008" connectableBus="_04555b87-c766-11e1-8775-005056c00008" p="9.0" q="0.0"></iidm:load>
+            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30.0" q0="12.0" bus="_04555b87-c766-11e1-8775-005056c00008" connectableBus="_04555b87-c766-11e1-8775-005056c00008" p="30.0" q="12.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047120e4-c766-11e1-8775-005056c00008" name="Bywater" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046c65f4-c766-11e1-8775-005056c00008" name="BYW132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046b7b91-c766-11e1-8775-005056c00008" name="Blaine" v="126.616516" angle="-10.5192728"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2.0" q0="1.0" bus="_046b7b91-c766-11e1-8775-005056c00008" connectableBus="_046b7b91-c766-11e1-8775-005056c00008" p="2.0" q="1.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0467f928-c766-11e1-8775-005056c00008" name="Tirion" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048bd4da-c766-11e1-8775-005056c00008" name="TIR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04667284-c766-11e1-8775-005056c00008" name="Sundial" v="133.4717" angle="-2.1101048"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15.0" q0="9.0" bus="_04667284-c766-11e1-8775-005056c00008" connectableBus="_04667284-c766-11e1-8775-005056c00008" p="15.0" q="9.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_048badc8-c766-11e1-8775-005056c00008" name="White Harbor" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0488c79a-c766-11e1-8775-005056c00008" name="WHI132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044a8618-c766-11e1-8775-005056c00008" name="Riversde" v="126.882912" angle="-19.081995"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51.0" q0="27.0" bus="_044a8618-c766-11e1-8775-005056c00008" connectableBus="_044a8618-c766-11e1-8775-005056c00008" p="51.0" q="27.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045e8345-c766-11e1-8775-005056c00008" name="Nobottle" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04773b6a-c766-11e1-8775-005056c00008" name="NOB132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0461b794-c766-11e1-8775-005056c00008" name="Randolph" v="128.468643" angle="-13.7844219"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10.0" q0="5.0" bus="_0461b794-c766-11e1-8775-005056c00008" connectableBus="_0461b794-c766-11e1-8775-005056c00008" p="10.0" q="5.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0452c37a-c766-11e1-8775-005056c00008" name="Formenos" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0478c204-c766-11e1-8775-005056c00008" name="FRM132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0467f927-c766-11e1-8775-005056c00008" name="WNwPhil2" v="126.58252" angle="-14.3884716"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12.0" q0="3.0" bus="_0467f927-c766-11e1-8775-005056c00008" connectableBus="_0467f927-c766-11e1-8775-005056c00008" p="12.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046b0666-c766-11e1-8775-005056c00008" name="Vinyamar" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04479fe8-c766-11e1-8775-005056c00008" name="VIN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044ef2e3-c766-11e1-8775-005056c00008" name="Cloverdl" v="126.723633" angle="-9.66302"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43.0" q0="16.0" bus="_044ef2e3-c766-11e1-8775-005056c00008" connectableBus="_044ef2e3-c766-11e1-8775-005056c00008" p="43.0" q="16.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046dec9b-c766-11e1-8775-005056c00008" name="Aldburg" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0483977a-c766-11e1-8775-005056c00008" name="ALD132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046783f5-c766-11e1-8775-005056c00008" name="Hancock" v="128.113724" angle="-8.302711"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38.0" q0="25.0" bus="_046783f5-c766-11e1-8775-005056c00008" connectableBus="_046783f5-c766-11e1-8775-005056c00008" p="38.0" q="25.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04865696-c766-11e1-8775-005056c00008" name="Scary" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04544a15-c766-11e1-8775-005056c00008" name="SCA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047c4478-c766-11e1-8775-005056c00008" name="WMVernon" v="130.212" angle="-16.10395"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16.0" q0="8.0" bus="_047c4478-c766-11e1-8775-005056c00008" connectableBus="_047c4478-c766-11e1-8775-005056c00008" p="16.0" q="8.0"></iidm:load>
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.212" targetDeadband="1.0" bus="_047c4478-c766-11e1-8775-005056c00008" connectableBus="_047c4478-c766-11e1-8775-005056c00008" q="-9.732265">
+                <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046030f9-c766-11e1-8775-005056c00008" name="Winterfell" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044f4102-c766-11e1-8775-005056c00008" name="WIN220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047ba832-c766-11e1-8775-005056c00008" name="Breed" v="230.999985" angle="5.752662"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300.0" maxP="600.0" ratedS="750.0" voltageRegulatorOn="true" targetP="450.0" targetV="230.999985" targetQ="0.0" bus="_047ba832-c766-11e1-8775-005056c00008" connectableBus="_047ba832-c766-11e1-8775-005056c00008" p="-450.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_f26d4eb3-ebdb-4025-8080-f856ce656b42"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_7566f2a7-61eb-42fe-a59a-8276257fdbc6"/>
+                <iidm:minMaxReactiveLimits minQ="-225.0" maxQ="640.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04703680-c766-11e1-8775-005056c00008" name="Brithombar" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04542300-c766-11e1-8775-005056c00008" name="BRI132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046a4314-c766-11e1-8775-005056c00008" name="Newcmrst" v="127.620132" angle="-13.6114807"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17.0" q0="8.0" bus="_046a4314-c766-11e1-8775-005056c00008" connectableBus="_046a4314-c766-11e1-8775-005056c00008" p="17.0" q="8.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0480b149-c766-11e1-8775-005056c00008" name="Nindamos" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04728079-c766-11e1-8775-005056c00008" name="NIN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04689567-c766-11e1-8775-005056c00008" name="TannrsCk1" v="138.599991" angle="-1.946908"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100.0" maxP="400.0" ratedS="500.0" voltageRegulatorOn="true" targetP="220.0" targetV="138.599991" targetQ="0.0" bus="_04689567-c766-11e1-8775-005056c00008" connectableBus="_04689567-c766-11e1-8775-005056c00008" p="-220.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_56975783-9739-40fc-8ec1-e1de8cb06c9a"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_b8449cd9-5a17-497e-bf04-70f728b0f9f2"/>
+                <iidm:minMaxReactiveLimits minQ="-150.0" maxQ="450.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_044f8f2a-c766-11e1-8775-005056c00008" name="NIN220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0455a9a6-c766-11e1-8775-005056c00008" name="TannrsCk2" v="223.3" angle="-0.158602178"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100.0" maxP="400.0" ratedS="500.0" voltageRegulatorOn="true" targetP="314.0" targetV="223.3" targetQ="0.0" bus="_0455a9a6-c766-11e1-8775-005056c00008" connectableBus="_0455a9a6-c766-11e1-8775-005056c00008" p="-314.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_05df66ba-3f64-40cb-8b18-c66d26c4e2c1"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_c1d29442-5f57-41d1-bb60-4b74b4994c20"/>
+                <iidm:minMaxReactiveLimits minQ="-150.0" maxQ="450.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0.0" x="6.6559680000000006" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_0455a9a6-c766-11e1-8775-005056c00008" connectableBus1="_0455a9a6-c766-11e1-8775-005056c00008" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" bus2="_04689567-c766-11e1-8775-005056c00008" connectableBus2="_04689567-c766-11e1-8775-005056c00008" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.041666688368056"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9615384430473377"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9259258916323744"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8928570950255128"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_ac81f7ca-04be-4b10-838b-fd5171e1b0f7" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_2a113652-9eee-4aa3-8fc5-b6ebccfafda5" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_f357d7c9-5bbd-4c6b-960a-7384577353db" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_42b6b196-1272-48c6-a627-914c00e3fe3e" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_04553470-c766-11e1-8775-005056c00008" name="Haysend" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0471bd23-c766-11e1-8775-005056c00008" name="HAY132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044a8615-c766-11e1-8775-005056c00008" name="Sporn1" v="136.62" angle="-0.0"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400.0" maxP="800.0" ratedS="1000.0" voltageRegulatorOn="true" targetP="513.437439" targetV="136.62" targetQ="-62.1325531" bus="_044a8615-c766-11e1-8775-005056c00008" connectableBus="_044a8615-c766-11e1-8775-005056c00008" p="-513.437439" q="62.1325531">
+                <iidm:property name="CGMES.GeneratingUnit" value="_27799004-aa1e-4889-ba95-ee6fdae64895"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_827a9c80-183d-4e33-9e73-ef0aab3dfb13"/>
+                <iidm:minMaxReactiveLimits minQ="-300.0" maxQ="850.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_0449e9d2-c766-11e1-8775-005056c00008" name="HAY220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044aad28-c766-11e1-8775-005056c00008" name="Sporn2" v="219.706345" angle="-2.41812253"/>
+            </iidm:busBreakerTopology>
+            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184.0" q0="0.0" r="0.16456" x="1.9602" g="0.0" b="3.38843E-4" ucteXnodeCode="XWE_BR21" bus="_044aad28-c766-11e1-8775-005056c00008" connectableBus="_044aad28-c766-11e1-8775-005056c00008" p="184.11572091711315" q="-14.972515845786626">
+                <iidm:currentLimits permanentLimit="1000.0">
+                    <iidm:temporaryLimit name="_7c27ab8a-8043-4a55-851d-72adb14d9f4d" acceptableDuration="900" value="1150.0"/>
+                    <iidm:temporaryLimit name="_f4458b8d-a0e1-4adc-977f-14a07b3c44e9" acceptableDuration="60" value="1400.0"/>
+                </iidm:currentLimits>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0.0" x="6.44688" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_044aad28-c766-11e1-8775-005056c00008" connectableBus1="_044aad28-c766-11e1-8775-005056c00008" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" bus2="_044a8615-c766-11e1-8775-005056c00008" connectableBus2="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.06951871657754"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9389671361502347"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8849557522123894"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8368200836820083"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7936507936507936"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7547169811320755"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_836577b9-5365-40b9-8bb1-0c635896faab" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_4ff8ded8-043c-467c-9730-a5f583b4631d" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_10213be6-3bb3-4f54-9d8e-67a412744ad4" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_5e63ebf0-b379-4249-91a8-f8f8c88302e7" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_046fe861-c766-11e1-8775-005056c00008" name="Bree" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046bf0c5-c766-11e1-8775-005056c00008" name="BRE132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044b9787-c766-11e1-8775-005056c00008" name="Natrium" v="131.702545" angle="-6.50974226"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77.0" q0="14.0" bus="_044b9787-c766-11e1-8775-005056c00008" connectableBus="_044b9787-c766-11e1-8775-005056c00008" p="77.0" q="14.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047fedfa-c766-11e1-8775-005056c00008" name="Mithlond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0485e169-c766-11e1-8775-005056c00008" name="MIT132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0480d858-c766-11e1-8775-005056c00008" name="Sterling" v="130.059479" angle="-19.1328583"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31.0" q0="17.0" bus="_0480d858-c766-11e1-8775-005056c00008" connectableBus="_0480d858-c766-11e1-8775-005056c00008" p="31.0" q="17.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0460f447-c766-11e1-8775-005056c00008" name="Pincup" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045ed163-c766-11e1-8775-005056c00008" name="PIN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045c8773-c766-11e1-8775-005056c00008" name="Switchbk" v="130.706055" angle="-1.35899651"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30.0" q0="16.0" bus="_045c8773-c766-11e1-8775-005056c00008" connectableBus="_045c8773-c766-11e1-8775-005056c00008" p="30.0" q="16.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0471e439-c766-11e1-8775-005056c00008" name="Casterly Rock" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04773b62-c766-11e1-8775-005056c00008" name="CAS132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044b7076-c766-11e1-8775-005056c00008" name="Bradley" v="135.103149" angle="-2.59428334"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34.0" q0="8.0" bus="_044b7076-c766-11e1-8775-005056c00008" connectableBus="_044b7076-c766-11e1-8775-005056c00008" p="34.0" q="8.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047cb9a6-c766-11e1-8775-005056c00008" name="Lannisport" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04819ba0-c766-11e1-8775-005056c00008" name="LAN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046c8d0b-c766-11e1-8775-005056c00008" name="Mullin" v="127.143242" angle="-16.2140541"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17.0" q0="7.0" bus="_046c8d0b-c766-11e1-8775-005056c00008" connectableBus="_046c8d0b-c766-11e1-8775-005056c00008" p="17.0" q="7.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0449c2c6-c766-11e1-8775-005056c00008" name="Armenelos" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04765109-c766-11e1-8775-005056c00008" name="ARM132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0468bc75-c766-11e1-8775-005056c00008" name="Glen Lyn" v="134.243988" angle="-1.97640443"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200.0" maxP="400.0" ratedS="500.0" voltageRegulatorOn="true" targetP="252.0" targetV="134.243988" targetQ="0.0" bus="_0468bc75-c766-11e1-8775-005056c00008" connectableBus="_0468bc75-c766-11e1-8775-005056c00008" p="-252.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_e54b499b-436c-4b89-9803-b1d75e2fa364"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5"/>
+                <iidm:minMaxReactiveLimits minQ="-150.0" maxQ="450.0"/>
+            </iidm:generator>
+            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37.0" q0="18.0" bus="_0468bc75-c766-11e1-8775-005056c00008" connectableBus="_0468bc75-c766-11e1-8775-005056c00008" p="37.0" q="18.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0474f171-c766-11e1-8775-005056c00008" name="Erebor" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044f6818-c766-11e1-8775-005056c00008" name="ERB132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046b066a-c766-11e1-8775-005056c00008" name="Kankakee" v="130.82402" angle="-16.7107086"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52.0" q0="22.0" bus="_046b066a-c766-11e1-8775-005056c00008" connectableBus="_046b066a-c766-11e1-8775-005056c00008" p="52.0" q="22.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045fe2d2-c766-11e1-8775-005056c00008" name="Ollivanders" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0465611a-c766-11e1-8775-005056c00008" name="OLL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04876809-c766-11e1-8775-005056c00008" name="Roanoke" v="127.423" angle="-9.429042"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31.0" q0="26.0" bus="_04876809-c766-11e1-8775-005056c00008" connectableBus="_04876809-c766-11e1-8775-005056c00008" p="31.0" q="26.0"></iidm:load>
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" bPerSection="2.296E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1.0" bus="_04876809-c766-11e1-8775-005056c00008" connectableBus="_04876809-c766-11e1-8775-005056c00008" q="-18.63964">
+                <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046cdb28-c766-11e1-8775-005056c00008" name="Pelargir" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048719e8-c766-11e1-8775-005056c00008" name="PEL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04577e63-c766-11e1-8775-005056c00008" name="Howard" v="123.81781" angle="-20.9805279"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37.0" q0="23.0" bus="_04577e63-c766-11e1-8775-005056c00008" connectableBus="_04577e63-c766-11e1-8775-005056c00008" p="37.0" q="23.0"></iidm:load>
+            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59.0" q0="0.0" bus="_04577e63-c766-11e1-8775-005056c00008" connectableBus="_04577e63-c766-11e1-8775-005056c00008" p="59.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044e56a1-c766-11e1-8775-005056c00008" name="Crickhollow" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048a272b-c766-11e1-8775-005056c00008" name="CRI220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0453d4e3-c766-11e1-8775-005056c00008" name="Kanawha" v="218.673645" angle="-1.87761688"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_046efe09-c766-11e1-8775-005056c00008" name="CRI132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04898ae9-c766-11e1-8775-005056c00008" name="CabinCrk" v="137.28" angle="-1.03307128"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300.0" maxP="600.0" ratedS="750.0" voltageRegulatorOn="true" targetP="477.0" targetV="137.28" targetQ="0.0" bus="_04898ae9-c766-11e1-8775-005056c00008" connectableBus="_04898ae9-c766-11e1-8775-005056c00008" p="-477.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_a6ec9760-88da-48df-a23f-7877e7c85ccd"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_e6131af8-c298-413b-84e3-4e21c3b6b06f"/>
+                <iidm:minMaxReactiveLimits minQ="-225.0" maxQ="640.0"/>
+            </iidm:generator>
+            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130.0" q0="26.0" bus="_04898ae9-c766-11e1-8775-005056c00008" connectableBus="_04898ae9-c766-11e1-8775-005056c00008" p="130.0" q="26.0"></iidm:load>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0.0" x="6.44688" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_0453d4e3-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e3-c766-11e1-8775-005056c00008" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" bus2="_04898ae9-c766-11e1-8775-005056c00008" connectableBus2="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.06951871657754"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9389671361502347"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8849557522123894"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8368200836820083"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7936507936507936"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7547169811320755"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7194244604316546"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6872852233676976"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6578947368421053"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6309148264984227"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6060606060606061"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5830903790087463"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5617977528089888"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5420054200542006"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5235602094240838"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5063291139240506"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_6ff12a17-7104-4420-bfdb-5621035eb4e5" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_f5010321-8804-4359-911d-7b7843d02753" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_b5d2a008-83c2-47a3-a978-283e6b8b2167" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_1a134158-4b67-4406-be2d-303158bd41c4" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_0478c205-c766-11e1-8775-005056c00008" name="Harlond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044778d3-c766-11e1-8775-005056c00008" name="HRL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044b7072-c766-11e1-8775-005056c00008" name="Zanesvll" v="134.723" angle="-9.946326"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20.0" q0="11.0" bus="_044b7072-c766-11e1-8775-005056c00008" connectableBus="_044b7072-c766-11e1-8775-005056c00008" p="20.0" q="11.0"></iidm:load>
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" bPerSection="1.722E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="134.723" targetDeadband="1.0" bus="_044b7072-c766-11e1-8775-005056c00008" connectableBus="_044b7072-c766-11e1-8775-005056c00008" q="-15.6273985">
+                <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04670ec0-c766-11e1-8775-005056c00008" name="Stock" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04789af0-c766-11e1-8775-005056c00008" name="STK132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04667289-c766-11e1-8775-005056c00008" name="Tazewell" v="130.195465" angle="0.792081952"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12.0" q0="7.0" bus="_04667289-c766-11e1-8775-005056c00008" connectableBus="_04667289-c766-11e1-8775-005056c00008" p="12.0" q="7.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04675ce0-c766-11e1-8775-005056c00008" name="Stormlands" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046bf0c7-c766-11e1-8775-005056c00008" name="STO132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04778983-c766-11e1-8775-005056c00008" name="NwLibrty" v="125.535988" angle="-21.3517132"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27.0" q0="11.0" bus="_04778983-c766-11e1-8775-005056c00008" connectableBus="_04778983-c766-11e1-8775-005056c00008" p="27.0" q="11.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044e7db2-c766-11e1-8775-005056c00008" name="Crownlands" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04784cd1-c766-11e1-8775-005056c00008" name="CRO132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0482d420-c766-11e1-8775-005056c00008" name="Danville" v="122.605453" angle="-14.3253107"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25.0" q0="13.0" bus="_0482d420-c766-11e1-8775-005056c00008" connectableBus="_0482d420-c766-11e1-8775-005056c00008" p="25.0" q="13.0"></iidm:load>
+            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43.0" q0="0.0" bus="_0482d420-c766-11e1-8775-005056c00008" connectableBus="_0482d420-c766-11e1-8775-005056c00008" p="43.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0455a9aa-c766-11e1-8775-005056c00008" name="Hobbiton" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0470f9d2-c766-11e1-8775-005056c00008" name="HOB132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047a96c0-c766-11e1-8775-005056c00008" name="Fremont" v="130.405121" angle="5.64272642"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48.0" q0="10.0" bus="_047a96c0-c766-11e1-8775-005056c00008" connectableBus="_047a96c0-c766-11e1-8775-005056c00008" p="48.0" q="10.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0452ea87-c766-11e1-8775-005056c00008" name="Goblin Town" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04703689-c766-11e1-8775-005056c00008" name="GOB132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04719616-c766-11e1-8775-005056c00008" name="Turner" v="132.47049" angle="-3.2331"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61.0" q0="28.0" bus="_04719616-c766-11e1-8775-005056c00008" connectableBus="_04719616-c766-11e1-8775-005056c00008" p="61.0" q="28.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0463da79-c766-11e1-8775-005056c00008" name="Rohan" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04588fd5-c766-11e1-8775-005056c00008" name="ROH132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04885267-c766-11e1-8775-005056c00008" name="Grant" v="127.201248" angle="-17.1918983"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24.0" q0="4.0" bus="_04885267-c766-11e1-8775-005056c00008" connectableBus="_04885267-c766-11e1-8775-005056c00008" p="24.0" q="4.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046eafe6-c766-11e1-8775-005056c00008" name="Andúnië" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047d07c9-c766-11e1-8775-005056c00008" name="AND220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045163e5-c766-11e1-8775-005056c00008" name="Olive1" v="222.522873" angle="-9.119988"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28.0" q0="0.0" bus="_045163e5-c766-11e1-8775-005056c00008" connectableBus="_045163e5-c766-11e1-8775-005056c00008" p="28.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_044be5a3-c766-11e1-8775-005056c00008" name="AND132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047147f0-c766-11e1-8775-005056c00008" name="Olive2" v="133.676" angle="-14.1409559"/>
+            </iidm:busBreakerTopology>
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" bPerSection="4.592E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="133.676" targetDeadband="1.0" bus="_047147f0-c766-11e1-8775-005056c00008" connectableBus="_047147f0-c766-11e1-8775-005056c00008" q="-41.0278473">
+                <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0.0" x="4.652208" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_045163e5-c766-11e1-8775-005056c00008" connectableBus1="_045163e5-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" bus2="_047147f0-c766-11e1-8775-005056c00008" connectableBus2="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0152284160890517"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9852216845834649"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9708738052596856"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9569378265149614"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9433962620149532"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9302326014061675"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9174312431613528"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9049774328944981"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_61e544bc-df04-4b97-8a18-5a8f66ae2ab7" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_4109402d-315d-4c0e-8d0e-a7a277ad5608" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_7d97fc29-56b8-4cd3-924e-aa67d27306c8" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_23406b6a-ccc0-4233-a063-caf8238c5a4e" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_045ab2b7-c766-11e1-8775-005056c00008" name="Michel Delving" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046ed6f7-c766-11e1-8775-005056c00008" name="MIC132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0485ba50-c766-11e1-8775-005056c00008" name="Wythe" v="130.954666" angle="-0.4037235"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22.0" q0="15.0" bus="_0485ba50-c766-11e1-8775-005056c00008" connectableBus="_0485ba50-c766-11e1-8775-005056c00008" p="22.0" q="15.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044c0cba-c766-11e1-8775-005056c00008" name="Calembel" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04817490-c766-11e1-8775-005056c00008" name="CAL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045ef874-c766-11e1-8775-005056c00008" name="WestLima" v="130.137146" angle="-19.1362"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33.0" q0="9.0" bus="_045ef874-c766-11e1-8775-005056c00008" connectableBus="_045ef874-c766-11e1-8775-005056c00008" p="33.0" q="9.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_048481d3-c766-11e1-8775-005056c00008" name="Riverlands" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04664b7a-c766-11e1-8775-005056c00008" name="RVR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045f1f84-c766-11e1-8775-005056c00008" name="BeaverCk" v="130.168991" angle="2.505279"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24.0" q0="15.0" bus="_045f1f84-c766-11e1-8775-005056c00008" connectableBus="_045f1f84-c766-11e1-8775-005056c00008" p="24.0" q="15.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0466e7ba-c766-11e1-8775-005056c00008" name="Standelf" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047b8123-c766-11e1-8775-005056c00008" name="STA220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046c3ee8-c766-11e1-8775-005056c00008" name="Sorenson2" v="216.352249" angle="-11.0758839"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0476c631-c766-11e1-8775-005056c00008" name="Sorenson1" v="130.74118" angle="-16.0552044"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11.0" q0="3.0" bus="_0476c631-c766-11e1-8775-005056c00008" connectableBus="_0476c631-c766-11e1-8775-005056c00008" p="11.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0.0" x="6.76051254" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_046c3ee8-c766-11e1-8775-005056c00008" connectableBus1="_046c3ee8-c766-11e1-8775-005056c00008" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" bus2="_0476c631-c766-11e1-8775-005056c00008" connectableBus2="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.041666688368056"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9615384430473377"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9259258916323744"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_d161a693-b7ea-488b-a945-b567ee43f412" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_f7fdb434-5e1f-4292-9849-2542cf0f4c3d" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_c65fcaa8-aacd-4104-90bc-ba8b3185073e" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_f62f2fc6-4b6c-4571-a8c5-40d6a89ac703" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_04642898-c766-11e1-8775-005056c00008" name="Rómenna" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0457f394-c766-11e1-8775-005056c00008" name="RÓM132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0454e653-c766-11e1-8775-005056c00008" name="Philo" v="135.3" angle="-8.939582"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100.0" maxP="400.0" ratedS="500.0" voltageRegulatorOn="true" targetP="204.0" targetV="135.3" targetQ="0.0" bus="_0454e653-c766-11e1-8775-005056c00008" connectableBus="_0454e653-c766-11e1-8775-005056c00008" p="-204.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_e3753d6d-b894-4cce-b6fa-307c50dc107f"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_dff93c01-9c84-4c1f-8529-66c054ed9e37"/>
+                <iidm:minMaxReactiveLimits minQ="-150.0" maxQ="450.0"/>
+            </iidm:generator>
+            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87.0" q0="30.0" bus="_0454e653-c766-11e1-8775-005056c00008" connectableBus="_0454e653-c766-11e1-8775-005056c00008" p="87.0" q="30.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04828600-c766-11e1-8775-005056c00008" name="Ost-in-Edhil" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047b0bf4-c766-11e1-8775-005056c00008" name="OST132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04716f02-c766-11e1-8775-005056c00008" name="BetsyLne" v="129.421829" angle="0.9595726"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11.0" q0="7.0" bus="_04716f02-c766-11e1-8775-005056c00008" connectableBus="_04716f02-c766-11e1-8775-005056c00008" p="11.0" q="7.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045fe2d1-c766-11e1-8775-005056c00008" name="Oldtown" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046205b3-c766-11e1-8775-005056c00008" name="OLD132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0483be8a-c766-11e1-8775-005056c00008" name="Reusens" v="124.763" angle="-12.388133"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22.0" q0="0.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" p="22.0" q="0.0"></iidm:load>
+            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28.0" q0="12.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" p="28.0" q="12.0"></iidm:load>
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" bPerSection="6.88E-5" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="124.763" targetDeadband="1.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" q="-5.354637">
+                <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0453fbf4-c766-11e1-8775-005056c00008" name="Grey Havens" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047d07c3-c766-11e1-8775-005056c00008" name="GRE132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_048433b2-c766-11e1-8775-005056c00008" name="Holston" v="126.513268" angle="3.558016"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85.0" q0="0.0" bus="_048433b2-c766-11e1-8775-005056c00008" connectableBus="_048433b2-c766-11e1-8775-005056c00008" p="85.0" q="0.0"></iidm:load>
+            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78.0" q0="42.0" bus="_048433b2-c766-11e1-8775-005056c00008" connectableBus="_048433b2-c766-11e1-8775-005056c00008" p="78.0" q="42.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04745531-c766-11e1-8775-005056c00008" name="Edhellond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048740f7-c766-11e1-8775-005056c00008" name="EDH132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04716f04-c766-11e1-8775-005056c00008" name="SthPoint" v="127.438782" angle="-7.091006"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47.0" q0="11.0" bus="_04716f04-c766-11e1-8775-005056c00008" connectableBus="_04716f04-c766-11e1-8775-005056c00008" p="47.0" q="11.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0476ed45-c766-11e1-8775-005056c00008" name="Forlond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04481510-c766-11e1-8775-005056c00008" name="FRL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0447ee09-c766-11e1-8775-005056c00008" name="CapitlHl" v="133.002" angle="-3.25421"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39.0" q0="32.0" bus="_0447ee09-c766-11e1-8775-005056c00008" connectableBus="_0447ee09-c766-11e1-8775-005056c00008" p="39.0" q="32.0"></iidm:load>
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" bPerSection="2.296E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="133.002" targetDeadband="1.0" bus="_0447ee09-c766-11e1-8775-005056c00008" connectableBus="_0447ee09-c766-11e1-8775-005056c00008" q="-20.3075829">
+                <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04825ef5-c766-11e1-8775-005056c00008" name="Osgiliath" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044fb634-c766-11e1-8775-005056c00008" name="OSG132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0482860b-c766-11e1-8775-005056c00008" name="Chemical" v="132.164886" angle="-3.54462719"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71.0" q0="26.0" bus="_0482860b-c766-11e1-8775-005056c00008" connectableBus="_0482860b-c766-11e1-8775-005056c00008" p="71.0" q="26.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0476510a-c766-11e1-8775-005056c00008" name="Ethring" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047eb571-c766-11e1-8775-005056c00008" name="ETH132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04684743-c766-11e1-8775-005056c00008" name="JacksnRd" v="130.680786" angle="-17.1475945"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19.0" q0="2.0" bus="_04684743-c766-11e1-8775-005056c00008" connectableBus="_04684743-c766-11e1-8775-005056c00008" p="19.0" q="2.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047edc88-c766-11e1-8775-005056c00008" name="Minas Ithil" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0468bc77-c766-11e1-8775-005056c00008" name="MNI132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04502b6a-c766-11e1-8775-005056c00008" name="Saltvlle" v="130.873917" angle="3.80151629"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65.0" q0="10.0" bus="_04502b6a-c766-11e1-8775-005056c00008" connectableBus="_04502b6a-c766-11e1-8775-005056c00008" p="65.0" q="10.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0452ea86-c766-11e1-8775-005056c00008" name="Frogmorton" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048c22fa-c766-11e1-8775-005056c00008" name="FRO132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04520021-c766-11e1-8775-005056c00008" name="Trenton" v="132.730774" angle="-9.129811"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13.0" q0="0.0" bus="_04520021-c766-11e1-8775-005056c00008" connectableBus="_04520021-c766-11e1-8775-005056c00008" p="13.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045dbff3-c766-11e1-8775-005056c00008" name="Nargothrond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047eb579-c766-11e1-8775-005056c00008" name="NAR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0471bd2a-c766-11e1-8775-005056c00008" name="HickryCk" v="128.575378" angle="-18.20656"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39.0" q0="10.0" bus="_0471bd2a-c766-11e1-8775-005056c00008" connectableBus="_0471bd2a-c766-11e1-8775-005056c00008" p="39.0" q="10.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045386c0-c766-11e1-8775-005056c00008" name="Kings Landing" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04854527-c766-11e1-8775-005056c00008" name="GOD220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047f2aa7-c766-11e1-8775-005056c00008" name="Tidd2" v="213.126556" angle="-7.192931"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_0455a9a2-c766-11e1-8775-005056c00008" name="KGL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045645e7-c766-11e1-8775-005056c00008" name="Tidd1" v="130.02" angle="-10.5625124"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120.0" maxP="240.0" ratedS="300.0" voltageRegulatorOn="true" targetP="155.0" targetV="130.02" targetQ="0.0" bus="_045645e7-c766-11e1-8775-005056c00008" connectableBus="_045645e7-c766-11e1-8775-005056c00008" p="-155.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_29df1e0b-36ca-4536-97b4-6f98b84d49d8"/>
+                <iidm:minMaxReactiveLimits minQ="-90.0" maxQ="255.0"/>
+            </iidm:generator>
+            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277.0" q0="113.0" bus="_045645e7-c766-11e1-8775-005056c00008" connectableBus="_045645e7-c766-11e1-8775-005056c00008" p="277.0" q="113.0"></iidm:load>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0.0" x="6.725664612" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_047f2aa7-c766-11e1-8775-005056c00008" connectableBus1="_047f2aa7-c766-11e1-8775-005056c00008" voltageLevelId1="_04854527-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.041666688368056"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9615384430473377"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9259258916323744"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8928570950255128"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8620689060642133"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8333332638888946"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8064515348595289"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7812499145507905"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7575756657484042"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7352940203287326"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7142856122449125"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6944443383487817"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6756755661066649"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6578946243074983"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6410255259697774"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.624999882812522"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6097559785841993"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.595237974773267"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.581395227149836"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5681816955062248"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5555554320987929"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5434781368147731"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5319147691263306"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5208332085503771"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5102039566847453"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.49999987500003124"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.4901959534794627"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.4807691059541743"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.47169798860807843"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.46296283864886734"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_67e78c48-0ca2-48d3-8a23-d06c0fcd887e" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_5629d2df-9e35-47ae-8a33-c8276f9343d9" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_1afd1e4c-1377-424b-a866-7f6cba69be6c" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_f2daef4d-6f1a-44d1-9c9b-228acff12575" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_0488eea4-c766-11e1-8775-005056c00008" name="Tuckborough" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04876804-c766-11e1-8775-005056c00008" name="TUC132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04494d93-c766-11e1-8775-005056c00008" name="Wooster" v="124.866585" angle="-15.5480585"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23.0" q0="11.0" bus="_04494d93-c766-11e1-8775-005056c00008" connectableBus="_04494d93-c766-11e1-8775-005056c00008" p="23.0" q="11.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046eafe3-c766-11e1-8775-005056c00008" name="Alqualondë" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04767817-c766-11e1-8775-005056c00008" name="ALQ132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04769f21-c766-11e1-8775-005056c00008" name="Wagenhls" v="125.576439" angle="-14.9212084"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63.0" q0="22.0" bus="_04769f21-c766-11e1-8775-005056c00008" connectableBus="_04769f21-c766-11e1-8775-005056c00008" p="63.0" q="22.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045ab2b4-c766-11e1-8775-005056c00008" name="Menegroth" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04851e1b-c766-11e1-8775-005056c00008" name="MEN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045b4ef9-c766-11e1-8775-005056c00008" name="Concord" v="128.097244" angle="-18.40343"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34.0" q0="16.0" bus="_045b4ef9-c766-11e1-8775-005056c00008" connectableBus="_045b4ef9-c766-11e1-8775-005056c00008" p="34.0" q="16.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0450c7a8-c766-11e1-8775-005056c00008" name="Erech" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047b3309-c766-11e1-8775-005056c00008" name="ERE132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04675ce7-c766-11e1-8775-005056c00008" name="Delaware" v="127.922295" angle="-15.096735"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59.0" q0="23.0" bus="_04675ce7-c766-11e1-8775-005056c00008" connectableBus="_04675ce7-c766-11e1-8775-005056c00008" p="59.0" q="23.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044f19f8-c766-11e1-8775-005056c00008" name="Dunharrow" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0467ab04-c766-11e1-8775-005056c00008" name="DUN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0474071a-c766-11e1-8775-005056c00008" name="FtWayne" v="127.583809" angle="-18.5791779"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90.0" q0="30.0" bus="_0474071a-c766-11e1-8775-005056c00008" connectableBus="_0474071a-c766-11e1-8775-005056c00008" p="90.0" q="30.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047ce0b8-c766-11e1-8775-005056c00008" name="Linhir" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0489b1f8-c766-11e1-8775-005056c00008" name="LIN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047c9297-c766-11e1-8775-005056c00008" name="WNwPhil1" v="128.105865" angle="-13.52993"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12.0" q0="3.0" bus="_047c9297-c766-11e1-8775-005056c00008" connectableBus="_047c9297-c766-11e1-8775-005056c00008" p="12.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045ef876-c766-11e1-8775-005056c00008" name="Nogrod" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046512f8-c766-11e1-8775-005056c00008" name="NOG132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044ea4c4-c766-11e1-8775-005056c00008" name="Logan" v="130.419" angle="-2.74680519"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54.0" q0="27.0" bus="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus="_044ea4c4-c766-11e1-8775-005056c00008" p="54.0" q="27.0"></iidm:load>
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" bPerSection="2.296E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.419" targetDeadband="1.0" bus="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus="_044ea4c4-c766-11e1-8775-005056c00008" q="-19.5264664">
+                <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046f7334-c766-11e1-8775-005056c00008" name="Beauxbatons" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048a7544-c766-11e1-8775-005056c00008" name="BEA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0462a1f3-c766-11e1-8775-005056c00008" name="W.Lancst" v="132.66" angle="-11.4028854"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0.0" maxP="40.0" ratedS="50.0" voltageRegulatorOn="true" targetP="19.0" targetV="132.66" targetQ="0.0" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" p="-19.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_83fae784-1da1-4055-8108-ba978276d1b6"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_5f711f63-f631-45d3-b26c-33821ab2ee56"/>
+                <iidm:minMaxReactiveLimits minQ="-15.0" maxQ="45.0"/>
+            </iidm:generator>
+            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28.0" q0="10.0" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" p="28.0" q="10.0"></iidm:load>
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1.0" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" q="-10.1016407">
+                <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0471e435-c766-11e1-8775-005056c00008" name="Carn Dûm" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045d98e1-c766-11e1-8775-005056c00008" name="CAR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04499bb3-c766-11e1-8775-005056c00008" name="Portsmth" v="129.4594" angle="-7.402933"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66.0" q0="20.0" bus="_04499bb3-c766-11e1-8775-005056c00008" connectableBus="_04499bb3-c766-11e1-8775-005056c00008" p="66.0" q="20.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0474a35b-c766-11e1-8775-005056c00008" name="Ephel Brandir" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04636548-c766-11e1-8775-005056c00008" name="EPH132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04723255-c766-11e1-8775-005056c00008" name="DeerCrk" v="127.644" angle="-17.0689125"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0.0" maxP="40.0" ratedS="50.0" voltageRegulatorOn="true" targetP="7.0" targetV="127.644" targetQ="0.0" bus="_04723255-c766-11e1-8775-005056c00008" connectableBus="_04723255-c766-11e1-8775-005056c00008" p="-7.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_e5a479a8-ab8d-4a54-bb52-376874ae2784"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_b55d80d5-720f-46f9-897f-ff8c5eaf8b44"/>
+                <iidm:minMaxReactiveLimits minQ="-15.0" maxQ="45.0"/>
+            </iidm:generator>
+            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43.0" q0="27.0" bus="_04723255-c766-11e1-8775-005056c00008" connectableBus="_04723255-c766-11e1-8775-005056c00008" p="43.0" q="27.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04669999-c766-11e1-8775-005056c00008" name="Staddle" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04555b83-c766-11e1-8775-005056c00008" name="STA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044fdd40-c766-11e1-8775-005056c00008" name="Medford" v="127.312294" angle="-15.4113827"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22.0" q0="7.0" bus="_044fdd40-c766-11e1-8775-005056c00008" connectableBus="_044fdd40-c766-11e1-8775-005056c00008" p="22.0" q="7.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04731cb4-c766-11e1-8775-005056c00008" name="Diagon Alley" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047f9fdb-c766-11e1-8775-005056c00008" name="DIA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0449e9d4-c766-11e1-8775-005056c00008" name="CollCrnr" v="132.910187" angle="-8.931758"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7.0" q0="3.0" bus="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus="_0449e9d4-c766-11e1-8775-005056c00008" p="7.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045fe2da-c766-11e1-8775-005056c00008" name="Ondosto" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044f4108-c766-11e1-8775-005056c00008" name="OND132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047e6750-c766-11e1-8775-005056c00008" name="Caldwell" v="129.429367" angle="-2.32587671"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42.0" q0="31.0" bus="_047e6750-c766-11e1-8775-005056c00008" connectableBus="_047e6750-c766-11e1-8775-005056c00008" p="42.0" q="31.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04631727-c766-11e1-8775-005056c00008" name="Rivendell" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046b7b99-c766-11e1-8775-005056c00008" name="RIV132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046c17da-c766-11e1-8775-005056c00008" name="Franklin" v="126.326439" angle="-10.9323874"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8.0" q0="3.0" bus="_046c17da-c766-11e1-8775-005056c00008" connectableBus="_046c17da-c766-11e1-8775-005056c00008" p="8.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04765106-c766-11e1-8775-005056c00008" name="Esgaroth" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04689563-c766-11e1-8775-005056c00008" name="ESG132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04686e54-c766-11e1-8775-005056c00008" name="McKinley" v="127.008171" angle="-18.19826"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60.0" q0="34.0" bus="_04686e54-c766-11e1-8775-005056c00008" connectableBus="_04686e54-c766-11e1-8775-005056c00008" p="60.0" q="34.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046b2d72-c766-11e1-8775-005056c00008" name="Hogwarts" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04479fe2-c766-11e1-8775-005056c00008" name="HOG132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047566a8-c766-11e1-8775-005056c00008" name="TwinBrch" v="130.680008" angle="-17.4932461"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50.0" maxP="160.0" ratedS="200.0" voltageRegulatorOn="true" targetP="85.0" targetV="130.680008" targetQ="0.0" bus="_047566a8-c766-11e1-8775-005056c00008" connectableBus="_047566a8-c766-11e1-8775-005056c00008" p="-85.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_668eb671-5c36-4351-a95d-53ca850581db"/>
+                <iidm:minMaxReactiveLimits minQ="-60.0" maxQ="170.0"/>
+            </iidm:generator>
+            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47.0" q0="10.0" bus="_047566a8-c766-11e1-8775-005056c00008" connectableBus="_047566a8-c766-11e1-8775-005056c00008" p="47.0" q="10.0"></iidm:load>
+            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20.0" q0="8.0" r="5.732496" x="24.3936" g="0.0" b="2.054637E-4" ucteXnodeCode="XMO_TE32" bus="_047566a8-c766-11e1-8775-005056c00008" connectableBus="_047566a8-c766-11e1-8775-005056c00008" p="20.152549931578697" q="5.197252003124272">
+                <iidm:currentLimits permanentLimit="1000.0">
+                    <iidm:temporaryLimit name="_c42b1a7f-971e-44aa-b615-fb7d49f3256c" acceptableDuration="900" value="1150.0"/>
+                    <iidm:temporaryLimit name="_543c8189-a696-4529-9d26-f06fd03e57ad" acceptableDuration="60" value="1400.0"/>
+                </iidm:currentLimits>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04499bb4-c766-11e1-8775-005056c00008" name="Annúminas" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04633e3a-c766-11e1-8775-005056c00008" name="ANN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04670ec8-c766-11e1-8775-005056c00008" name="Lincoln" v="126.691772" angle="-18.766777"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45.0" q0="25.0" bus="_04670ec8-c766-11e1-8775-005056c00008" connectableBus="_04670ec8-c766-11e1-8775-005056c00008" p="45.0" q="25.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046f2515-c766-11e1-8775-005056c00008" name="Azkaban" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04644fa4-c766-11e1-8775-005056c00008" name="AZK132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_048c4a07-c766-11e1-8775-005056c00008" name="Hinton" v="134.659927" angle="-3.0770843"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42.0" q0="0.0" bus="_048c4a07-c766-11e1-8775-005056c00008" connectableBus="_048c4a07-c766-11e1-8775-005056c00008" p="42.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04631725-c766-11e1-8775-005056c00008" name="Qarth" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04878f10-c766-11e1-8775-005056c00008" name="QAR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_048b86b5-c766-11e1-8775-005056c00008" name="EastLima1" v="131.565" angle="-18.24901"/>
+            </iidm:busBreakerTopology>
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" bPerSection="2.87E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1.0" bus="_048b86b5-c766-11e1-8775-005056c00008" connectableBus="_048b86b5-c766-11e1-8775-005056c00008" q="-24.8389168">
+                <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_04742e21-c766-11e1-8775-005056c00008" name="QAR220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0451b206-c766-11e1-8775-005056c00008" name="EastLima2" v="211.959686" angle="-13.0689487"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0.0" x="6.534000539999999" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_0451b206-c766-11e1-8775-005056c00008" connectableBus1="_0451b206-c766-11e1-8775-005056c00008" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" bus2="_048b86b5-c766-11e1-8775-005056c00008" connectableBus2="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.06951871657754"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9389671361502347"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8849557522123894"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8368200836820083"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7936507936507936"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7547169811320755"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7194244604316546"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6872852233676976"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_fc89899a-e1ba-48c5-aec0-1d321408483c" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_6ee590e8-2483-491d-a919-ffe1e93a41d3" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_f0cc6f7c-99a3-496d-8d13-1ac44171b1b9" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_c97df399-5a91-4c8b-b72c-496cade334b5" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_0486a4b7-c766-11e1-8775-005056c00008" name="St Mungos" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046f7338-c766-11e1-8775-005056c00008" name="STM132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04531195-c766-11e1-8775-005056c00008" name="N. E." v="129.679718" angle="-17.8200111"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25.0" q0="10.0" bus="_04531195-c766-11e1-8775-005056c00008" connectableBus="_04531195-c766-11e1-8775-005056c00008" p="25.0" q="10.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044aad21-c766-11e1-8775-005056c00008" name="Belegost" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04806326-c766-11e1-8775-005056c00008" name="BEL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_048c22f1-c766-11e1-8775-005056c00008" name="SCoshoct" v="126.293083" angle="-14.5671663"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18.0" q0="5.0" bus="_048c22f1-c766-11e1-8775-005056c00008" connectableBus="_048c22f1-c766-11e1-8775-005056c00008" p="18.0" q="5.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04784cda-c766-11e1-8775-005056c00008" name="Gulltown" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047a96c5-c766-11e1-8775-005056c00008" name="GUL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0479102a-c766-11e1-8775-005056c00008" name="WHuntngd" v="124.835312" angle="-8.056691"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33.0" q0="15.0" bus="_0479102a-c766-11e1-8775-005056c00008" connectableBus="_0479102a-c766-11e1-8775-005056c00008" p="33.0" q="15.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0456bb19-c766-11e1-8775-005056c00008" name="Khazad-dûm" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046a1c00-c766-11e1-8775-005056c00008" name="KHA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045fe2d4-c766-11e1-8775-005056c00008" name="DanRiver" v="129.36" angle="-10.3138609"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20.0" maxP="40.0" ratedS="50.0" voltageRegulatorOn="true" targetP="36.0" targetV="129.36" targetQ="0.0" bus="_045fe2d4-c766-11e1-8775-005056c00008" connectableBus="_045fe2d4-c766-11e1-8775-005056c00008" p="-36.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_fec62959-21c5-4921-90b2-7c85e9f3bfab"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_9db08c95-4586-4a2b-87e3-5a17c944b43a"/>
+                <iidm:minMaxReactiveLimits minQ="-15.0" maxQ="45.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045bc420-c766-11e1-8775-005056c00008" name="Minas Morgul" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04664b78-c766-11e1-8775-005056c00008" name="MNM132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04878f11-c766-11e1-8775-005056c00008" name="X5 TRI" v="129.8615" angle="-7.8189826"/>
+            </iidm:busBreakerTopology>
+            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6.0" q0="0.0" r="1.508918" x="7.910496" g="0.0" b="6.76079E-5" ucteXnodeCode="XMO_TE31" bus="_04878f11-c766-11e1-8775-005056c00008" connectableBus="_04878f11-c766-11e1-8775-005056c00008" p="6.0032519495334284" q="-1.1227797436619282">
+                <iidm:currentLimits permanentLimit="1000.0">
+                    <iidm:temporaryLimit name="_d8fc27d8-dd8b-4396-ae7f-b877910f9726" acceptableDuration="900" value="1150.0"/>
+                    <iidm:temporaryLimit name="_1481884d-3134-4896-ae32-b507830cc47a" acceptableDuration="60" value="1400.0"/>
+                </iidm:currentLimits>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04595327-c766-11e1-8775-005056c00008" name="Lond Daer Enedh" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0456e220-c766-11e1-8775-005056c00008" name="LON132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04812671-c766-11e1-8775-005056c00008" name="Summerfl" v="134.582016" angle="-5.09154034"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28.0" q0="7.0" bus="_04812671-c766-11e1-8775-005056c00008" connectableBus="_04812671-c766-11e1-8775-005056c00008" p="28.0" q="7.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047391e8-c766-11e1-8775-005056c00008" name="Durmstrang" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0448d866-c766-11e1-8775-005056c00008" name="DUR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0453d4e4-c766-11e1-8775-005056c00008" name="ClinchRv" v="132.66" angle="9.704128"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400.0" maxP="800.0" ratedS="1000.0" voltageRegulatorOn="true" targetP="607.0" targetV="132.66" targetQ="0.0" bus="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus="_0453d4e4-c766-11e1-8775-005056c00008" p="-607.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_2621b09a-22e3-4630-b3bd-32c102e36741"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_b0d662e5-64c9-4d59-b8e0-9b1ed175769b"/>
+                <iidm:minMaxReactiveLimits minQ="-300.0" maxQ="850.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044ca8f4-c766-11e1-8775-005056c00008" name="Combe" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045d4ac5-c766-11e1-8775-005056c00008" name="COM132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045fe2d7-c766-11e1-8775-005056c00008" name="Pokagon" v="128.538834" angle="-18.4971886"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20.0" q0="9.0" bus="_045fe2d7-c766-11e1-8775-005056c00008" connectableBus="_045fe2d7-c766-11e1-8775-005056c00008" p="20.0" q="9.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04500458-c766-11e1-8775-005056c00008" name="Eldalondë" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047b8129-c766-11e1-8775-005056c00008" name="ELD132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047e4045-c766-11e1-8775-005056c00008" name="GoshenJt" v="129.711578" angle="-18.22939"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14.0" q0="1.0" bus="_047e4045-c766-11e1-8775-005056c00008" connectableBus="_047e4045-c766-11e1-8775-005056c00008" p="14.0" q="1.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047d2ed1-c766-11e1-8775-005056c00008" name="Lorien" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048c4a08-c766-11e1-8775-005056c00008" name="LOR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04544a19-c766-11e1-8775-005056c00008" name="S.Tiffin" v="122.716858" angle="-22.757822"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37.0" q0="10.0" bus="_04544a19-c766-11e1-8775-005056c00008" connectableBus="_04544a19-c766-11e1-8775-005056c00008" p="37.0" q="10.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0478e914-c766-11e1-8775-005056c00008" name="Harrenhal" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0456bb11-c766-11e1-8775-005056c00008" name="HAR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045e0e10-c766-11e1-8775-005056c00008" name="Haviland" v="128.295212" angle="-19.275671"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23.0" q0="9.0" bus="_045e0e10-c766-11e1-8775-005056c00008" connectableBus="_045e0e10-c766-11e1-8775-005056c00008" p="23.0" q="9.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046ab849-c766-11e1-8775-005056c00008" name="Valmar" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045cfca4-c766-11e1-8775-005056c00008" name="VAL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047d2ed4-c766-11e1-8775-005056c00008" name="SWKammer" v="131.090652" angle="-6.788445"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78.0" q0="3.0" bus="_047d2ed4-c766-11e1-8775-005056c00008" connectableBus="_047d2ed4-c766-11e1-8775-005056c00008" p="78.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047343c0-c766-11e1-8775-005056c00008" name="Dol Amroth" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045a1672-c766-11e1-8775-005056c00008" name="DOL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0479fa80-c766-11e1-8775-005056c00008" name="Baileysv" v="130.977081" angle="-2.48613644"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38.0" q0="15.0" bus="_0479fa80-c766-11e1-8775-005056c00008" connectableBus="_0479fa80-c766-11e1-8775-005056c00008" p="38.0" q="15.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0476ed41-c766-11e1-8775-005056c00008" name="Fangorn Forest" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044f8f29-c766-11e1-8775-005056c00008" name="FAN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04675ce9-c766-11e1-8775-005056c00008" name="HolstonT" v="128.206528" angle="3.32668257"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10.0" q0="0.0" bus="_04675ce9-c766-11e1-8775-005056c00008" connectableBus="_04675ce9-c766-11e1-8775-005056c00008" p="10.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046c17d5-c766-11e1-8775-005056c00008" name="Westerlands" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04791027-c766-11e1-8775-005056c00008" name="WES132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046f9a47-c766-11e1-8775-005056c00008" name="WMedford" v="127.35347" angle="-15.4067049"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8.0" q0="3.0" bus="_046f9a47-c766-11e1-8775-005056c00008" connectableBus="_046f9a47-c766-11e1-8775-005056c00008" p="8.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0467ab01-c766-11e1-8775-005056c00008" name="Tharbad" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0483be8b-c766-11e1-8775-005056c00008" name="THA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044e56a4-c766-11e1-8775-005056c00008" name="Rockhill" v="130.814" angle="-18.7122536"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59.0" q0="26.0" bus="_044e56a4-c766-11e1-8775-005056c00008" connectableBus="_044e56a4-c766-11e1-8775-005056c00008" p="59.0" q="26.0"></iidm:load>
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" bPerSection="1.606E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.814" targetDeadband="1.0" bus="_044e56a4-c766-11e1-8775-005056c00008" connectableBus="_044e56a4-c766-11e1-8775-005056c00008" q="-13.7411785">
+                <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04719613-c766-11e1-8775-005056c00008" name="Caras Galadhon" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04728074-c766-11e1-8775-005056c00008" name="CAR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046a9133-c766-11e1-8775-005056c00008" name="Sprigg" v="129.935" angle="-1.56099224"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20.0" q0="10.0" bus="_046a9133-c766-11e1-8775-005056c00008" connectableBus="_046a9133-c766-11e1-8775-005056c00008" p="20.0" q="10.0"></iidm:load>
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1.0" bus="_046a9133-c766-11e1-8775-005056c00008" connectableBus="_046a9133-c766-11e1-8775-005056c00008" q="-9.690902">
+                <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0488eea8-c766-11e1-8775-005056c00008" name="Umbar" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0479d371-c766-11e1-8775-005056c00008" name="UMB132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045868c7-c766-11e1-8775-005056c00008" name="West End" v="123.667236" angle="-22.2906227"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46.0" q0="0.0" bus="_045868c7-c766-11e1-8775-005056c00008" connectableBus="_045868c7-c766-11e1-8775-005056c00008" p="46.0" q="0.0"></iidm:load>
+            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20.0" q0="23.0" bus="_045868c7-c766-11e1-8775-005056c00008" connectableBus="_045868c7-c766-11e1-8775-005056c00008" p="20.0" q="23.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047343ca-c766-11e1-8775-005056c00008" name="Dorne" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04662460-c766-11e1-8775-005056c00008" name="DOR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0453d4eb-c766-11e1-8775-005056c00008" name="Deer Crk" v="130.412933" angle="-16.0396042"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6.0" q0="0.0" bus="_0453d4eb-c766-11e1-8775-005056c00008" connectableBus="_0453d4eb-c766-11e1-8775-005056c00008" p="6.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04745536-c766-11e1-8775-005056c00008" name="Eglarest" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0457f396-c766-11e1-8775-005056c00008" name="EGL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045d23b1-c766-11e1-8775-005056c00008" name="Crooksvl" v="134.25235" angle="-9.172073"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34.0" q0="0.0" bus="_045d23b1-c766-11e1-8775-005056c00008" connectableBus="_045d23b1-c766-11e1-8775-005056c00008" p="34.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0480b143-c766-11e1-8775-005056c00008" name="Newbury" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044d1e26-c766-11e1-8775-005056c00008" name="NEW132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044a5f04-c766-11e1-8775-005056c00008" name="WCambrdg" v="132.138168" angle="-10.9845123"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17.0" q0="4.0" bus="_044a5f04-c766-11e1-8775-005056c00008" connectableBus="_044a5f04-c766-11e1-8775-005056c00008" p="17.0" q="4.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04640189-c766-11e1-8775-005056c00008" name="Rushey" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04605807-c766-11e1-8775-005056c00008" name="RUS132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0458b6e4-c766-11e1-8775-005056c00008" name="SouthBnd" v="130.527084" angle="-17.0296078"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70.0" q0="23.0" bus="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus="_0458b6e4-c766-11e1-8775-005056c00008" p="70.0" q="23.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0453add1-c766-11e1-8775-005056c00008" name="Gondolin" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045c8779-c766-11e1-8775-005056c00008" name="GON220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044e7db1-c766-11e1-8775-005056c00008" name="X9" v="229.031372" angle="-1.83390415"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04745534-c766-11e1-8775-005056c00008" name="Edoras" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04544a18-c766-11e1-8775-005056c00008" name="EDO220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0457f395-c766-11e1-8775-005056c00008" name="Kammer" v="216.42598" angle="-5.43209553"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_0448d867-c766-11e1-8775-005056c00008" name="EDO132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04814d88-c766-11e1-8775-005056c00008" name="W.Kammer" v="131.34" angle="-5.89862871"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120.0" maxP="240.0" ratedS="300.0" voltageRegulatorOn="true" targetP="160.0" targetV="131.34" targetQ="0.0" bus="_04814d88-c766-11e1-8775-005056c00008" connectableBus="_04814d88-c766-11e1-8775-005056c00008" p="-160.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_17852426-f663-4add-9a2b-0a635d51f101"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd"/>
+                <iidm:minMaxReactiveLimits minQ="-90.0" maxQ="255.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0.0" x="4.669632" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_0457f395-c766-11e1-8775-005056c00008" connectableBus1="_0457f395-c766-11e1-8775-005056c00008" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" bus2="_04814d88-c766-11e1-8775-005056c00008" connectableBus2="_04814d88-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0152284160890517"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9852216845834649"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9708738052596856"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9569378265149614"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9433962620149532"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9302326014061675"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9174312431613528"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9049774328944981"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8928572066326577"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8810573385860445"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_9d8d5d2f-e17b-44ba-8e5c-c743c13b8932" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_dbe87453-c7d1-4a10-8f4e-992b351d4810" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_c2676f61-6c29-44b7-9841-6209f952b0dd" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_f6b1a81c-eda7-4a08-b290-bd29a5ed9fa4" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.192352" x="17.16264" g1="0.0" b1="7.20271E-5" g2="0.0" b2="7.20271E-5" bus1="_04723255-c766-11e1-8775-005056c00008" connectableBus1="_04723255-c766-11e1-8775-005056c00008" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" bus2="_04675ce7-c766-11e1-8775-005056c00008" connectableBus2="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f69dc237-d327-475e-93f6-25cbffe65d37" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_de6da3cb-8cb5-4900-9c33-8ad45632b535" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.258288" x="10.7331839" g1="0.0" b1="4.51102E-5" g2="0.0" b2="4.51102E-5" bus1="_045fe2d7-c766-11e1-8775-005056c00008" connectableBus1="_045fe2d7-c766-11e1-8775-005056c00008" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" bus2="_047566a8-c766-11e1-8775-005056c00008" connectableBus2="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_09a180b3-124b-4a91-b323-4aad01f45e8a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6bd63dd1-1344-4183-b7bd-af326919f4eb" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.35224" x="10.6634884" g1="0.0" b1="4.671715E-5" g2="0.0" b2="4.671715E-5" bus1="_04675ce7-c766-11e1-8775-005056c00008" connectableBus1="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" bus2="_046f9a47-c766-11e1-8775-005056c00008" connectableBus2="_046f9a47-c766-11e1-8775-005056c00008" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_a8e81058-e847-4ff2-adf2-c4129ce23783" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_5f05650a-c63d-46e5-a426-2db4f036929f" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.502912" x="34.15104" g1="0.0" b1="1.4003675E-4" g2="0.0" b2="1.4003675E-4" bus1="_04520021-c766-11e1-8775-005056c00008" connectableBus1="_04520021-c766-11e1-8775-005056c00008" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" bus2="_0472a783-c766-11e1-8775-005056c00008" connectableBus2="_0472a783-c766-11e1-8775-005056c00008" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_a65972e6-89bc-4bc2-adaf-0434a8cb1628" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_d2074163-ab09-4251-a1d7-6983091dc4f1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.143152" x="8.79912" g1="0.0" b1="3.72475E-5" g2="0.0" b2="3.72475E-5" bus1="_0476c631-c766-11e1-8775-005056c00008" connectableBus1="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" bus2="_04686e54-c766-11e1-8775-005056c00008" connectableBus2="_04686e54-c766-11e1-8775-005056c00008" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f12edde3-3545-483e-8323-461ae7aa0ada" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2b6693c7-4e29-4c2c-91d0-3485bbe8fe87" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0.0" b1="2.203855E-5" g2="0.0" b2="2.203855E-5" bus1="_0476c631-c766-11e1-8775-005056c00008" connectableBus1="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" bus2="_0453d4eb-c766-11e1-8775-005056c00008" connectableBus2="_0453d4eb-c766-11e1-8775-005056c00008" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_83e15527-5937-42e4-964e-4c736913e9b0" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_786432da-fa4d-4751-a275-87d0e20529f1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.652208" x="13.1028481" g1="0.0" b1="5.37764E-5" g2="0.0" b2="5.37764E-5" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_044a5f04-c766-11e1-8775-005056c00008" connectableBus2="_044a5f04-c766-11e1-8775-005056c00008" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_5f6ea7e2-f472-4dba-a863-10ce21ee9702" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_1f0844a5-ea5c-42b2-abcb-6fac2c426092" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.247696" x="7.387776" g1="0.0" b1="3.104915E-5" g2="0.0" b2="3.104915E-5" bus1="_044a8618-c766-11e1-8775-005056c00008" connectableBus1="_044a8618-c766-11e1-8775-005056c00008" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" bus2="_0471bd2a-c766-11e1-8775-005056c00008" connectableBus2="_0471bd2a-c766-11e1-8775-005056c00008" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_bd6a7b7b-b30f-440f-bf3e-7d1d8007b0ab" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_4ea43e34-67a3-42b8-9601-2189db7790d4" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.143152" x="9.740016" g1="0.0" b1="4.2011E-5" g2="0.0" b2="4.2011E-5" bus1="_04502b6a-c766-11e1-8775-005056c00008" connectableBus1="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" bus2="_04845ac5-c766-11e1-8775-005056c00008" connectableBus2="_04845ac5-c766-11e1-8775-005056c00008" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_70154a1f-3853-4c24-8c87-aef442bdefdb" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_23cc194e-9273-46e9-a793-84a9c2911737" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.885552" x="12.7543688" g1="0.0" b1="5.38338E-5" g2="0.0" b2="5.38338E-5" bus1="_04667289-c766-11e1-8775-005056c00008" connectableBus1="_04667289-c766-11e1-8775-005056c00008" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" bus2="_045c8773-c766-11e1-8775-005056c00008" connectableBus2="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f5c30ce2-41bf-4665-a68c-a4d64962821a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_1a9fe09e-3f63-4904-8e36-aa38c5e16c59" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.93136" g1="0.0" b1="1.3544535E-4" g2="0.0" b2="1.3544535E-4" bus1="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus1="_0462a1f3-c766-11e1-8775-005056c00008" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" bus2="_044b7072-c766-11e1-8775-005056c00008" connectableBus2="_044b7072-c766-11e1-8775-005056c00008" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_79d9d9c2-3ecc-40f2-99c0-c26a56c19fe7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_467ba04d-dbad-4fe1-81c8-3bc87b41fcd1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.0126553" g1="0.0" b1="7.11662E-5" g2="0.0" b2="7.11662E-5" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_04862f81-c766-11e1-8775-005056c00008" connectableBus2="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_58073794-ab85-4c83-b59e-07d01d71ec5f" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_d0737ab4-5a3a-46c8-8aeb-789313f0f332" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.52648" x="8.380943" g1="0.0" b1="3.437785E-5" g2="0.0" b2="3.437785E-5" bus1="_04716f04-c766-11e1-8775-005056c00008" connectableBus1="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" bus2="_0479102a-c766-11e1-8775-005056c00008" connectableBus2="_0479102a-c766-11e1-8775-005056c00008" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_4ea8b910-752d-4475-8141-89e03e629b4e" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_173dc7ff-ae18-4410-b2e1-a4c2abac8ff6" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.687056" x="15.1414566" g1="0.0" b1="6.60009E-5" g2="0.0" b2="6.60009E-5" bus1="_045c8773-c766-11e1-8775-005056c00008" connectableBus1="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" bus2="_0479fa80-c766-11e1-8775-005056c00008" connectableBus2="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_15760a98-ef2d-4bd9-9370-acb8533d07b8" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_efde58bf-c92e-496d-b558-d0095a271083" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.495392" x="20.38608" g1="0.0" b1="8.895775E-5" g2="0.0" b2="8.895775E-5" bus1="_044b9787-c766-11e1-8775-005056c00008" connectableBus1="_044b9787-c766-11e1-8775-005056c00008" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" bus2="_04812671-c766-11e1-8775-005056c00008" connectableBus2="_04812671-c766-11e1-8775-005056c00008" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_bb70f086-9826-4662-b5f7-d88e35724d27" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_8a81d4ae-2bc8-4038-8650-27a6150946b1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.327984" x="10.89" g1="0.0" b1="4.602845E-5" g2="0.0" b2="4.602845E-5" bus1="_045d23b1-c766-11e1-8775-005056c00008" connectableBus1="_045d23b1-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_36231d1d-0ec0-42d3-a72a-d56bd20ed7b0" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_8d6a074c-900d-4a37-830c-5da4c1de1ab5" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.90096" g1="0.0" b1="1.779155E-4" g2="0.0" b2="1.779155E-4" bus1="_0468bc75-c766-11e1-8775-005056c00008" connectableBus1="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" bus2="_044ef2e3-c766-11e1-8775-005056c00008" connectableBus2="_044ef2e3-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_2da72d83-6a1a-4a6d-a873-847a8741dc7f" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3154dc30-b0e5-4570-8e52-9333bae20ef2" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.160576" g1="0.0" b1="3.62718E-5" g2="0.0" b2="3.62718E-5" bus1="_04719616-c766-11e1-8775-005056c00008" connectableBus1="_04719616-c766-11e1-8775-005056c00008" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" bus2="_0482860b-c766-11e1-8775-005056c00008" connectableBus2="_0482860b-c766-11e1-8775-005056c00008" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f6dcf23b-e28d-4722-9b81-e4ae2b782a53" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_cce754c5-b9d5-4105-a431-32da96e4a6cf" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.799762" x="3.624192" g1="0.0" b1="1.578285E-5" g2="0.0" b2="1.578285E-5" bus1="_046b066a-c766-11e1-8775-005056c00008" connectableBus1="_046b066a-c766-11e1-8775-005056c00008" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" bus2="_04684743-c766-11e1-8775-005056c00008" connectableBus2="_04684743-c766-11e1-8775-005056c00008" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ecaca589-8952-4cab-b3dc-f787858d46a9" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_361a9cc3-fb33-4037-9b9a-c20adb90b66b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.122656" x="18.2952" g1="0.0" b1="6.5427E-5" g2="0.0" b2="6.5427E-5" bus1="_04719616-c766-11e1-8775-005056c00008" connectableBus1="_04719616-c766-11e1-8775-005056c00008" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" bus2="_04898ae9-c766-11e1-8775-005056c00008" connectableBus2="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_fdae333c-349a-484b-9226-2b694611f4fe" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_da00c66f-a882-4938-923b-f2455f7f9a81" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135" x="4.251456" g1="0.0" b1="1.859505E-5" g2="0.0" b2="1.859505E-5" bus1="_0482860b-c766-11e1-8775-005056c00008" connectableBus1="_0482860b-c766-11e1-8775-005056c00008" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" bus2="_0447ee09-c766-11e1-8775-005056c00008" connectableBus2="_0447ee09-c766-11e1-8775-005056c00008" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_1f58489c-4298-48ca-914f-1a86392e8a4d" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ba4abe9d-8490-4c19-b19b-c9d2c3597fc9" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.119584" x="27.5996151" g1="0.0" b1="1.1679295E-4" g2="0.0" b2="1.1679295E-4" bus1="_04597a36-c766-11e1-8775-005056c00008" connectableBus1="_04597a36-c766-11e1-8775-005056c00008" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" bus2="_046783f5-c766-11e1-8775-005056c00008" connectableBus2="_046783f5-c766-11e1-8775-005056c00008" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_e286f134-f966-4dd2-b24b-b8388ca849a5" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2320da74-eda7-4f7f-ade9-1ed0e994f3af" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.979504" x="9.530928" g1="0.0" b1="4.2298E-5" g2="0.0" b2="4.2298E-5" bus1="_047e6750-c766-11e1-8775-005056c00008" connectableBus1="_047e6750-c766-11e1-8775-005056c00008" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" bus2="_0479fa80-c766-11e1-8775-005056c00008" connectableBus2="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_489df699-65e3-4b74-b657-04f7e24da3e0" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3bc03415-e95f-47a7-8e92-01089d304a9c" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.96208" x="8.450641" g1="0.0" b1="1.3544535E-4" g2="0.0" b2="1.3544535E-4" bus1="_04719616-c766-11e1-8775-005056c00008" connectableBus1="_04719616-c766-11e1-8775-005056c00008" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" bus2="_04898ae9-c766-11e1-8775-005056c00008" connectableBus2="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_bb9699a6-dcec-459a-b50a-7c7ff7419b33" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_f93b6d4c-39fa-4f6f-a42d-c63a4cf21a67" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.537072" x="11.8831682" g1="0.0" b1="4.987375E-5" g2="0.0" b2="4.987375E-5" bus1="_047147f0-c766-11e1-8775-005056c00008" connectableBus1="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" bus2="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus2="_0458b6e4-c766-11e1-8775-005056c00008" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_55d07074-4a4b-419b-819d-8d6048fcfd1c" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3bc4ab96-7a0d-4e18-b9f5-d89f63a82f0a" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.771104" x="31.3632011" g1="0.0" b1="1.2752525E-4" g2="0.0" b2="1.2752525E-4" bus1="_04878f11-c766-11e1-8775-005056c00008" connectableBus1="_04878f11-c766-11e1-8775-005056c00008" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" bus2="_0472a783-c766-11e1-8775-005056c00008" connectableBus2="_0472a783-c766-11e1-8775-005056c00008" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7a622384-0095-408a-9cc5-b561a4bec039" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_bcb69c6e-125e-449c-acb3-a4deb151668d" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.902976" x="17.68536" g1="0.0" b1="7.69628E-5" g2="0.0" b2="7.69628E-5" bus1="_04862f81-c766-11e1-8775-005056c00008" connectableBus1="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" bus2="_04812671-c766-11e1-8775-005056c00008" connectableBus2="_04812671-c766-11e1-8775-005056c00008" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_fd2f6dbe-d54c-4d17-9492-da52445d0640" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b4b8a31d-dc3c-4b51-88ad-a22e070eb96c" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.196112" x="29.2897434" g1="0.0" b1="1.212695E-4" g2="0.0" b2="1.212695E-4" bus1="_044e56a4-c766-11e1-8775-005056c00008" connectableBus1="_044e56a4-c766-11e1-8775-005056c00008" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" bus2="_046bf0cb-c766-11e1-8775-005056c00008" connectableBus2="_046bf0cb-c766-11e1-8775-005056c00008" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_498a5fc8-8519-4545-b941-9e3648608651" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_5585c67a-0839-48e6-8847-4393e1e9b9c7" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.05672" x="28.48824" g1="0.0" b1="1.164486E-4" g2="0.0" b2="1.164486E-4" bus1="_048c22f1-c766-11e1-8775-005056c00008" connectableBus1="_048c22f1-c766-11e1-8775-005056c00008" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" bus2="_04494d93-c766-11e1-8775-005056c00008" connectableBus2="_04494d93-c766-11e1-8775-005056c00008" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_005c0497-2c3d-4384-b39b-e1c8e4695081" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_e7c9dfab-fb45-4470-964f-4ba9e391f60b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.23472" x="31.88592" g1="0.0" b1="1.3544535E-4" g2="0.0" b2="1.3544535E-4" bus1="_04876809-c766-11e1-8775-005056c00008" connectableBus1="_04876809-c766-11e1-8775-005056c00008" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" bus2="_0483be8a-c766-11e1-8775-005056c00008" connectableBus2="_0483be8a-c766-11e1-8775-005056c00008" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_78d5285a-1f72-4d4e-a8ce-d760901cdf1e" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_fff133bf-25fd-46b2-b144-a227c31ee882" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.826448" x="21.9890881" g1="0.0" b1="9.412305E-5" g2="0.0" b2="9.412305E-5" bus1="_0468bc75-c766-11e1-8775-005056c00008" connectableBus1="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" bus2="_0485ba50-c766-11e1-8775-005056c00008" connectableBus2="_0485ba50-c766-11e1-8775-005056c00008" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_78f10485-1742-4778-93bc-90854ee15eb6" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_217e3c95-24b5-438f-a721-d2257e1a43b4" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.8315849" g1="0.0" b1="6.944445E-5" g2="0.0" b2="6.944445E-5" bus1="_045b9d15-c766-11e1-8775-005056c00008" connectableBus1="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" bus2="_047c9297-c766-11e1-8775-005056c00008" connectableBus2="_047c9297-c766-11e1-8775-005056c00008" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_1b2b5b52-3ac1-40eb-af2e-e5a724e34ed4" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_f5547027-3d48-4a53-937b-bd5ba63ef70d" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.7058554" x="48.40387" g1="0.0" b1="2.035124E-4" g2="0.0" b2="2.035124E-4" bus1="_045d23b1-c766-11e1-8775-005056c00008" connectableBus1="_045d23b1-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" bus2="_044a8615-c766-11e1-8775-005056c00008" connectableBus2="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_2e74f628-a179-44d3-bd7f-1d262370e8d2" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_e9fec217-cf6f-4d39-9495-26ed10c05100" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.83328" x="13.1551189" g1="0.0" b1="5.73921E-5" g2="0.0" b2="5.73921E-5" bus1="_04550d63-c766-11e1-8775-005056c00008" connectableBus1="_04550d63-c766-11e1-8775-005056c00008" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" bus2="_045fe2d4-c766-11e1-8775-005056c00008" connectableBus2="_045fe2d4-c766-11e1-8775-005056c00008" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_489598c7-fb80-48bb-abdc-7fbc89ff0fd7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ea48fee0-31b6-4990-a332-25d08b7d731f" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.5224018" g1="0.0" b1="9.87144E-5" g2="0.0" b2="9.87144E-5" bus1="_04544a19-c766-11e1-8775-005056c00008" connectableBus1="_04544a19-c766-11e1-8775-005056c00008" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" bus2="_04577e63-c766-11e1-8775-005056c00008" connectableBus2="_04577e63-c766-11e1-8775-005056c00008" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_91e7cb96-de23-4948-881e-3112959809d0" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_063af52c-fe10-4c1e-85d4-dd80dcc1d2f9" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.910496" x="35.89344" g1="0.0" b1="1.5668045E-4" g2="0.0" b2="1.5668045E-4" bus1="_04898ae9-c766-11e1-8775-005056c00008" connectableBus1="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" bus2="_048c4a07-c766-11e1-8775-005056c00008" connectableBus2="_048c4a07-c766-11e1-8775-005056c00008" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_b3ada113-b597-41a3-b96c-e2d6413ccd2b" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_c05229ce-6abb-4209-ad4f-0dcd4a070f28" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.764272" x="39.95323" g1="0.0" b1="1.716024E-4" g2="0.0" b2="1.716024E-4" bus1="_04549837-c766-11e1-8775-005056c00008" connectableBus1="_04549837-c766-11e1-8775-005056c00008" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f947c23d-f412-4092-bee0-955d804a356e" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ac528cbe-6fc1-41dd-ba9d-d8b7a4c77576" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.380943" x="27.52992" g1="0.0" b1="1.1650595E-4" g2="0.0" b2="1.1650595E-4" bus1="_04502b6a-c766-11e1-8775-005056c00008" connectableBus1="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" bus2="_045c8773-c766-11e1-8775-005056c00008" connectableBus2="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_288185b8-2129-4450-a2c7-ad8080ce1f0a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6ac84228-6b04-4b10-b560-29655c8e93b4" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.593104" x="18.46944" g1="0.0" b1="7.747935E-5" g2="0.0" b2="7.747935E-5" bus1="_048b86b5-c766-11e1-8775-005056c00008" connectableBus1="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" bus2="_04778983-c766-11e1-8775-005056c00008" connectableBus2="_04778983-c766-11e1-8775-005056c00008" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_dfe3b6e2-9b9f-400e-93a7-90b35c43d3ea" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2ccdc288-c132-40d1-a928-3887bec4ff67" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.62112" x="22.12848" g1="0.0" b1="9.06795E-5" g2="0.0" b2="9.06795E-5" bus1="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus1="_0462a1f3-c766-11e1-8775-005056c00008" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" bus2="_045d23b1-c766-11e1-8775-005056c00008" connectableBus2="_045d23b1-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_81e5d0c5-7cb3-42c7-829e-11059f8a64c3" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_06ca3245-2668-448f-a5c6-961924217a5c" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0473e004-c766-11e1-8775-005056c00008" name="30-38" r="2.24576" x="26.1360016" g1="0.0" b1="4.359504E-4" g2="0.0" b2="4.359504E-4" bus1="_046c3ee8-c766-11e1-8775-005056c00008" connectableBus1="_046c3ee8-c766-11e1-8775-005056c00008" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" bus2="_0451b206-c766-11e1-8775-005056c00008" connectableBus2="_0451b206-c766-11e1-8775-005056c00008" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_29165bcc-a0d7-4427-a8b8-8393eb928631" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.951488" x="6.385896" g1="0.0" b1="1.089302E-4" g2="0.0" b2="1.089302E-4" bus1="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus1="_044ea4c4-c766-11e1-8775-005056c00008" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" bus2="_046a9133-c766-11e1-8775-005056c00008" connectableBus2="_046a9133-c766-11e1-8775-005056c00008" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_31992d9c-cc50-4558-b52a-f9a597797818" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_dfbd2f07-76ab-41e3-910f-dc706979ea4b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.018112" g1="0.0" b1="2.1809E-5" g2="0.0" b2="2.1809E-5" bus1="_046b7b91-c766-11e1-8775-005056c00008" connectableBus1="_046b7b91-c766-11e1-8775-005056c00008" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" bus2="_046c17da-c766-11e1-8775-005056c00008" connectableBus2="_046c17da-c766-11e1-8775-005056c00008" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ce219edd-f122-4f03-ae4f-0dd3493375e7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_11451cec-81c7-4f83-a7db-df7dcaffa94e" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.987024" x="23.0519524" g1="0.0" b1="9.66483E-5" g2="0.0" b2="9.66483E-5" bus1="_04499bb3-c766-11e1-8775-005056c00008" connectableBus1="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" bus2="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus2="_0486f2d6-c766-11e1-8775-005056c00008" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_fa81f928-3439-4353-ac4c-3785ae142ba2" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_37a5cc00-bd7f-4ec7-a77c-e140e23450d2" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.192352" x="14.8626719" g1="0.0" b1="2.345615E-4" g2="0.0" b2="2.345615E-4" bus1="_04719616-c766-11e1-8775-005056c00008" connectableBus1="_04719616-c766-11e1-8775-005056c00008" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" bus2="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus2="_044ea4c4-c766-11e1-8775-005056c00008" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_1f7aa218-1550-426b-9fd1-6361f5c3e363" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_e9798d58-b518-4fab-984c-c72076dfc2ae" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.35224" x="8.572608" g1="0.0" b1="1.4290635E-4" g2="0.0" b2="1.4290635E-4" bus1="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus1="_0449e9d4-c766-11e1-8775-005056c00008" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" bus2="_04520021-c766-11e1-8775-005056c00008" connectableBus2="_04520021-c766-11e1-8775-005056c00008" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_8b924c6b-d010-4981-b109-fc33cd937313" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_e8ec73b8-1ecf-4d18-9ef9-80eabf3a4969" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.299968" x="7.614288" g1="0.0" b1="1.2741045E-4" g2="0.0" b2="1.2741045E-4" bus1="_0474071a-c766-11e1-8775-005056c00008" connectableBus1="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" bus2="_0476c631-c766-11e1-8775-005056c00008" connectableBus2="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_0a1e553e-a285-429e-a660-00078dd05878" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2ceac3d1-f73d-43db-8d37-9e329f1787bb" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.08604" x="24.3936" g1="0.0" b1="5.3099176E-4" g2="0.0" b2="5.3099176E-4" bus1="_045163e5-c766-11e1-8775-005056c00008" connectableBus1="_045163e5-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" bus2="_046c3ee8-c766-11e1-8775-005056c00008" connectableBus2="_046c3ee8-c766-11e1-8775-005056c00008" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_2e5a9b0c-24d7-4bb6-9761-484be58c5bf6" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ca795ad3-97e5-4416-aaba-53cce27f6434" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.4537621" g1="0.0" b1="2.376033E-4" g2="0.0" b2="2.376033E-4" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_044a8615-c766-11e1-8775-005056c00008" connectableBus2="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_4f55c6a7-4a84-47ac-84a2-f7da319866f4" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_c42dc3ef-3a2e-4070-8efb-78e5c0cd5554" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.5842552" g1="0.0" b1="1.7986685E-4" g2="0.0" b2="1.7986685E-4" bus1="_045b4ef9-c766-11e1-8775-005056c00008" connectableBus1="_045b4ef9-c766-11e1-8775-005056c00008" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" bus2="_0474071a-c766-11e1-8775-005056c00008" connectableBus2="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_40c3caa3-b6ce-4e62-ada3-2053aaadb18b" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ad988fd9-9270-4230-95a2-1858f32259df" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2272" x="22.12848" g1="0.0" b1="3.5009185E-4" g2="0.0" b2="3.5009185E-4" bus1="_044a8615-c766-11e1-8775-005056c00008" connectableBus1="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" bus2="_04499bb3-c766-11e1-8775-005056c00008" connectableBus2="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f71ac0ab-1003-49e3-baae-6860eaa27ea1" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_519e3ecb-3561-4d11-ac6b-172a0b4b09b2" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.390848" x="20.38608" g1="0.0" b1="8.551425E-5" g2="0.0" b2="8.551425E-5" bus1="_04670ec8-c766-11e1-8775-005056c00008" connectableBus1="_04670ec8-c766-11e1-8775-005056c00008" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" bus2="_0474f17a-c766-11e1-8775-005056c00008" connectableBus2="_0474f17a-c766-11e1-8775-005056c00008" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_e0ff2082-d064-46f0-89c2-f6597d7c5acb" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b88528bf-cb1c-4c00-ad79-d5937197d40c" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.299968" x="7.562016" g1="0.0" b1="3.18526E-5" g2="0.0" b2="3.18526E-5" bus1="_045c8773-c766-11e1-8775-005056c00008" connectableBus1="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" bus2="_047e6750-c766-11e1-8775-005056c00008" connectableBus2="_047e6750-c766-11e1-8775-005056c00008" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_9b58679f-8c7f-489f-884a-30224849053b" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b70e76a1-6e79-4fb6-b487-dffa9bfeab7b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.693888" x="14.5316162" g1="0.0" b1="6.140955E-5" g2="0.0" b2="6.140955E-5" bus1="_047566a8-c766-11e1-8775-005056c00008" connectableBus1="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" bus2="_04531195-c766-11e1-8775-005056c00008" connectableBus2="_04531195-c766-11e1-8775-005056c00008" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_25cb43d7-517b-4c25-b213-a01c4afe495d" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_af73f526-c58b-40e7-8e1c-14f05a39f6a2" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.78784" x="9.1476" g1="0.0" b1="1.5381085E-4" g2="0.0" b2="1.5381085E-4" bus1="_0468bc75-c766-11e1-8775-005056c00008" connectableBus1="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" bus2="_04597a36-c766-11e1-8775-005056c00008" connectableBus2="_04597a36-c766-11e1-8775-005056c00008" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ce5f31b6-0de2-41fb-8091-c2d5742b1828" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_1631e50b-21a3-470b-803b-f9665b6fcd60" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.990096" x="13.1551189" g1="0.0" b1="5.52686E-5" g2="0.0" b2="5.52686E-5" bus1="_04483c26-c766-11e1-8775-005056c00008" connectableBus1="_04483c26-c766-11e1-8775-005056c00008" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" bus2="_04675ce7-c766-11e1-8775-005056c00008" connectableBus2="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_cd4a9202-6aaa-4709-8293-bc142c0c9bc0" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_52eb4b09-42bb-4106-ac26-fe1059639d3a" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.715072" x="26.1360016" g1="0.0" b1="1.113407E-4" g2="0.0" b2="1.113407E-4" bus1="_045645e7-c766-11e1-8775-005056c00008" connectableBus1="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" bus2="_04814d88-c766-11e1-8775-005056c00008" connectableBus2="_04814d88-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_13d74b35-2eae-4bb7-9968-655ba9ecd015" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b5a7dea0-bfce-4548-a04d-7bb7b6d9f80a" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.858224" x="35.54496" g1="0.0" b1="1.5524565E-4" g2="0.0" b2="1.5524565E-4" bus1="_0468bc75-c766-11e1-8775-005056c00008" connectableBus1="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" bus2="_046783f5-c766-11e1-8775-005056c00008" connectableBus2="_046783f5-c766-11e1-8775-005056c00008" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_80225115-e6ed-47cd-b7d2-04f198d2417f" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_17a10cd0-b653-4dcf-bdc3-4d5005ea9591" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.8305779" g1="0.0" b1="1.4284895E-4" g2="0.0" b2="1.4284895E-4" bus1="_04716f04-c766-11e1-8775-005056c00008" connectableBus1="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" bus2="_04719616-c766-11e1-8775-005056c00008" connectableBus2="_04719616-c766-11e1-8775-005056c00008" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f64d2e1f-164f-4cd3-b7bd-9be3300eacb1" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6f81df11-7e71-4b6e-a6ee-a8c5f72f4ba5" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.523408" x="20.0898724" g1="0.0" b1="3.3660465E-4" g2="0.0" b2="3.3660465E-4" bus1="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus1="_0449e9d4-c766-11e1-8775-005056c00008" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" bus2="_04675ce7-c766-11e1-8775-005056c00008" connectableBus2="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ac71ed2f-6a14-4b3d-aa1b-b7a3cd071a96" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_a8f6a7d2-e58d-4671-a776-97be7291355e" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.014352" x="15.42024" g1="0.0" b1="6.887055E-5" g2="0.0" b2="6.887055E-5" bus1="_0479fa80-c766-11e1-8775-005056c00008" connectableBus1="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" bus2="_04667284-c766-11e1-8775-005056c00008" connectableBus2="_04667284-c766-11e1-8775-005056c00008" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_b6767a5e-0078-4311-b973-464b8f35bbfd" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ea6d39aa-df95-4d3e-b7b6-a800e552e72a" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.540833" x="28.4011211" g1="0.0" b1="5.06198385E-4" g2="0.0" b2="5.06198385E-4" bus1="_04689567-c766-11e1-8775-005056c00008" connectableBus1="_04689567-c766-11e1-8775-005056c00008" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" bus2="_04483c26-c766-11e1-8775-005056c00008" connectableBus2="_04483c26-c766-11e1-8775-005056c00008" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_8a1cb557-29ed-49ae-9120-65b4bdb8d2b1" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_d9d53af2-5ffa-4f2a-a4e6-ed22371332d6" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.303728" x="11.1513615" g1="0.0" b1="1.779155E-4" g2="0.0" b2="1.779155E-4" bus1="_04550d63-c766-11e1-8775-005056c00008" connectableBus1="_04550d63-c766-11e1-8775-005056c00008" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" bus2="_0482d420-c766-11e1-8775-005056c00008" connectableBus2="_0482d420-c766-11e1-8775-005056c00008" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_e55ac0b9-b111-4207-b7ee-59ac708a4e23" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_d50299b9-a055-408a-aa1e-2e93a715120f" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.724976" x="8.79912" g1="0.0" b1="1.5725435E-4" g2="0.0" b2="1.5725435E-4" bus1="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" bus2="_04502b6a-c766-11e1-8775-005056c00008" connectableBus2="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_4f767c6c-7f3a-4cb0-8a7d-04b1b4897817" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_eee9ca2b-764f-4ab8-a745-405338044743" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.7038422" g1="0.0" b1="2.094812E-4" g2="0.0" b2="2.094812E-4" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_04549837-c766-11e1-8775-005056c00008" connectableBus2="_04549837-c766-11e1-8775-005056c00008" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_c1091068-8e12-44e2-bdc4-44450556f80f" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_690202a4-aad2-4ad3-8842-961b39e37709" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.52648" x="8.485488" g1="0.0" b1="3.50666E-5" g2="0.0" b2="3.50666E-5" bus1="_045868c7-c766-11e1-8775-005056c00008" connectableBus1="_045868c7-c766-11e1-8775-005056c00008" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" bus2="_04544a19-c766-11e1-8775-005056c00008" connectableBus2="_04544a19-c766-11e1-8775-005056c00008" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_3d919b23-d14b-4639-a104-ce09f5d78235" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_34f2ef7c-32da-4444-b989-d02f5f931c50" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0.0" b1="4.453625E-5" g2="0.0" b2="4.453625E-5" bus1="_04778983-c766-11e1-8775-005056c00008" connectableBus1="_04778983-c766-11e1-8775-005056c00008" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" bus2="_045868c7-c766-11e1-8775-005056c00008" connectableBus2="_045868c7-c766-11e1-8775-005056c00008" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_d8fb151e-0854-45a9-8df9-177e6bfebf52" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_38d58455-5205-46bb-8e44-c66873f62938" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.847632" x="27.5473423" g1="0.0" b1="1.1880165E-4" g2="0.0" b2="1.1880165E-4" bus1="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" bus2="_04502b6a-c766-11e1-8775-005056c00008" connectableBus2="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_135d109b-ce06-4ee9-9fdc-bc39b1cd4791" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_0cce41c7-b99f-4fec-93d2-73ea24433fa1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.23096" x="24.74208" g1="0.0" b1="1.0502755E-4" g2="0.0" b2="1.0502755E-4" bus1="_045e0e10-c766-11e1-8775-005056c00008" connectableBus1="_045e0e10-c766-11e1-8775-005056c00008" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" bus2="_048b86b5-c766-11e1-8775-005056c00008" connectableBus2="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f5fb6f64-e16e-422b-b721-de1a781e8c01" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_343677c6-7477-4bf6-a12c-2c7e4a684d6f" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.547664" x="12.2490721" g1="0.0" b1="5.29155E-5" g2="0.0" b2="5.29155E-5" bus1="_04876809-c766-11e1-8775-005056c00008" connectableBus1="_04876809-c766-11e1-8775-005056c00008" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" bus2="_046b7b91-c766-11e1-8775-005056c00008" connectableBus2="_046b7b91-c766-11e1-8775-005056c00008" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_072c26b8-9b37-418f-b9a6-338f9a198a84" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_74cf84b9-e14f-4f81-9e8b-3a791cd474a0" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.446054" x="1.637856" g1="0.0" b1="2.82369E-5" g2="0.0" b2="2.82369E-5" bus1="_044e56a4-c766-11e1-8775-005056c00008" connectableBus1="_044e56a4-c766-11e1-8775-005056c00008" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" bus2="_048b86b5-c766-11e1-8775-005056c00008" connectableBus2="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_1ee3b9bf-743b-4bcb-b6a3-faa02fc44cc1" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_8e90bf2e-3be4-41be-a84e-c1d4e709f8a1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.551424" g1="0.0" b1="2.812215E-5" g2="0.0" b2="2.812215E-5" bus1="_04814d88-c766-11e1-8775-005056c00008" connectableBus1="_04814d88-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" bus2="_044b9787-c766-11e1-8775-005056c00008" connectableBus2="_044b9787-c766-11e1-8775-005056c00008" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_b653b5eb-5efc-4bcc-9e10-1eb6bfa6f57c" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_39a23399-348e-44d9-8032-8fc62e6c7d63" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.286304" x="19.5148811" g1="0.0" b1="8.43664E-5" g2="0.0" b2="8.43664E-5" bus1="_0485ba50-c766-11e1-8775-005056c00008" connectableBus1="_0485ba50-c766-11e1-8775-005056c00008" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" bus2="_04845ac5-c766-11e1-8775-005056c00008" connectableBus2="_04845ac5-c766-11e1-8775-005056c00008" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_6be4027d-eae3-4d93-8b3a-bd3ecbefb0a1" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_0501dacc-29fc-44a2-8cad-31a20b011d25" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.86716" x="41.624" g1="0.0" b1="9.380165E-4" g2="0.0" b2="9.380165E-4" bus1="_0455a9a6-c766-11e1-8775-005056c00008" connectableBus1="_0455a9a6-c766-11e1-8775-005056c00008" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" bus2="_046c3ee8-c766-11e1-8775-005056c00008" connectableBus2="_046c3ee8-c766-11e1-8775-005056c00008" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_0b8a340a-b8d4-4498-8223-9e70f54345ff" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_c95a66fd-913c-48c7-b8ef-cf3007c60af6" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.45816" x="56.2795219" g1="0.0" b1="2.4678605E-4" g2="0.0" b2="2.4678605E-4" bus1="_04577e63-c766-11e1-8775-005056c00008" connectableBus1="_04577e63-c766-11e1-8775-005056c00008" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_1aa29312-557e-4a5f-965c-219d32569822" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6cd83bc2-204f-44d5-afd4-fbfef8d2146f" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.43936" x="9.530928" g1="0.0" b1="4.115015E-5" g2="0.0" b2="4.115015E-5" bus1="_04876809-c766-11e1-8775-005056c00008" connectableBus1="_04876809-c766-11e1-8775-005056c00008" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" bus2="_044ef2e3-c766-11e1-8775-005056c00008" connectableBus2="_044ef2e3-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_6a482321-ff03-47e5-8d69-0a211cec9016" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_487e1317-48f9-4747-b931-f3f79e95f55a" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.459994" x="2.35224" g1="0.0" b1="4.178145E-5" g2="0.0" b2="4.178145E-5" bus1="_047d2ed4-c766-11e1-8775-005056c00008" connectableBus1="_047d2ed4-c766-11e1-8775-005056c00008" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" bus2="_04814d88-c766-11e1-8775-005056c00008" connectableBus2="_04814d88-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_8f379d20-b516-4eec-b535-925586132d69" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3c55a929-a755-409b-af5f-bae188892af1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.718144" x="13.9391994" g1="0.0" b1="2.479339E-4" g2="0.0" b2="2.479339E-4" bus1="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus1="_0449e9d4-c766-11e1-8775-005056c00008" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" bus2="_04689567-c766-11e1-8775-005056c00008" connectableBus2="_04689567-c766-11e1-8775-005056c00008" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_3e4b7d9a-4e85-4b10-9dba-a83fb76bf6b7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_9658628a-596f-41a9-96a7-c5a8aaf5400c" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.1028481" x="43.0372772" g1="0.0" b1="1.8135905E-4" g2="0.0" b2="1.8135905E-4" bus1="_04670ec8-c766-11e1-8775-005056c00008" connectableBus1="_04670ec8-c766-11e1-8775-005056c00008" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" bus2="_044e56a4-c766-11e1-8775-005056c00008" connectableBus2="_044e56a4-c766-11e1-8775-005056c00008" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7d1b5b44-e965-446d-b0a2-2abd8f995343" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b69ab61b-751d-487a-a538-2d47eea7572e" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.523408" x="25.2648" g1="0.0" b1="1.0789715E-4" g2="0.0" b2="1.0789715E-4" bus1="_045645e7-c766-11e1-8775-005056c00008" connectableBus1="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" bus2="_047d2ed4-c766-11e1-8775-005056c00008" connectableBus2="_047d2ed4-c766-11e1-8775-005056c00008" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_37b8abba-f482-471a-a82d-65606ca1d4d5" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_a38d4859-b54a-482f-a2ad-0b4ce4c4da2a" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.09088" x="6.865056" g1="0.0" b1="2.8983E-5" g2="0.0" b2="2.8983E-5" bus1="_0474071a-c766-11e1-8775-005056c00008" connectableBus1="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" bus2="_04670ec8-c766-11e1-8775-005056c00008" connectableBus2="_04670ec8-c766-11e1-8775-005056c00008" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_beec41ff-5166-438d-8178-950089f889c8" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_15d16bd2-d87c-4584-93d2-b294dc1be116" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.425696" x="14.5664635" g1="0.0" b1="6.140955E-5" g2="0.0" b2="6.140955E-5" bus1="_048433b2-c766-11e1-8775-005056c00008" connectableBus1="_048433b2-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" bus2="_04675ce9-c766-11e1-8775-005056c00008" connectableBus2="_04675ce9-c766-11e1-8775-005056c00008" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ff16ab37-609f-4d89-97e0-8f4fd8cfa2e3" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_7d2a67fb-9d8c-4745-a67e-ce6ade5e520e" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.959008" x="27.7041588" g1="0.0" b1="1.1593205E-4" g2="0.0" b2="1.1593205E-4" bus1="_0461b794-c766-11e1-8775-005056c00008" connectableBus1="_0461b794-c766-11e1-8775-005056c00008" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" bus2="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus2="_0449e9d4-c766-11e1-8775-005056c00008" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_55a45a23-6031-4a23-956f-992afb08c743" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6477d99a-dd64-4083-8f56-1396610879f0" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.49232" x="25.78752" g1="0.0" b1="9.986225E-5" g2="0.0" b2="9.986225E-5" bus1="_046a9133-c766-11e1-8775-005056c00008" connectableBus1="_046a9133-c766-11e1-8775-005056c00008" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" bus2="_045f1f84-c766-11e1-8775-005056c00008" connectableBus2="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ad873b1b-014a-4c65-b7cd-22ebb86236bc" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_38cb3e5b-af1a-4684-aa2f-242826ed460c" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.258976" x="27.2337112" g1="0.0" b1="1.1449725E-4" g2="0.0" b2="1.1449725E-4" bus1="_0476c631-c766-11e1-8775-005056c00008" connectableBus1="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" bus2="_04723255-c766-11e1-8775-005056c00008" connectableBus2="_04723255-c766-11e1-8775-005056c00008" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_55a3f358-a56b-467d-96f8-1bfbe09799dc" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_9066b19a-f404-42c3-88ce-51d375f6fdb5" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.025632" x="32.75712" g1="0.0" b1="1.5151515E-4" g2="0.0" b2="1.5151515E-4" bus1="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" bus2="_048433b2-c766-11e1-8775-005056c00008" connectableBus2="_048433b2-c766-11e1-8775-005056c00008" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_d228fae3-2cfd-42c2-85bf-6ed2417949ef" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_924b4a0b-bef5-432a-ad87-ab5c10d9c019" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.457472" x="24.56784" g1="0.0" b1="1.033058E-4" g2="0.0" b2="1.033058E-4" bus1="_04499bb3-c766-11e1-8775-005056c00008" connectableBus1="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" bus2="_04716f04-c766-11e1-8775-005056c00008" connectableBus2="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_30aabccf-8ec8-46a2-a3a1-ba354c62f10a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_d432d118-553c-4f4c-a734-e98e0762ec40" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.258976" x="23.34816" g1="0.0" b1="9.52709E-5" g2="0.0" b2="9.52709E-5" bus1="_044a5f04-c766-11e1-8775-005056c00008" connectableBus1="_044a5f04-c766-11e1-8775-005056c00008" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" bus2="_047c9297-c766-11e1-8775-005056c00008" connectableBus2="_047c9297-c766-11e1-8775-005056c00008" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_aff34ffe-0ef8-42ff-99bd-8e286c8073a8" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2f32bda4-7275-4485-9901-12f8cff9e4a1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.073456" x="9.40896" g1="0.0" b1="4.092055E-5" g2="0.0" b2="4.092055E-5" bus1="_047147f0-c766-11e1-8775-005056c00008" connectableBus1="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" bus2="_046b066a-c766-11e1-8775-005056c00008" connectableBus2="_046b066a-c766-11e1-8775-005056c00008" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_3678bd5d-c47e-4eb0-8620-7f9e24a10618" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b3b0e81b-a434-4e9c-ad94-1161ff47b077" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.257234" x="37.6009941" g1="0.0" b1="1.620179E-4" g2="0.0" b2="1.620179E-4" bus1="_04769f21-c766-11e1-8775-005056c00008" connectableBus1="_04769f21-c766-11e1-8775-005056c00008" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_4a915430-984f-4a53-9533-53efa325d9e5" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6db0d250-4a2e-4169-abf0-f842aeca485d" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.279472" x="17.4065762" g1="0.0" b1="7.288795E-5" g2="0.0" b2="7.288795E-5" bus1="_044a8618-c766-11e1-8775-005056c00008" connectableBus1="_044a8618-c766-11e1-8775-005056c00008" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" bus2="_045fe2d7-c766-11e1-8775-005056c00008" connectableBus2="_045fe2d7-c766-11e1-8775-005056c00008" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ebd82352-16ad-454f-8920-32a110d327d1" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_9f39cb45-314c-445e-b177-909854a9ce45" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.036728" x="3.415104" g1="0.0" b1="1.44054E-5" g2="0.0" b2="1.44054E-5" bus1="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus1="_0458b6e4-c766-11e1-8775-005056c00008" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" bus2="_047566a8-c766-11e1-8775-005056c00008" connectableBus2="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_c0261082-5d30-4965-882d-3c1719e82054" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_70fad3e1-4529-4a7f-9e6c-8ab249d65460" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0.0" b1="0.001200413215" g2="0.0" b2="0.001200413215" bus1="_045163e5-c766-11e1-8775-005056c00008" connectableBus1="_045163e5-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" bus2="_044e7db1-c766-11e1-8775-005056c00008" connectableBus2="_044e7db1-c766-11e1-8775-005056c00008" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_0ea6e870-9b01-4226-80d3-5ff1a2f88c40" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_205e5d8a-f05a-479d-adaa-3514f48f6857" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0.0" b1="3.92562E-4" g2="0.0" b2="3.92562E-4" bus1="_0457f395-c766-11e1-8775-005056c00008" connectableBus1="_0457f395-c766-11e1-8775-005056c00008" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" bus2="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus2="_0458ddf2-c766-11e1-8775-005056c00008" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_09341906-df9b-4a95-a073-d9e12f3841be" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_8cee2b62-2953-439b-ba4b-4a48d55116c0" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47916" x="1.663992" g1="0.0" b1="2.10055E-5" g2="0.0" b2="2.10055E-5" bus1="_04549837-c766-11e1-8775-005056c00008" connectableBus1="_04549837-c766-11e1-8775-005056c00008" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" bus2="_045b9d15-c766-11e1-8775-005056c00008" connectableBus2="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_665fcc7f-38d1-4204-95fa-0c63c2a2ddc5" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_640627c7-0672-413e-8dc8-c9965709a5cb" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.262048" x="11.1687832" g1="0.0" b1="3.541095E-5" g2="0.0" b2="3.541095E-5" bus1="_04716f02-c766-11e1-8775-005056c00008" connectableBus1="_04716f02-c766-11e1-8775-005056c00008" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" bus2="_045f1f84-c766-11e1-8775-005056c00008" connectableBus2="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_eeb51357-560f-40d7-89d7-4fdfd53a167f" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_8b888209-5038-4b98-80fc-062b5ea55747" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0.0" b1="1.629935E-5" g2="0.0" b2="1.629935E-5" bus1="_044e56a4-c766-11e1-8775-005056c00008" connectableBus1="_044e56a4-c766-11e1-8775-005056c00008" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" bus2="_0480d858-c766-11e1-8775-005056c00008" connectableBus2="_0480d858-c766-11e1-8775-005056c00008" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_52f8cd12-1364-4ef3-ae3d-0285817f0354" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_c0a08025-3a61-4d24-9944-f3ef0b079f64" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507" x="71.69976" g1="0.0" b1="2.9264235E-4" g2="0.0" b2="2.9264235E-4" bus1="_04520021-c766-11e1-8775-005056c00008" connectableBus1="_04520021-c766-11e1-8775-005056c00008" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" bus2="_04499bb3-c766-11e1-8775-005056c00008" connectableBus2="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_66b89c81-20ba-41de-82a2-f999d5085ebd" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_32793450-bbfd-4dcd-a911-89e199600780" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0984" x="21.43152" g1="0.0" b1="7.92011E-5" g2="0.0" b2="7.92011E-5" bus1="_045f1f84-c766-11e1-8775-005056c00008" connectableBus1="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" bus2="_04689561-c766-11e1-8775-005056c00008" connectableBus2="_04689561-c766-11e1-8775-005056c00008" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_a9a5c23c-642d-4ae6-9eda-818565194dc7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2ec4bef5-7abb-4f52-bb62-49ee474d672b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.910496" x="31.3806229" g1="0.0" b1="1.337236E-4" g2="0.0" b2="1.337236E-4" bus1="_04531195-c766-11e1-8775-005056c00008" connectableBus1="_04531195-c766-11e1-8775-005056c00008" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" bus2="_0476c631-c766-11e1-8775-005056c00008" connectableBus2="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_142dbec6-04c3-4fb9-becf-7e45d36725bc" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_9280074c-8555-49ff-9e62-8ed8f7d95060" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.398368" x="37.9843178" g1="0.0" b1="1.6586315E-4" g2="0.0" b2="1.6586315E-4" bus1="_044b9787-c766-11e1-8775-005056c00008" connectableBus1="_044b9787-c766-11e1-8775-005056c00008" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" bus2="_04862f81-c766-11e1-8775-005056c00008" connectableBus2="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_c3ef7069-26cb-4184-bb94-4ac49df0603d" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ace48562-0a49-4b76-ae82-c896a00b04f9" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.78752" g1="0.0" b1="1.0560145E-4" g2="0.0" b2="1.0560145E-4" bus1="_047ba835-c766-11e1-8775-005056c00008" connectableBus1="_047ba835-c766-11e1-8775-005056c00008" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" bus2="_04719616-c766-11e1-8775-005056c00008" connectableBus2="_04719616-c766-11e1-8775-005056c00008" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_bc06dfbb-eb99-4db7-8c9d-ec079e03009f" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3f744dba-88dc-4d89-90d4-a6f196054b28" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.143152" x="9.774864" g1="0.0" b1="4.21258E-5" g2="0.0" b2="4.21258E-5" bus1="_047d2ed4-c766-11e1-8775-005056c00008" connectableBus1="_047d2ed4-c766-11e1-8775-005056c00008" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" bus2="_044b9787-c766-11e1-8775-005056c00008" connectableBus2="_044b9787-c766-11e1-8775-005056c00008" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7da82087-b318-404c-9514-65732f211e14" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_43f91aaf-c5f4-4995-85a2-37afac616331" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.333211" x="14.89752" g1="0.0" b1="6.19835E-5" g2="0.0" b2="6.19835E-5" bus1="_04483c26-c766-11e1-8775-005056c00008" connectableBus1="_04483c26-c766-11e1-8775-005056c00008" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" bus2="_046c8d0b-c766-11e1-8775-005056c00008" connectableBus2="_046c8d0b-c766-11e1-8775-005056c00008" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_611015af-1467-451a-a0ba-6c093df0fde0" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2c20e8bd-84e6-4a1e-b88e-071f631327cb" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9696" x="23.6269436" g1="0.0" b1="9.52709E-5" g2="0.0" b2="9.52709E-5" bus1="_04725962-c766-11e1-8775-005056c00008" connectableBus1="_04725962-c766-11e1-8775-005056c00008" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" bus2="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus2="_0462a1f3-c766-11e1-8775-005056c00008" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7a4b30c3-e92f-4a39-aeff-e9554d8ce96e" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6ad31f7e-233f-4801-898f-9ffc883ec724" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.590032" g1="0.0" b1="3.27709E-5" g2="0.0" b2="3.27709E-5" bus1="_04686e54-c766-11e1-8775-005056c00008" connectableBus1="_04686e54-c766-11e1-8775-005056c00008" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" bus2="_04670ec8-c766-11e1-8775-005056c00008" connectableBus2="_04670ec8-c766-11e1-8775-005056c00008" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_917c1ba3-4b76-4e83-a631-84a088996b57" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_a025c9d8-58f9-4320-a1fe-73ecc68d4147" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.24872" x="15.5848007" g1="0.0" b1="0.00127066113" g2="0.0" b2="0.00127066113" bus1="_044e7db1-c766-11e1-8775-005056c00008" connectableBus1="_044e7db1-c766-11e1-8775-005056c00008" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" bus2="_047ba832-c766-11e1-8775-005056c00008" connectableBus2="_047ba832-c766-11e1-8775-005056c00008" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_a0202601-e216-4568-ab78-b4fe21fd1fba" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b7fac0a3-c5af-48b9-af49-261fd8d46e00" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4848" x="17.77248" g1="0.0" b1="7.92011E-5" g2="0.0" b2="7.92011E-5" bus1="_045f1f84-c766-11e1-8775-005056c00008" connectableBus1="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" bus2="_047a96c0-c766-11e1-8775-005056c00008" connectableBus2="_047a96c0-c766-11e1-8775-005056c00008" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_1662e4d0-c8bc-4830-a853-01d4c6f3c737" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_51646744-d343-42b5-8ba7-fcedc7cc3a98" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.384016" x="17.59824" g1="0.0" b1="2.97865E-4" g2="0.0" b2="2.97865E-4" bus1="_044a8615-c766-11e1-8775-005056c00008" connectableBus1="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" bus2="_04719616-c766-11e1-8775-005056c00008" connectableBus2="_04719616-c766-11e1-8775-005056c00008" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_2dd1be0d-4305-4e5a-af1e-424eda4251b7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_76311a15-b79a-4439-a7ce-47afa8fa6fe2" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.87684" x="12.7369442" g1="0.0" b1="5.38338E-5" g2="0.0" b2="5.38338E-5" bus1="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus1="_0458b6e4-c766-11e1-8775-005056c00008" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" bus2="_045b4ef9-c766-11e1-8775-005056c00008" connectableBus2="_045b4ef9-c766-11e1-8775-005056c00008" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7bf0d6eb-6015-4b67-b5f5-7e9417da9602" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_efbf8de7-4b84-4834-bb7c-6250b6072211" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.32184" x="28.314" g1="0.0" b1="1.170799E-4" g2="0.0" b2="1.170799E-4" bus1="_04597a36-c766-11e1-8775-005056c00008" connectableBus1="_04597a36-c766-11e1-8775-005056c00008" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" bus2="_04876809-c766-11e1-8775-005056c00008" connectableBus2="_04876809-c766-11e1-8775-005056c00008" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_77f8dc85-1e26-4f69-8f9d-2e85760a932b" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_22b6919a-a7a0-49fc-9e90-329069c55055" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.9180164" x="32.40864" g1="0.0" b1="1.2741045E-4" g2="0.0" b2="1.2741045E-4" bus1="_04725962-c766-11e1-8775-005056c00008" connectableBus1="_04725962-c766-11e1-8775-005056c00008" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_3ad3799b-5f8c-4ba0-9e85-81d48157adf6" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_8b91f4fd-4038-45b7-870c-fbc08592b95a" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.421936" x="12.4058876" g1="0.0" b1="5.549815E-5" g2="0.0" b2="5.549815E-5" bus1="_047a96c0-c766-11e1-8775-005056c00008" connectableBus1="_047a96c0-c766-11e1-8775-005056c00008" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" bus2="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus2="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_6dd129f4-2730-4d27-b5dd-b91c16fc6588" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_970bc323-73bf-440d-a3c5-00aebc3a1992" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.146912" x="18.81792" g1="0.0" b1="8.20707E-5" g2="0.0" b2="8.20707E-5" bus1="_04898ae9-c766-11e1-8775-005056c00008" connectableBus1="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" bus2="_044b7076-c766-11e1-8775-005056c00008" connectableBus2="_044b7076-c766-11e1-8775-005056c00008" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_70ad4f3f-a659-48e9-8383-8ac70b8bce31" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_cb084dc7-1b26-415f-9495-4695df661912" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.743088" x="22.16333" g1="0.0" b1="9.37787E-5" g2="0.0" b2="9.37787E-5" bus1="_04675ce9-c766-11e1-8775-005056c00008" connectableBus1="_04675ce9-c766-11e1-8775-005056c00008" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" bus2="_04502b6a-c766-11e1-8775-005056c00008" connectableBus2="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_a688473b-de97-456e-afb7-e65c079e3b34" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3a165a76-f6ba-461b-84d6-159a5e0b5077" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.92416" g1="0.0" b1="2.508035E-5" g2="0.0" b2="2.508035E-5" bus1="_04684743-c766-11e1-8775-005056c00008" connectableBus1="_04684743-c766-11e1-8775-005056c00008" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" bus2="_047566a8-c766-11e1-8775-005056c00008" connectableBus2="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_bed061b3-3663-40ad-956f-90cda64cbaab" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b19bc945-cc51-4d77-8eaa-3f6afe2d9316" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.1657114" g1="0.0" b1="6.19835E-5" g2="0.0" b2="6.19835E-5" bus1="_048c4a07-c766-11e1-8775-005056c00008" connectableBus1="_048c4a07-c766-11e1-8775-005056c00008" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" bus2="_0468bc75-c766-11e1-8775-005056c00008" connectableBus2="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_1bb497d6-1d54-49c9-bdd5-c8634a07cfb5" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_a9e283ed-fcad-4f4c-ab57-8531875bb098" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.812096" g1="0.0" b1="7.9201E-6" g2="0.0" b2="7.9201E-6" bus1="_046f9a47-c766-11e1-8775-005056c00008" connectableBus1="_046f9a47-c766-11e1-8775-005056c00008" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" bus2="_044fdd40-c766-11e1-8775-005056c00008" connectableBus2="_044fdd40-c766-11e1-8775-005056c00008" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_683d7e84-46ea-46ad-9327-754235536ac4" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_c59e4022-b1c0-4811-a32e-f54656bff32d" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.89" x="22.99968" g1="0.0" b1="7.40358E-5" g2="0.0" b2="7.40358E-5" bus1="_046a9133-c766-11e1-8775-005056c00008" connectableBus1="_046a9133-c766-11e1-8775-005056c00008" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" bus2="_04716f02-c766-11e1-8775-005056c00008" connectableBus2="_04716f02-c766-11e1-8775-005056c00008" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_204653d4-8c5b-43bc-9283-a2a842f366a9" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_1268eb09-e233-44ce-b8af-22dc30eb16ad" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.36728" x="33.9768" g1="0.0" b1="1.440542E-4" g2="0.0" b2="1.440542E-4" bus1="_047e4045-c766-11e1-8775-005056c00008" connectableBus1="_047e4045-c766-11e1-8775-005056c00008" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" bus2="_0474071a-c766-11e1-8775-005056c00008" connectableBus2="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ff77fc37-c585-41b5-90d2-a44430227501" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_9c0c454b-ecc3-40f6-b505-f32fec412522" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.202944" x="31.71168" g1="0.0" b1="1.417585E-4" g2="0.0" b2="1.417585E-4" bus1="_04898ae9-c766-11e1-8775-005056c00008" connectableBus1="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" bus2="_0479fa80-c766-11e1-8775-005056c00008" connectableBus2="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_d63c0548-9f5e-4d60-bae2-0566a6473e46" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_1432f4d6-9299-4b0d-bd7f-16e059f9de66" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.64336" g1="0.0" b1="1.5381085E-4" g2="0.0" b2="1.5381085E-4" bus1="_045b9d15-c766-11e1-8775-005056c00008" connectableBus1="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_08a97648-23dd-422a-a403-bdb89143a421" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_193f6952-4267-4cc8-a541-726c095028ba" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.2907524" x="51.4008" g1="0.0" b1="1.3544535E-4" g2="0.0" b2="1.3544535E-4" bus1="_04502b6a-c766-11e1-8775-005056c00008" connectableBus1="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" bus2="_0468bc75-c766-11e1-8775-005056c00008" connectableBus2="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_07757788-2dda-494c-9038-c1d010214558" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_579249ce-1c81-4d29-8d3f-5fc627a18f99" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792" x="42.7584953" g1="0.0" b1="1.7412765E-4" g2="0.0" b2="1.7412765E-4" bus1="_046bf0cb-c766-11e1-8775-005056c00008" connectableBus1="_046bf0cb-c766-11e1-8775-005056c00008" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" bus2="_047c4478-c766-11e1-8775-005056c00008" connectableBus2="_047c4478-c766-11e1-8775-005056c00008" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f1be8c91-71cf-4d95-bcee-a6e3c19c9a0a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3d2cb4b5-ee82-4866-9855-4a5f4803cd3b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.843872" x="13.2770882" g1="0.0" b1="5.7966E-5" g2="0.0" b2="5.7966E-5" bus1="_046c17da-c766-11e1-8775-005056c00008" connectableBus1="_046c17da-c766-11e1-8775-005056c00008" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" bus2="_04550d63-c766-11e1-8775-005056c00008" connectableBus2="_04550d63-c766-11e1-8775-005056c00008" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_4895e133-ecd4-4a69-b358-c2d8d11bd39d" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6fc48d8d-05f8-4104-a6a2-3686d430a091" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.847" x="9.776799" g1="0.0" b1="8.3471078E-4" g2="0.0" b2="8.3471078E-4" bus1="_044aad28-c766-11e1-8775-005056c00008" connectableBus1="_044aad28-c766-11e1-8775-005056c00008" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" bus2="_0453d4e3-c766-11e1-8775-005056c00008" connectableBus2="_0453d4e3-c766-11e1-8775-005056c00008" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_4428a1f2-00f5-474c-b891-600c8f530e1f" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_191836a1-39cd-402b-8dcf-4f3867c45bd0" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.164336" x="30.1435184" g1="0.0" b1="1.3487145E-4" g2="0.0" b2="1.3487145E-4" bus1="_045f1f84-c766-11e1-8775-005056c00008" connectableBus1="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" bus2="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus2="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_4d831a76-7147-4776-a08a-9b166d2dcc7d" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_66cbdeeb-a4e4-4bfc-aec1-9fb7a2d2b6bc" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.146912" x="17.371727" g1="0.0" b1="3.0417815E-4" g2="0.0" b2="3.0417815E-4" bus1="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" bus2="_048433b2-c766-11e1-8775-005056c00008" connectableBus2="_048433b2-c766-11e1-8775-005056c00008" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_2eff6ba2-5d90-4d71-bcc6-a0c31c1d028d" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_8489e809-6588-4ed2-a9a4-43c44a0d47da" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.917328" x="31.188961" g1="0.0" b1="1.365932E-4" g2="0.0" b2="1.365932E-4" bus1="_044b7076-c766-11e1-8775-005056c00008" connectableBus1="_044b7076-c766-11e1-8775-005056c00008" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" bus2="_0468bc75-c766-11e1-8775-005056c00008" connectableBus2="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_a27844ae-f43e-4dea-82b7-bbfa8265a2d2" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_620beaaf-63c8-4020-bea5-c3609c0eaadf" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.129488" x="16.4308319" g1="0.0" b1="6.82966E-5" g2="0.0" b2="6.82966E-5" bus1="_046c8d0b-c766-11e1-8775-005056c00008" connectableBus1="_046c8d0b-c766-11e1-8775-005056c00008" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" bus2="_04885267-c766-11e1-8775-005056c00008" connectableBus2="_04885267-c766-11e1-8775-005056c00008" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.199184" x="18.81792" g1="0.0" b1="8.14968E-5" g2="0.0" b2="8.14968E-5" bus1="_0471bd2a-c766-11e1-8775-005056c00008" connectableBus1="_0471bd2a-c766-11e1-8775-005056c00008" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" bus2="_047147f0-c766-11e1-8775-005056c00008" connectableBus2="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_751f81c5-bc0f-47d9-8bf1-215d33c20a33" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_828ca44c-560b-4f94-b825-21e237285fae" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.822688" x="9.23472" g1="0.0" b1="1.561065E-4" g2="0.0" b2="1.561065E-4" bus1="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus1="_044ea4c4-c766-11e1-8775-005056c00008" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" bus2="_0479fa80-c766-11e1-8775-005056c00008" connectableBus2="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_c0d073c0-9e3c-443a-898c-1b775bffd91a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_233b7735-85f4-4a6f-9d87-15129fe42ef5" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.36084" x="47.7224" g1="0.0" b1="0.0010805785" g2="0.0" b2="0.0010805785" bus1="_0451b206-c766-11e1-8775-005056c00008" connectableBus1="_0451b206-c766-11e1-8775-005056c00008" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" bus2="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus2="_0458ddf2-c766-11e1-8775-005056c00008" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_bbea6b5b-db2c-40f6-afef-3da510b3b212" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_990ce3c5-c90c-41b9-abee-fb803d9df3a5" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.23472" x="31.88592" g1="0.0" b1="1.3544535E-4" g2="0.0" b2="1.3544535E-4" bus1="_044ef2e3-c766-11e1-8775-005056c00008" connectableBus1="_044ef2e3-c766-11e1-8775-005056c00008" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" bus2="_0483be8a-c766-11e1-8775-005056c00008" connectableBus2="_0483be8a-c766-11e1-8775-005056c00008" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_9bb71092-9fe9-497f-9296-4a8b4d9b2bf6" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_1372c3b0-62d7-47d7-a8c0-ed8e10bc1f1a" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.857536" x="12.9111843" g1="0.0" b1="5.65886E-5" g2="0.0" b2="5.65886E-5" bus1="_04483c26-c766-11e1-8775-005056c00008" connectableBus1="_04483c26-c766-11e1-8775-005056c00008" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" bus2="_044fdd40-c766-11e1-8775-005056c00008" connectableBus2="_044fdd40-c766-11e1-8775-005056c00008" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_e8ff318f-6a55-4c01-9fcf-9cfe688188ce" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_64cfd0fb-1d8e-45d2-a52f-469238dfc0c6" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.74616" x="12.3187675" g1="0.0" b1="5.211205E-5" g2="0.0" b2="5.211205E-5" bus1="_047566a8-c766-11e1-8775-005056c00008" connectableBus1="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" bus2="_047e4045-c766-11e1-8775-005056c00008" connectableBus2="_047e4045-c766-11e1-8775-005056c00008" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_cd9654e8-0619-442a-898e-2fc144b2abec" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_efe2501d-bcee-42ff-a037-3d8a280487b0" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.857536" x="9.478656" g1="0.0" b1="3.891185E-5" g2="0.0" b2="3.891185E-5" bus1="_047ba835-c766-11e1-8775-005056c00008" connectableBus1="_047ba835-c766-11e1-8775-005056c00008" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" bus2="_0479102a-c766-11e1-8775-005056c00008" connectableBus2="_0479102a-c766-11e1-8775-005056c00008" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_9c2c041c-d52f-4062-836d-c76e124232b0" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2ae204bf-78cc-49cb-b886-a933b33057e4" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.143152" x="7.074144" g1="0.0" b1="2.96717E-5" g2="0.0" b2="2.96717E-5" bus1="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus1="_0486f2d6-c766-11e1-8775-005056c00008" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" bus2="_04716f04-c766-11e1-8775-005056c00008" connectableBus2="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_340906fe-83b3-451f-8724-1708b8dc630b" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_e822432e-79af-4bba-8f40-5250468f81a0" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.433216" x="27.8783989" g1="0.0" b1="1.1650595E-4" g2="0.0" b2="1.1650595E-4" bus1="_0471bd2a-c766-11e1-8775-005056c00008" connectableBus1="_0471bd2a-c766-11e1-8775-005056c00008" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" bus2="_047566a8-c766-11e1-8775-005056c00008" connectableBus2="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_00e770fb-802e-479b-ae76-a52f5614bc15" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_c437e52c-43d7-4ae9-87ad-dc19396dc6ff" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0.0" b1="9.81405E-5" g2="0.0" b2="9.81405E-5" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_046a4314-c766-11e1-8775-005056c00008" connectableBus2="_046a4314-c766-11e1-8775-005056c00008" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_3904e93a-ed7a-4222-9cbc-575270ef2037" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_90dcdbe1-437b-443f-b0b5-c2353f7c6954" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.670321" x="31.88592" g1="0.0" b1="1.337236E-4" g2="0.0" b2="1.337236E-4" bus1="_045868c7-c766-11e1-8775-005056c00008" connectableBus1="_045868c7-c766-11e1-8775-005056c00008" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" bus2="_04577e63-c766-11e1-8775-005056c00008" connectableBus2="_04577e63-c766-11e1-8775-005056c00008" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_b9ea0da8-57a8-46d3-bfa0-dc21a2f40ee7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_9b8510fa-bd0e-4e63-8f4c-0e5443a3eb63" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.37072" g1="0.0" b1="1.4864555E-4" g2="0.0" b2="1.4864555E-4" bus1="_04675ce7-c766-11e1-8775-005056c00008" connectableBus1="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" bus2="_0453d4eb-c766-11e1-8775-005056c00008" connectableBus2="_0453d4eb-c766-11e1-8775-005056c00008" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7a4d98b5-2e0c-4af5-b1d0-c41bea482943" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_336bfd86-a922-4154-9e06-cd87382cdc5f" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.44312" x="12.5278568" g1="0.0" b1="5.130855E-5" g2="0.0" b2="5.130855E-5" bus1="_046a4314-c766-11e1-8775-005056c00008" connectableBus1="_046a4314-c766-11e1-8775-005056c00008" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" bus2="_0467f927-c766-11e1-8775-005056c00008" connectableBus2="_0467f927-c766-11e1-8775-005056c00008" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_9c6f5c6b-1c48-486d-817d-544297fbef05" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2be10dec-f0ac-470d-83f7-a2a4e70f3491" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.881792" x="5.767344" g1="0.0" b1="2.38177E-5" g2="0.0" b2="2.38177E-5" bus1="_04885267-c766-11e1-8775-005056c00008" connectableBus1="_04885267-c766-11e1-8775-005056c00008" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" bus2="_04723255-c766-11e1-8775-005056c00008" connectableBus2="_04723255-c766-11e1-8775-005056c00008" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ee57814f-f263-4a45-87db-86c93966cf99" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_f0e21213-6535-44a7-89b6-3063f8738d6b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66792" x="7.744" g1="0.0" b1="6.5909093E-4" g2="0.0" b2="6.5909093E-4" bus1="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus1="_0458ddf2-c766-11e1-8775-005056c00008" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" bus2="_044aad28-c766-11e1-8775-005056c00008" connectableBus2="_044aad28-c766-11e1-8775-005056c00008" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_be72c97f-9801-4b6e-acc0-fd79b256c7ab" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ab31cd46-6d0c-4d9c-95f1-396a45a237e1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.71952" x="50.3553619" g1="0.0" b1="2.1177685E-4" g2="0.0" b2="2.1177685E-4" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_04549837-c766-11e1-8775-005056c00008" connectableBus2="_04549837-c766-11e1-8775-005056c00008" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_c929168a-b558-48fa-aa86-314a35dd7d82" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_1bf78539-b6fa-4d8b-ba8e-9b5970019be6" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.18552" g1="0.0" b1="2.519515E-5" g2="0.0" b2="2.519515E-5" bus1="_04499bb3-c766-11e1-8775-005056c00008" connectableBus1="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" bus2="_04878f11-c766-11e1-8775-005056c00008" connectableBus2="_04878f11-c766-11e1-8775-005056c00008" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_173c0b25-4aa7-4c49-a38e-daf8ddd9b8b7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_08ff3ae4-d1dd-49f7-9eda-32ffc8eb0010" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.850291" x="2.631024" g1="0.0" b1="1.07323E-5" g2="0.0" b2="1.07323E-5" bus1="_04769f21-c766-11e1-8775-005056c00008" connectableBus1="_04769f21-c766-11e1-8775-005056c00008" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" bus2="_045b9d15-c766-11e1-8775-005056c00008" connectableBus2="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f19aeba4-5612-451d-a2d5-8f8415f42907" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_94316214-afd8-4c0d-bca4-916acb92af85" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.91664" x="8.659728" g1="0.0" b1="3.78214E-5" g2="0.0" b2="3.78214E-5" bus1="_045ef874-c766-11e1-8775-005056c00008" connectableBus1="_045ef874-c766-11e1-8775-005056c00008" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" bus2="_048b86b5-c766-11e1-8775-005056c00008" connectableBus2="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_a9ea718f-3a70-4590-bdc8-a638045c7097" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_4ea6b532-d914-4b0c-97ee-9f02a14a40b3" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.306662" x="1.390435" g1="0.0" b1="6.02615E-6" g2="0.0" b2="6.02615E-6" bus1="_04555b87-c766-11e1-8775-005056c00008" connectableBus1="_04555b87-c766-11e1-8775-005056c00008" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" bus2="_047147f0-c766-11e1-8775-005056c00008" connectableBus2="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7ecdb83b-300c-47f9-a746-141b4e88f5d1" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2a95fb2b-6661-46e7-a9f6-fe63c1b7433c" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.188592" x="14.7929754" g1="0.0" b1="6.19835E-5" g2="0.0" b2="6.19835E-5" bus1="_0474f17a-c766-11e1-8775-005056c00008" connectableBus1="_0474f17a-c766-11e1-8775-005056c00008" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" bus2="_045a1670-c766-11e1-8775-005056c00008" connectableBus2="_045a1670-c766-11e1-8775-005056c00008" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_9c62dbd2-5c0b-4651-9a3e-60685bcfdf52" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_4b67f5f5-f0e1-4bfb-9d57-4d3474720a45" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.586272" g1="0.0" b1="2.82943E-5" g2="0.0" b2="2.82943E-5" bus1="_046783f5-c766-11e1-8775-005056c00008" connectableBus1="_046783f5-c766-11e1-8775-005056c00008" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" bus2="_04876809-c766-11e1-8775-005056c00008" connectableBus2="_04876809-c766-11e1-8775-005056c00008" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_d4cfc077-4796-4a02-b938-a43c0f88d615" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_1ca40dc7-6736-4fa8-b4cb-ca696949e421" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.902976" x="15.6990232" g1="0.0" b1="6.427915E-5" g2="0.0" b2="6.427915E-5" bus1="_047c4478-c766-11e1-8775-005056c00008" connectableBus1="_047c4478-c766-11e1-8775-005056c00008" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" bus2="_04725962-c766-11e1-8775-005056c00008" connectableBus2="_04725962-c766-11e1-8775-005056c00008" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_9ba5e8b2-6a11-456a-aac4-3a733a324ddf" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ba738481-ddba-4ebe-a218-8aad0b537f5b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0.0" b1="5.01607E-5" g2="0.0" b2="5.01607E-5" bus1="_04555b87-c766-11e1-8775-005056c00008" connectableBus1="_04555b87-c766-11e1-8775-005056c00008" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" bus2="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus2="_0458b6e4-c766-11e1-8775-005056c00008" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_16d1fe69-1ba4-46ed-870c-952d884df26b" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b1d87c24-e527-4174-aa04-cd0b9de271ea" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.495392" x="14.7755518" g1="0.0" b1="6.25574E-5" g2="0.0" b2="6.25574E-5" bus1="_04502b6a-c766-11e1-8775-005056c00008" connectableBus1="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" bus2="_04667289-c766-11e1-8775-005056c00008" connectableBus2="_04667289-c766-11e1-8775-005056c00008" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_341ddbb0-3a2a-4eb9-bc29-2e0f7900c00a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_4e1daf8e-7708-4b96-8d3f-67f58f2505f9" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.45816" x="56.2795219" g1="0.0" b1="2.4678605E-4" g2="0.0" b2="2.4678605E-4" bus1="_04577e63-c766-11e1-8775-005056c00008" connectableBus1="_04577e63-c766-11e1-8775-005056c00008" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_9f7663d9-452e-4006-88ac-295dc5108fe7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_c58940cb-bd36-4dfc-9615-11716dd652a7" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.05672" x="21.25728" g1="0.0" b1="3.5583105E-4" g2="0.0" b2="3.5583105E-4" bus1="_044a8615-c766-11e1-8775-005056c00008" connectableBus1="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" bus2="_04716f04-c766-11e1-8775-005056c00008" connectableBus2="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f2cd1019-50d4-4961-a413-a74f33221b99" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3c9a454c-10ee-4c72-a059-77f723f5b7c7" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.718144" x="12.2664957" g1="0.0" b1="5.36616E-5" g2="0.0" b2="5.36616E-5" bus1="_0447ee09-c766-11e1-8775-005056c00008" connectableBus1="_0447ee09-c766-11e1-8775-005056c00008" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" bus2="_04898ae9-c766-11e1-8775-005056c00008" connectableBus2="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7452c739-95b4-4967-9703-6790355cb281" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_270a7d04-9ff9-4178-8b72-b610735a72ac" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.537072" x="10.2453117" g1="0.0" b1="4.00597E-5" g2="0.0" b2="4.00597E-5" bus1="_046a4314-c766-11e1-8775-005056c00008" connectableBus1="_046a4314-c766-11e1-8775-005056c00008" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" bus2="_048c22f1-c766-11e1-8775-005056c00008" connectableBus2="_048c22f1-c766-11e1-8775-005056c00008" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_701af727-7df8-4c87-9615-f7ade9c35e3a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_9d1eb182-ceb5-426e-9440-5f4d426a31cb" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.582512" x="21.25728" g1="0.0" b1="8.895775E-5" g2="0.0" b2="8.895775E-5" bus1="_04494d93-c766-11e1-8775-005056c00008" connectableBus1="_04494d93-c766-11e1-8775-005056c00008" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" bus2="_04549837-c766-11e1-8775-005056c00008" connectableBus2="_04549837-c766-11e1-8775-005056c00008" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7f361a6a-3949-46c7-a8dd-e212dd07dfcc" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_735ac8df-6a6a-43f0-86f2-49d3280c9a3b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.944656" x="12.3187675" g1="0.0" b1="5.7966E-5" g2="0.0" b2="5.7966E-5" bus1="_04549837-c766-11e1-8775-005056c00008" connectableBus1="_04549837-c766-11e1-8775-005056c00008" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" bus2="_04769f21-c766-11e1-8775-005056c00008" connectableBus2="_04769f21-c766-11e1-8775-005056c00008" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_83d1a365-5ebd-48e1-b477-f4bdcb1c880b" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_52aadf8d-53f2-4827-8c70-421bdf1ba822" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.188592" x="16.2740154" g1="0.0" b1="7.288795E-5" g2="0.0" b2="7.288795E-5" bus1="_04898ae9-c766-11e1-8775-005056c00008" connectableBus1="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" bus2="_04667284-c766-11e1-8775-005056c00008" connectableBus2="_04667284-c766-11e1-8775-005056c00008" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_77813798-83ae-4088-a129-0c46810ef5f1" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_fece5807-6af8-4161-8de8-8f8473d92f11" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.805814" x="31.5897121" g1="0.0" b1="1.322888E-4" g2="0.0" b2="1.322888E-4" bus1="_04597a36-c766-11e1-8775-005056c00008" connectableBus1="_04597a36-c766-11e1-8775-005056c00008" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" bus2="_04550d63-c766-11e1-8775-005056c00008" connectableBus2="_04550d63-c766-11e1-8775-005056c00008" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_07a99745-5437-4372-a0a7-3b4704c6e20c" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3eacc034-737e-41de-a7b6-b610d3bd0921" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.8315849" g1="0.0" b1="6.944445E-5" g2="0.0" b2="6.944445E-5" bus1="_045b9d15-c766-11e1-8775-005056c00008" connectableBus1="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" bus2="_0467f927-c766-11e1-8775-005056c00008" connectableBus2="_0467f927-c766-11e1-8775-005056c00008" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_5e786d5a-d8b0-4e68-8b0e-80418c4a25da" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_0d0c3ec5-798a-48a4-9bc8-d19c57128a13" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.62112" x="21.6754551" g1="0.0" b1="9.16552E-5" g2="0.0" b2="9.16552E-5" bus1="_0474071a-c766-11e1-8775-005056c00008" connectableBus1="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" bus2="_045e0e10-c766-11e1-8775-005056c00008" connectableBus2="_045e0e10-c766-11e1-8775-005056c00008" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_92371c95-ca5e-4604-96b0-3ee21aa98f9b" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_5b0395f4-534d-4975-a1af-e0b6ef439193" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.390298" x="1.777248" g1="0.0" b1="7.69055E-6" g2="0.0" b2="7.69055E-6" bus1="_045ef874-c766-11e1-8775-005056c00008" connectableBus1="_045ef874-c766-11e1-8775-005056c00008" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" bus2="_0480d858-c766-11e1-8775-005056c00008" connectableBus2="_0480d858-c766-11e1-8775-005056c00008" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7100ff8d-0038-4fea-b382-1114fdbbbb80" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_74c4b341-7b99-4a81-b88a-2ed3b0c4b1de" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0475dbd8-c766-11e1-8775-005056c00008" name="63-64" r="0.83248" x="9.679999" g1="0.0" b1="2.231405E-4" g2="0.0" b2="2.231405E-4" bus1="_047f2aa7-c766-11e1-8775-005056c00008" connectableBus1="_047f2aa7-c766-11e1-8775-005056c00008" voltageLevelId1="_04854527-c766-11e1-8775-005056c00008" bus2="_0457f395-c766-11e1-8775-005056c00008" connectableBus2="_0457f395-c766-11e1-8775-005056c00008" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_eb59d486-fc89-4f4e-9fa7-ec08a3c9cf64" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ae4eadea-f3fc-4ac6-8899-c1698ece7a89" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.27232" g1="0.0" b1="1.205234E-4" g2="0.0" b2="1.205234E-4" bus1="_048b86b5-c766-11e1-8775-005056c00008" connectableBus1="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" bus2="_045868c7-c766-11e1-8775-005056c00008" connectableBus2="_045868c7-c766-11e1-8775-005056c00008" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7c0938b3-2f8c-437c-8ed9-3d743f305160" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_e98d56fe-a54b-45e4-acff-0ac310beb3dd" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.118896" x="8.79912" g1="0.0" b1="3.609965E-5" g2="0.0" b2="3.609965E-5" bus1="_044b7072-c766-11e1-8775-005056c00008" connectableBus1="_044b7072-c766-11e1-8775-005056c00008" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_472d8096-6f57-454e-a3d8-3f306b4f4f27" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_f2e58700-2366-46e0-8408-9472d85acd23" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.7342377" g1="0.0" b1="1.632805E-4" g2="0.0" b2="1.632805E-4" bus1="_045b9d15-c766-11e1-8775-005056c00008" connectableBus1="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_3b9aa0d5-4cdd-4527-91e2-89d797598afe" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_89654167-95a6-4c76-aad7-63a881116e17" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.101472" x="10.10592" g1="0.0" b1="1.7332415E-4" g2="0.0" b2="1.7332415E-4" bus1="_045c8773-c766-11e1-8775-005056c00008" connectableBus1="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" bus2="_0468bc75-c766-11e1-8775-005056c00008" connectableBus2="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_45d8a8d9-59e4-412f-8e4e-ac26b87c52b6" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_216c0f3b-03e8-4b7d-96fc-a5f891331f7f" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.0126553" g1="0.0" b1="7.11662E-5" g2="0.0" b2="7.11662E-5" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_04862f81-c766-11e1-8775-005056c00008" connectableBus2="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_1451f44e-543d-4c6f-b201-d7a52943238a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_32655e4f-e7da-46b0-a908-b601224ddb73" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.9012814" g1="0.0" b1="7.05923E-5" g2="0.0" b2="7.05923E-5" bus1="_045a1670-c766-11e1-8775-005056c00008" connectableBus1="_045a1670-c766-11e1-8775-005056c00008" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" bus2="_0461b794-c766-11e1-8775-005056c00008" connectableBus2="_0461b794-c766-11e1-8775-005056c00008" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_a4ca519a-5dee-49fc-9d34-d25e4d3e0430" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_bafaeace-e459-4dc2-87a0-467a9ea25f8d" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+</iidm:network>

--- a/dynaflow/src/test/resources/SmallBusBranch/dynaflow-outputs/BaseCase-outputIIDM.xml
+++ b/dynaflow/src/test/resources/SmallBusBranch/dynaflow-outputs/BaseCase-outputIIDM.xml
@@ -1,0 +1,2405 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_4" id="urn:uuid:2399cbd2-9a39-11e0-aa80-0800200c9a66_EU" caseDate="2030-01-02T09:00:00+00:00" forecastDistance="7993438" sourceFormat="CGMES">
+    <iidm:property name="CGMESModelDetail" value="bus-branch"/>
+    <iidm:substation id="_047c929a-c766-11e1-8775-005056c00008" name="Godrics Hollow" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0460f448-c766-11e1-8775-005056c00008" name="GOD132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045a1670-c766-11e1-8775-005056c00008" name="Jay" v="118.30145762004793" angle="-30.746486151099884"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" bus="_045a1670-c766-11e1-8775-005056c00008" connectableBus="_045a1670-c766-11e1-8775-005056c00008" p="13.720020311707575" q="7.7351341740133144"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04819ba1-c766-11e1-8775-005056c00008" name="Nurmengard" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0476c639-c766-11e1-8775-005056c00008" name="NUR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04483c26-c766-11e1-8775-005056c00008" name="Madison" v="123.43772142073045" angle="-28.373365945554838"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" bus="_04483c26-c766-11e1-8775-005056c00008" connectableBus="_04483c26-c766-11e1-8775-005056c00008" p="61.296872113846653" q="12.755213313015295"/>
+            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" bus="_04483c26-c766-11e1-8775-005056c00008" connectableBus="_04483c26-c766-11e1-8775-005056c00008" p="8.897933048784191" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04542302-c766-11e1-8775-005056c00008" name="Gringotts" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0450eeb4-c766-11e1-8775-005056c00008" name="GRI132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04549837-c766-11e1-8775-005056c00008" name="Torrey" v="126.05999999097978" angle="-11.805458501341919"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" bus="_04549837-c766-11e1-8775-005056c00008" connectableBus="_04549837-c766-11e1-8775-005056c00008" p="-55.656160666103659" q="-2.4731691851366731">
+                <iidm:property name="CGMES.GeneratingUnit" value="_b97aee41-3115-4cfd-9071-b52fb44d0b66"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_5005c073-28d1-4a7d-b257-649dec43ec73"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-30" maxQ="85"/>
+            </iidm:generator>
+            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" bus="_04549837-c766-11e1-8775-005056c00008" connectableBus="_04549837-c766-11e1-8775-005056c00008" p="112.9999999878714" q="31.999999994275598"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045de701-c766-11e1-8775-005056c00008" name="Needlehole" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04808a33-c766-11e1-8775-005056c00008" name="NEE132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047ba835-c766-11e1-8775-005056c00008" name="Darrah" v="122.21832674576288" angle="-3.1599323844681924"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" bus="_047ba835-c766-11e1-8775-005056c00008" connectableBus="_047ba835-c766-11e1-8775-005056c00008" p="67.78755496918653" q="35.812743781525086"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0472f5a8-c766-11e1-8775-005056c00008" name="Dale" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0467d214-c766-11e1-8775-005056c00008" name="DAL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04845ac5-c766-11e1-8775-005056c00008" name="Smythe" v="130.42712167891273" angle="14.306106160667138"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" bus="_04845ac5-c766-11e1-8775-005056c00008" connectableBus="_04845ac5-c766-11e1-8775-005056c00008" p="4.9974792828333383" q="2.9974797064580732"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047a48a3-c766-11e1-8775-005056c00008" name="Hogsmeade" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047e675c-c766-11e1-8775-005056c00008" name="HOG132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045b9d15-c766-11e1-8775-005056c00008" name="Sunnysde" v="125.91886212720208" angle="-11.911952649422306"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" bus="_045b9d15-c766-11e1-8775-005056c00008" connectableBus="_045b9d15-c766-11e1-8775-005056c00008" p="84.000716474219985" q="18.000255884377513"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046f4c23-c766-11e1-8775-005056c00008" name="Barad-dûr" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047dcb11-c766-11e1-8775-005056c00008" name="BAR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0486f2d6-c766-11e1-8775-005056c00008" name="Bellefnt" v="124.17698602526663" angle="-5.0340583540630544"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" bus="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus="_0486f2d6-c766-11e1-8775-005056c00008" p="67.695650246134122" q="26.798892706912376"/>
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" bus="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus="_0486f2d6-c766-11e1-8775-005056c00008" q="-10.624327538381971">
+                <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
+                <iidm:shuntLinearModel bPerSection="0.00013779999999999999" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047a6fb6-c766-11e1-8775-005056c00008" name="Waymoot" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04740714-c766-11e1-8775-005056c00008" name="WAY132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04550d63-c766-11e1-8775-005056c00008" name="Fieldale" v="126.0673267002731" angle="0.17046024494173798"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" bus="_04550d63-c766-11e1-8775-005056c00008" connectableBus="_04550d63-c766-11e1-8775-005056c00008" p="39.00094621286123" q="30.00121310322244"/>
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" bus="_04550d63-c766-11e1-8775-005056c00008" connectableBus="_04550d63-c766-11e1-8775-005056c00008" q="-5.467181976305568">
+                <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
+                <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0488eea9-c766-11e1-8775-005056c00008" name="Upbourn" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047147f4-c766-11e1-8775-005056c00008" name="UPB132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04862f81-c766-11e1-8775-005056c00008" name="Muskngum1" v="138.59999110383939" angle="-0.062107048686664883"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_047f0391-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="392" targetV="138.59999099999999" targetQ="0" bus="_04862f81-c766-11e1-8775-005056c00008" connectableBus="_04862f81-c766-11e1-8775-005056c00008" p="-400" q="1.431725274864182">
+                <iidm:property name="CGMES.GeneratingUnit" value="_d9948603-709f-41dd-a0ff-2ebda091255a"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_23727856-fd9b-4124-a981-4e862148f3bb"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
+            </iidm:generator>
+            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" bus="_04862f81-c766-11e1-8775-005056c00008" connectableBus="_04862f81-c766-11e1-8775-005056c00008" p="39.000000043828337" q="18.000000033714102"/>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_0463da78-c766-11e1-8775-005056c00008" name="UPB220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0458ddf2-c766-11e1-8775-005056c00008" name="Muskngum2" v="221.09999999999997" angle="0"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" bus="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus="_0458ddf2-c766-11e1-8775-005056c00008" p="-400" q="-243.23283841624291">
+                <iidm:property name="CGMES.GeneratingUnit" value="_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_12b01822-ca11-4cf8-a6b4-2f8ff805ca20"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus1="_0458ddf2-c766-11e1-8775-005056c00008" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" bus2="_04862f81-c766-11e1-8775-005056c00008" connectableBus2="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="3.3064363949437028" q1="72.239714989776587" p2="-3.3064363949437028" q2="-70.564950544590772">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0695187165775399"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.93896713615023475"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.88495575221238942"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.83682008368200833"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.79365079365079361"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.75471698113207553"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.71942446043165464"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.6872852233676976"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.65789473684210531"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.63091482649842268"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.60606060606060608"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.58309037900874627"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_069c77f0-1cf0-491a-ae17-8f71e0c7cc0b" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_a7b7f7b8-4ee3-45f5-ba3e-edb3678e0866" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_85b581c6-1005-4dc0-a758-ad5cfa9b05c4" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_981fee8c-aaa5-4946-b2d2-292bb3a4e7df" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_04773b6b-c766-11e1-8775-005056c00008" name="Fornost Erain" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046b2d70-c766-11e1-8775-005056c00008" name="FOR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0474f17a-c766-11e1-8775-005056c00008" name="Adams" v="116.94898008469335" angle="-33.564345582107848"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" bus="_0474f17a-c766-11e1-8775-005056c00008" connectableBus="_0474f17a-c766-11e1-8775-005056c00008" p="17.59192243561019" q="2.8875039172186883"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04887979-c766-11e1-8775-005056c00008" name="The Wall" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0475b4c0-c766-11e1-8775-005056c00008" name="THE132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04597a36-c766-11e1-8775-005056c00008" name="Claytor" v="133.32004975772765" angle="5.9614896241749245"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" bus="_04597a36-c766-11e1-8775-005056c00008" connectableBus="_04597a36-c766-11e1-8775-005056c00008" p="-55.31232133220734" q="-79.342679747699734">
+                <iidm:property name="CGMES.GeneratingUnit" value="_e56da2eb-bb6a-4133-953c-40073c5bc5f4"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_d41be6b4-155e-4c8f-b46b-16b50c49f0f4"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
+            </iidm:generator>
+            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" bus="_04597a36-c766-11e1-8775-005056c00008" connectableBus="_04597a36-c766-11e1-8775-005056c00008" p="23.000014946309175" q="16.000017329057869"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04795e41-c766-11e1-8775-005056c00008" name="Havens of the Falas" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045d23b4-c766-11e1-8775-005056c00008" name="HAV132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04725962-c766-11e1-8775-005056c00008" name="N.Newark" v="127.49967560547208" angle="-14.039180111220286"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" bus="_04725962-c766-11e1-8775-005056c00008" connectableBus="_04725962-c766-11e1-8775-005056c00008" p="52.693791858533892" q="21.788566125406678"/>
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" bus="_04725962-c766-11e1-8775-005056c00008" connectableBus="_04725962-c766-11e1-8775-005056c00008" q="-9.3310400184333488">
+                <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
+                <iidm:shuntLinearModel bPerSection="0.0001148" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047e404a-c766-11e1-8775-005056c00008" name="Minas Anor" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048433b5-c766-11e1-8775-005056c00008" name="MNA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0472a783-c766-11e1-8775-005056c00008" name="Hillsbro" v="127.33540672378433" angle="-12.959778949048681"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" bus="_0472a783-c766-11e1-8775-005056c00008" connectableBus="_0472a783-c766-11e1-8775-005056c00008" p="11.901191261615093" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0449c2ca-c766-11e1-8775-005056c00008" name="Avallonë" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045e8349-c766-11e1-8775-005056c00008" name="AVA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046bf0cb-c766-11e1-8775-005056c00008" name="S.Kenton" v="120.38905819071212" angle="-25.88458233028663"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" bus="_046bf0cb-c766-11e1-8775-005056c00008" connectableBus="_046bf0cb-c766-11e1-8775-005056c00008" p="17.627927590741074" q="6.7605074341963114"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0468bc71-c766-11e1-8775-005056c00008" name="Vale of Arryn" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0484f70a-c766-11e1-8775-005056c00008" name="VLA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04689561-c766-11e1-8775-005056c00008" name="Hazard" v="129.4088057509008" angle="13.007507286858162"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" bus="_04689561-c766-11e1-8775-005056c00008" connectableBus="_04689561-c766-11e1-8775-005056c00008" p="20.992082630591259" q="9.9937171631974575"/>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_04555b88-c766-11e1-8775-005056c00008" name="VALE33KV" nominalV="33" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04505279-c766-11e1-8775-005056c00008" name="Pinevlle" v="33.495016271378702" angle="13.683213901202148"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_047fc6e6-c766-11e1-8775-005056c00008" name="Pinevlle SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="4" targetV="33.494999999999997" targetQ="0" bus="_04505279-c766-11e1-8775-005056c00008" connectableBus="_04505279-c766-11e1-8775-005056c00008" p="-7.8280803330518332" q="-15.913965523388629">
+                <iidm:property name="CGMES.GeneratingUnit" value="_9a6bdb3c-346d-4426-8127-5f6cbf0150b2"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_98f667da-02d1-4a31-b826-44314a1fbbfe"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" bus1="_04689561-c766-11e1-8775-005056c00008" connectableBus1="_04689561-c766-11e1-8775-005056c00008" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" bus2="_04505279-c766-11e1-8775-005056c00008" connectableBus2="_04505279-c766-11e1-8775-005056c00008" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="-7.7417410768738817" q1="-11.00379456206873" p2="7.8280816836905052" q2="15.914005920224991">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="31" loadTapChangingCapabilities="false">
+                <iidm:step r="-78.460970487743992" x="-78.460970487743992" g="364.27347129590328" b="364.27347129590328" rho="0.4641016"/>
+                <iidm:step r="-76.770985444658564" x="-76.770985444658564" g="330.49609255595948" b="330.49609255595948" rho="0.48196488000000004"/>
+                <iidm:step r="-75.017181047101431" x="-75.017181047101431" g="300.27508580410921" b="300.27508580410921" rho="0.49982816000000002"/>
+                <iidm:step r="-73.199557295072623" x="-73.199557295072623" g="273.1281647135425" b="273.1281647135425" rho="0.51769144000000011"/>
+                <iidm:step r="-71.318114188572153" x="-71.318114188572153" g="248.65210975826625" b="248.65210975826625" rho="0.53555472000000004"/>
+                <iidm:step r="-69.372851727600008" x="-69.372851727600008" g="226.50770848984379" b="226.50770848984379" rho="0.55341799999999997"/>
+                <iidm:step r="-67.363769912156158" x="-67.363769912156158" g="206.40793906293555" b="206.40793906293555" rho="0.57128128"/>
+                <iidm:step r="-65.290868742240633" x="-65.290868742240633" g="188.10862264852744" b="188.10862264852744" rho="0.58914456000000004"/>
+                <iidm:step r="-63.154148217853432" x="-63.154148217853432" g="171.40097232995538" b="171.40097232995538" rho="0.60700784000000008"/>
+                <iidm:step r="-60.953608338994556" x="-60.953608338994556" g="156.10561116167679" b="156.10561116167679" rho="0.62487112"/>
+                <iidm:step r="-58.689249105663997" x="-58.689249105663997" g="142.06773741726079" b="142.06773741726079" rho="0.64273440000000004"/>
+                <iidm:step r="-56.361070517861769" x="-56.361070517861769" g="129.15319231405709" b="129.15319231405709" rho="0.66059767999999996"/>
+                <iidm:step r="-53.969072575587838" x="-53.969072575587838" g="117.24524269951107" b="117.24524269951107" rho="0.67846096"/>
+                <iidm:step r="-51.51325527884223" x="-51.51325527884223" g="106.24193390397649" b="106.24193390397649" rho="0.69632424000000004"/>
+                <iidm:step r="-48.993618627624947" x="-48.993618627624947" g="96.053900138385018" b="96.053900138385018" rho="0.71418752000000008"/>
+                <iidm:step r="-46.410162621936003" x="-46.410162621936003" g="86.602544237115268" b="86.602544237115268" rho="0.7320508"/>
+                <iidm:step r="-43.762887261775354" x="-43.762887261775354" g="77.81851722275475" b="77.81851722275475" rho="0.74991407999999993"/>
+                <iidm:step r="-41.051792547143037" x="-41.051792547143037" g="69.640442552852292" b="69.640442552852292" rho="0.76777735999999996"/>
+                <iidm:step r="-38.276878478039045" x="-38.276878478039045" g="62.013841060226049" b="62.013841060226049" rho="0.78564064"/>
+                <iidm:step r="-35.438145054463355" x="-35.438145054463355" g="54.890221299184191" b="54.890221299184191" rho="0.80350392000000004"/>
+                <iidm:step r="-32.53559227641599" x="-32.53559227641599" g="48.2263068397802" b="48.2263068397802" rho="0.82136720000000008"/>
+                <iidm:step r="-29.569220143896956" x="-29.569220143896956" g="41.983377444222199" b="41.983377444222199" rho="0.83923048"/>
+                <iidm:step r="-26.53902865690624" x="-26.53902865690624" g="36.126705339843348" b="36.126705339843348" rho="0.85709376000000004"/>
+                <iidm:step r="-23.445017815443848" x="-23.445017815443848" g="30.625071218648301" b="30.625071218648301" rho="0.87495704000000007"/>
+                <iidm:step r="-20.287187619509762" x="-20.287187619509762" g="25.450347332714429" b="25.450347332714429" rho="0.89282032000000011"/>
+                <iidm:step r="-17.06553806910399" x="-17.06553806910399" g="20.577137262099331" b="20.577137262099331" rho="0.91068360000000004"/>
+                <iidm:step r="-13.780069164226571" x="-13.780069164226571" g="15.982463718828566" b="15.982463718828566" rho="0.92854687999999996"/>
+                <iidm:step r="-10.430780904877434" x="-10.430780904877434" g="11.645497203453271" b="11.645497203453271" rho="0.94641016"/>
+                <iidm:step r="-7.0176732910566368" x="-7.0176732910566368" g="7.5473195169912355" b="7.5473195169912355" rho="0.96427344000000004"/>
+                <iidm:step r="-3.5407463227641656" x="-3.5407463227641656" g="3.6707171036300279" b="3.6707171036300279" rho="0.98213671999999985"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="3.6045656772358381" x="3.6045656772358381" g="-3.4791571719583358" b="-3.4791571719583358" rho="1.01786328"/>
+                <iidm:step r="7.272950708943382" x="7.272950708943382" g="-6.7798551833225922" b="-6.7798551833225922" rho="1.0357265600000001"/>
+                <iidm:step r="11.005155095122543" x="11.005155095122543" g="-9.9140937064517427" b="-9.9140937064517427" rho="1.0535898399999999"/>
+                <iidm:step r="14.801178835773431" x="14.801178835773431" g="-12.892880531259154" b="-12.892880531259154" rho="1.0714531199999999"/>
+                <iidm:step r="18.661021930895984" x="18.661021930895984" g="-15.726328348801433" b="-15.726328348801433" rho="1.0893164"/>
+                <iidm:step r="22.584684380490238" x="22.584684380490238" g="-18.423740693731116" b="-18.423740693731116" rho="1.10717968"/>
+                <iidm:step r="26.572166184556178" x="26.572166184556178" g="-20.993688411566747" b="-20.993688411566747" rho="1.12504296"/>
+                <iidm:step r="30.623467343093779" x="30.623467343093779" g="-23.444077826121855" b="-23.444077826121855" rho="1.1429062400000001"/>
+                <iidm:step r="34.738587856103067" x="34.738587856103067" g="-25.782211620922489" b="-25.782211620922489" rho="1.1607695200000001"/>
+                <iidm:step r="38.917527723583987" x="38.917527723583987" g="-28.014843311220961" b="-28.014843311220961" rho="1.1786327999999999"/>
+                <iidm:step r="43.16028694553664" x="43.16028694553664" g="-30.148226066322692" b="-30.148226066322692" rho="1.19649608"/>
+                <iidm:step r="47.466865521960955" x="47.466865521960955" g="-32.188156542116317" b="-32.188156542116317" rho="1.21435936"/>
+                <iidm:step r="51.837263452856973" x="51.837263452856973" g="-34.140014298236885" b="-34.140014298236885" rho="1.23222264"/>
+                <iidm:step r="56.271480738224653" x="56.271480738224653" g="-36.0087973009527" b="-36.0087973009527" rho="1.2500859200000001"/>
+                <iidm:step r="60.769517378063973" x="60.769517378063973" g="-37.799153949786998" b="-37.799153949786998" rho="1.2679491999999999"/>
+                <iidm:step r="65.331373372375026" x="65.331373372375026" g="-39.515412011505823" b="-39.515412011505823" rho="1.2858124799999999"/>
+                <iidm:step r="69.957048721157761" x="69.957048721157761" g="-41.161604798123854" b="-41.161604798123854" rho="1.30367576"/>
+                <iidm:step r="74.646543424412172" x="74.646543424412172" g="-42.741494884907091" b="-42.741494884907091" rho="1.32153904"/>
+                <iidm:step r="79.399857482138245" x="79.399857482138245" g="-44.258595629064871" b="-44.258595629064871" rho="1.33940232"/>
+                <iidm:step r="84.216990894335964" x="84.216990894335964" g="-45.716190719151165" b="-45.716190719151165" rho="1.3572655999999998"/>
+                <iidm:step r="89.097943661005473" x="89.097943661005473" g="-47.11735195848069" b="-47.11735195848069" rho="1.3751288800000001"/>
+                <iidm:step r="94.04271578214653" x="94.04271578214653" g="-48.464955462553469" b="-48.464955462553469" rho="1.3929921599999999"/>
+                <iidm:step r="99.051307257759348" x="99.051307257759348" g="-49.761696430103783" b="-49.761696430103783" rho="1.41085544"/>
+                <iidm:step r="104.12371808784383" x="104.12371808784383" g="-51.010102629540867" b="-51.010102629540867" rho="1.42871872"/>
+                <iidm:step r="109.25994827240002" x="109.25994827240002" g="-52.212546726893493" b="-52.212546726893493" rho="1.446582"/>
+                <iidm:step r="114.45999781142788" x="114.45999781142788" g="-53.371257567609966" b="-53.371257567609966" rho="1.4644452800000001"/>
+                <iidm:step r="119.72386670492732" x="119.72386670492732" g="-54.488330512455207" b="-54.488330512455207" rho="1.4823085599999999"/>
+                <iidm:step r="125.05155495289854" x="125.05155495289854" g="-55.565736917068101" b="-55.565736917068101" rho="1.5001718399999999"/>
+                <iidm:step r="130.44306255534144" x="130.44306255534144" g="-56.605332835313817" b="-56.605332835313817" rho="1.51803512"/>
+                <iidm:step r="135.89838951225599" x="135.89838951225599" g="-57.608867018227542" b="-57.608867018227542" rho="1.5358984"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="2186">
+                <iidm:temporaryLimit name="_580d3b53-5508-4d8d-97cc-4ea463e0cdb9" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_a867e68a-58d1-49cb-955f-bb8e59cf2a11" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="8747">
+                <iidm:temporaryLimit name="_1a7f23f9-e2c0-46a6-a93c-687f2209e33d" acceptableDuration="900" value="10059"/>
+                <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_045beb3a-c766-11e1-8775-005056c00008" name="Minas Tirith" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048a9c58-c766-11e1-8775-005056c00008" name="MNT132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04555b87-c766-11e1-8775-005056c00008" name="NwCarlsl" v="120.64461540742927" angle="-41.672891820764548"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" bus="_04555b87-c766-11e1-8775-005056c00008" connectableBus="_04555b87-c766-11e1-8775-005056c00008" p="8.7431639798362415" q="0"/>
+            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" bus="_04555b87-c766-11e1-8775-005056c00008" connectableBus="_04555b87-c766-11e1-8775-005056c00008" p="29.14387993278747" q="11.434699866287563"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047120e4-c766-11e1-8775-005056c00008" name="Bywater" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046c65f4-c766-11e1-8775-005056c00008" name="BYW132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046b7b91-c766-11e1-8775-005056c00008" name="Blaine" v="126.62288508481438" angle="1.1598441096321184"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" bus="_046b7b91-c766-11e1-8775-005056c00008" connectableBus="_046b7b91-c766-11e1-8775-005056c00008" p="2.0000584151344225" q="1.0000486797526185"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0467f928-c766-11e1-8775-005056c00008" name="Tirion" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048bd4da-c766-11e1-8775-005056c00008" name="TIR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04667284-c766-11e1-8775-005056c00008" name="Sundial" v="133.15602032009772" angle="6.0268997948669973"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" bus="_04667284-c766-11e1-8775-005056c00008" connectableBus="_04667284-c766-11e1-8775-005056c00008" p="14.991859781326934" q="8.9918612539304075"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_048badc8-c766-11e1-8775-005056c00008" name="White Harbor" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0488c79a-c766-11e1-8775-005056c00008" name="WHI132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044a8618-c766-11e1-8775-005056c00008" name="Riversde" v="116.3325961150622" angle="-45.766037163303693"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" bus="_044a8618-c766-11e1-8775-005056c00008" connectableBus="_044a8618-c766-11e1-8775-005056c00008" p="49.604124917713207" q="25.77961683935624"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045e8345-c766-11e1-8775-005056c00008" name="Nobottle" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04773b6a-c766-11e1-8775-005056c00008" name="NOB132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0461b794-c766-11e1-8775-005056c00008" name="Randolph" v="121.55701682279955" angle="-26.808605298018019"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" bus="_0461b794-c766-11e1-8775-005056c00008" connectableBus="_0461b794-c766-11e1-8775-005056c00008" p="9.8405142219602322" q="4.8678029913150276"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0452c37a-c766-11e1-8775-005056c00008" name="Formenos" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0478c204-c766-11e1-8775-005056c00008" name="FRM132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0467f927-c766-11e1-8775-005056c00008" name="WNwPhil2" v="126.62468847651847" angle="-11.767904275891198"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" bus="_0467f927-c766-11e1-8775-005056c00008" connectableBus="_0467f927-c766-11e1-8775-005056c00008" p="12.000905477529383" q="3.0003772917932916"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046b0666-c766-11e1-8775-005056c00008" name="Vinyamar" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04479fe8-c766-11e1-8775-005056c00008" name="VIN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044ef2e3-c766-11e1-8775-005056c00008" name="Cloverdl" v="126.73775031166031" angle="1.8383393744228973"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" bus="_044ef2e3-c766-11e1-8775-005056c00008" connectableBus="_044ef2e3-c766-11e1-8775-005056c00008" p="43.001744618921158" q="16.001081948846874"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046dec9b-c766-11e1-8775-005056c00008" name="Aldburg" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0483977a-c766-11e1-8775-005056c00008" name="ALD132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046783f5-c766-11e1-8775-005056c00008" name="Hancock" v="128.11677456607453" angle="3.2320761364356607"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" bus="_046783f5-c766-11e1-8775-005056c00008" connectableBus="_046783f5-c766-11e1-8775-005056c00008" p="38.000629740432998" q="25.000690508675106"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04865696-c766-11e1-8775-005056c00008" name="Scary" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04544a15-c766-11e1-8775-005056c00008" name="SCA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047c4478-c766-11e1-8775-005056c00008" name="WMVernon" v="125.14944992869599" angle="-17.796734020538906"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" bus="_047c4478-c766-11e1-8775-005056c00008" connectableBus="_047c4478-c766-11e1-8775-005056c00008" p="15.829183222571675" q="7.8581598574804286"/>
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" bus="_047c4478-c766-11e1-8775-005056c00008" connectableBus="_047c4478-c766-11e1-8775-005056c00008" q="-8.9902088852192783">
+                <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
+                <iidm:shuntLinearModel bPerSection="0.0001148" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046030f9-c766-11e1-8775-005056c00008" name="Winterfell" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044f4102-c766-11e1-8775-005056c00008" name="WIN220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047ba832-c766-11e1-8775-005056c00008" name="Breed" v="0" angle="0"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" connectableBus="_047ba832-c766-11e1-8775-005056c00008" p="-0" q="-0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_f26d4eb3-ebdb-4025-8080-f856ce656b42"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_7566f2a7-61eb-42fe-a59a-8276257fdbc6"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-225" maxQ="640"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04703680-c766-11e1-8775-005056c00008" name="Brithombar" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04542300-c766-11e1-8775-005056c00008" name="BRI132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046a4314-c766-11e1-8775-005056c00008" name="Newcmrst" v="127.68409283878752" angle="-11.146049914441642"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" bus="_046a4314-c766-11e1-8775-005056c00008" connectableBus="_046a4314-c766-11e1-8775-005056c00008" p="17.001936787464288" q="8.0015191066786144"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0480b149-c766-11e1-8775-005056c00008" name="Nindamos" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04728079-c766-11e1-8775-005056c00008" name="NIN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04689567-c766-11e1-8775-005056c00008" name="TannrsCk1" v="138.60043930079925" angle="-14.066603055590564"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" bus="_04689567-c766-11e1-8775-005056c00008" connectableBus="_04689567-c766-11e1-8775-005056c00008" p="-258.28080333051832" q="-98.652962580927976">
+                <iidm:property name="CGMES.GeneratingUnit" value="_56975783-9739-40fc-8ec1-e1de8cb06c9a"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_b8449cd9-5a17-497e-bf04-70f728b0f9f2"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_044f8f2a-c766-11e1-8775-005056c00008" name="NIN220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0455a9a6-c766-11e1-8775-005056c00008" name="TannrsCk2" v="223.30072214677159" angle="-13.121152447719799"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" bus="_0455a9a6-c766-11e1-8775-005056c00008" connectableBus="_0455a9a6-c766-11e1-8775-005056c00008" p="-352.28080333051832" q="-119.51655770599365">
+                <iidm:property name="CGMES.GeneratingUnit" value="_05df66ba-3f64-40cb-8b18-c66d26c4e2c1"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_c1d29442-5f57-41d1-bb60-4b74b4994c20"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_0455a9a6-c766-11e1-8775-005056c00008" connectableBus1="_0455a9a6-c766-11e1-8775-005056c00008" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" bus2="_04689567-c766-11e1-8775-005056c00008" connectableBus2="_04689567-c766-11e1-8775-005056c00008" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="47.953470025433177" q1="20.577757198067314" p2="-47.953470025433219" q2="-19.647259571234976">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0416666883680561"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.96153844304733771"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.92592589163237438"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.8928570950255128"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_ac81f7ca-04be-4b10-838b-fd5171e1b0f7" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_2a113652-9eee-4aa3-8fc5-b6ebccfafda5" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_f357d7c9-5bbd-4c6b-960a-7384577353db" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_42b6b196-1272-48c6-a627-914c00e3fe3e" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_04553470-c766-11e1-8775-005056c00008" name="Haysend" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0471bd23-c766-11e1-8775-005056c00008" name="HAY132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044a8615-c766-11e1-8775-005056c00008" name="Sporn1" v="136.62000097283911" angle="4.3997009125794353"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" bus="_044a8615-c766-11e1-8775-005056c00008" connectableBus="_044a8615-c766-11e1-8775-005056c00008" p="-589.99904566103669" q="23.495730835143512">
+                <iidm:property name="CGMES.GeneratingUnit" value="_27799004-aa1e-4889-ba95-ee6fdae64895"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_827a9c80-183d-4e33-9e73-ef0aab3dfb13"/>
+                <iidm:property name="CGMES.normalPF" value="1.0"/>
+                <iidm:minMaxReactiveLimits minQ="-300" maxQ="850"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_0449e9d2-c766-11e1-8775-005056c00008" name="HAY220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044aad28-c766-11e1-8775-005056c00008" name="Sporn2" v="219.70202048147218" angle="1.2605310004836221"/>
+            </iidm:busBreakerTopology>
+            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" bus="_044aad28-c766-11e1-8775-005056c00008" connectableBus="_044aad28-c766-11e1-8775-005056c00008" p="184.11557642237312" q="-14.978910475168284">
+                <iidm:currentLimits permanentLimit="1000">
+                    <iidm:temporaryLimit name="_7c27ab8a-8043-4a55-851d-72adb14d9f4d" acceptableDuration="900" value="1150"/>
+                    <iidm:temporaryLimit name="_f4458b8d-a0e1-4adc-977f-14a07b3c44e9" acceptableDuration="60" value="1400"/>
+                </iidm:currentLimits>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_044aad28-c766-11e1-8775-005056c00008" connectableBus1="_044aad28-c766-11e1-8775-005056c00008" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" bus2="_044a8615-c766-11e1-8775-005056c00008" connectableBus2="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-163.61129351120925" q1="99.945813007703805" p2="163.61129351120923" q2="-88.023734893706646">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0695187165775399"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.93896713615023475"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.88495575221238942"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.83682008368200833"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.79365079365079361"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.75471698113207553"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_836577b9-5365-40b9-8bb1-0c635896faab" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_4ff8ded8-043c-467c-9730-a5f583b4631d" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_10213be6-3bb3-4f54-9d8e-67a412744ad4" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_5e63ebf0-b379-4249-91a8-f8f8c88302e7" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_046fe861-c766-11e1-8775-005056c00008" name="Bree" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046bf0c5-c766-11e1-8775-005056c00008" name="BRE132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044b9787-c766-11e1-8775-005056c00008" name="Natrium" v="131.71670991588493" angle="-3.5628277966896738"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" bus="_044b9787-c766-11e1-8775-005056c00008" connectableBus="_044b9787-c766-11e1-8775-005056c00008" p="77.001814246515394" q="14.000549775989166"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047fedfa-c766-11e1-8775-005056c00008" name="Mithlond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0485e169-c766-11e1-8775-005056c00008" name="MIT132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0480d858-c766-11e1-8775-005056c00008" name="Sterling" v="119.10583595802541" angle="-30.155705898042427"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" bus="_0480d858-c766-11e1-8775-005056c00008" connectableBus="_0480d858-c766-11e1-8775-005056c00008" p="30.224933452115149" q="16.297526174006368"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0460f447-c766-11e1-8775-005056c00008" name="Pincup" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045ed163-c766-11e1-8775-005056c00008" name="PIN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045c8773-c766-11e1-8775-005056c00008" name="Switchbk" v="130.22751554565562" angle="9.2424915157552761"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" bus="_045c8773-c766-11e1-8775-005056c00008" connectableBus="_045c8773-c766-11e1-8775-005056c00008" p="29.97518504806898" q="15.977948347305269"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0471e439-c766-11e1-8775-005056c00008" name="Casterly Rock" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04773b62-c766-11e1-8775-005056c00008" name="CAS132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044b7076-c766-11e1-8775-005056c00008" name="Bradley" v="135.05545183049122" angle="6.0217563506441429"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" bus="_044b7076-c766-11e1-8775-005056c00008" connectableBus="_044b7076-c766-11e1-8775-005056c00008" p="33.996957082739954" q="7.9988067347132361"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047cb9a6-c766-11e1-8775-005056c00008" name="Lannisport" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04819ba0-c766-11e1-8775-005056c00008" name="LAN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046c8d0b-c766-11e1-8775-005056c00008" name="Mullin" v="122.02806850808196" angle="-30.718346624822463"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" bus="_046c8d0b-c766-11e1-8775-005056c00008" connectableBus="_046c8d0b-c766-11e1-8775-005056c00008" p="16.782803130241625" q="6.851579026613555"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0449c2c6-c766-11e1-8775-005056c00008" name="Armenelos" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04765109-c766-11e1-8775-005056c00008" name="ARM132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0468bc75-c766-11e1-8775-005056c00008" name="Glen Lyn" v="134.24403976310981" angle="9.2226919406593897"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" bus="_0468bc75-c766-11e1-8775-005056c00008" connectableBus="_0468bc75-c766-11e1-8775-005056c00008" p="-290.28080333051832" q="-82.906117998043413">
+                <iidm:property name="CGMES.GeneratingUnit" value="_e54b499b-436c-4b89-9803-b1d75e2fa364"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
+            </iidm:generator>
+            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" bus="_0468bc75-c766-11e1-8775-005056c00008" connectableBus="_0468bc75-c766-11e1-8775-005056c00008" p="37.00002140023485" q="18.000017351545111"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0474f171-c766-11e1-8775-005056c00008" name="Erebor" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044f6818-c766-11e1-8775-005056c00008" name="ERB132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046b066a-c766-11e1-8775-005056c00008" name="Kankakee" v="119.98185209490779" angle="-43.337042068461699"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" bus="_046b066a-c766-11e1-8775-005056c00008" connectableBus="_046b066a-c766-11e1-8775-005056c00008" p="50.630220429596896" q="21.04263579044806"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045fe2d2-c766-11e1-8775-005056c00008" name="Ollivanders" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0465611a-c766-11e1-8775-005056c00008" name="OLL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04876809-c766-11e1-8775-005056c00008" name="Roanoke" v="127.42168981211185" angle="2.1376899617685439"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" bus="_04876809-c766-11e1-8775-005056c00008" connectableBus="_04876809-c766-11e1-8775-005056c00008" p="31.000426846514429" q="26.00059666990926"/>
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" bus="_04876809-c766-11e1-8775-005056c00008" connectableBus="_04876809-c766-11e1-8775-005056c00008" q="-18.639257515691014">
+                <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
+                <iidm:shuntLinearModel bPerSection="0.0002296" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046cdb28-c766-11e1-8775-005056c00008" name="Pelargir" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048719e8-c766-11e1-8775-005056c00008" name="PEL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04577e63-c766-11e1-8775-005056c00008" name="Howard" v="116.12017066175056" angle="-25.238095292159159"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" bus="_04577e63-c766-11e1-8775-005056c00008" connectableBus="_04577e63-c766-11e1-8775-005056c00008" p="36.315074464466349" q="22.294780158896135"/>
+            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" bus="_04577e63-c766-11e1-8775-005056c00008" connectableBus="_04577e63-c766-11e1-8775-005056c00008" p="57.907821443338236" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044e56a1-c766-11e1-8775-005056c00008" name="Crickhollow" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048a272b-c766-11e1-8775-005056c00008" name="CRI220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0453d4e3-c766-11e1-8775-005056c00008" name="Kanawha" v="218.77050282597148" angle="3.0952844394723753"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_046efe09-c766-11e1-8775-005056c00008" name="CRI132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04898ae9-c766-11e1-8775-005056c00008" name="CabinCrk" v="137.2800129884015" angle="6.0607149119462473"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" bus="_04898ae9-c766-11e1-8775-005056c00008" connectableBus="_04898ae9-c766-11e1-8775-005056c00008" p="-534.42120499577743" q="-151.54008691389441">
+                <iidm:property name="CGMES.GeneratingUnit" value="_a6ec9760-88da-48df-a23f-7877e7c85ccd"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_e6131af8-c298-413b-84e3-4e21c3b6b06f"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-225" maxQ="640"/>
+            </iidm:generator>
+            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" bus="_04898ae9-c766-11e1-8775-005056c00008" connectableBus="_04898ae9-c766-11e1-8775-005056c00008" p="130.00001844943435" q="26.000006149811743"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_0453d4e3-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e3-c766-11e1-8775-005056c00008" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" bus2="_04898ae9-c766-11e1-8775-005056c00008" connectableBus2="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-154.65263799190552" q1="71.671531414087042" p2="154.65263799190555" q2="-62.167619563058629">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0695187165775399"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.93896713615023475"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.88495575221238942"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.83682008368200833"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.79365079365079361"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.75471698113207553"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.71942446043165464"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.6872852233676976"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.65789473684210531"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.63091482649842268"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.60606060606060608"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.58309037900874627"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.5617977528089888"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.5420054200542006"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.52356020942408377"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.50632911392405056"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_6ff12a17-7104-4420-bfdb-5621035eb4e5" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_f5010321-8804-4359-911d-7b7843d02753" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_b5d2a008-83c2-47a3-a978-283e6b8b2167" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_1a134158-4b67-4406-be2d-303158bd41c4" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_0478c205-c766-11e1-8775-005056c00008" name="Harlond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044778d3-c766-11e1-8775-005056c00008" name="HRL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044b7072-c766-11e1-8775-005056c00008" name="Zanesvll" v="134.70250621826418" angle="-8.0330685898195959"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" bus="_044b7072-c766-11e1-8775-005056c00008" connectableBus="_044b7072-c766-11e1-8775-005056c00008" p="19.99930410984566" q="10.999362108090351"/>
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" bus="_044b7072-c766-11e1-8775-005056c00008" connectableBus="_044b7072-c766-11e1-8775-005056c00008" q="-15.622642821255573">
+                <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
+                <iidm:shuntLinearModel bPerSection="0.00017220000000000001" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04670ec0-c766-11e1-8775-005056c00008" name="Stock" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04789af0-c766-11e1-8775-005056c00008" name="STK132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04667289-c766-11e1-8775-005056c00008" name="Tazewell" v="129.69838444090433" angle="12.13837813754421"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" bus="_04667289-c766-11e1-8775-005056c00008" connectableBus="_04667289-c766-11e1-8775-005056c00008" p="11.989753947209678" q="6.9900413952074132"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04675ce0-c766-11e1-8775-005056c00008" name="Stormlands" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046bf0c7-c766-11e1-8775-005056c00008" name="STO132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04778983-c766-11e1-8775-005056c00008" name="NwLibrty" v="115.45917987395059" angle="-30.641130952044133"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" bus="_04778983-c766-11e1-8775-005056c00008" connectableBus="_04778983-c766-11e1-8775-005056c00008" p="26.344946966873096" q="10.558817721818983"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044e7db2-c766-11e1-8775-005056c00008" name="Crownlands" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04784cd1-c766-11e1-8775-005056c00008" name="CRO132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0482d420-c766-11e1-8775-005056c00008" name="Danville" v="122.60662487427008" angle="-2.4767047786779357"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" bus="_0482d420-c766-11e1-8775-005056c00008" connectableBus="_0482d420-c766-11e1-8775-005056c00008" p="25.000654019359686" q="13.000566821721165"/>
+            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" bus="_0482d420-c766-11e1-8775-005056c00008" connectableBus="_0482d420-c766-11e1-8775-005056c00008" p="43.001124913298661" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0455a9aa-c766-11e1-8775-005056c00008" name="Hobbiton" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0470f9d2-c766-11e1-8775-005056c00008" name="HOB132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047a96c0-c766-11e1-8775-005056c00008" name="Fremont" v="130.07584449003113" angle="18.104386384305524"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" bus="_047a96c0-c766-11e1-8775-005056c00008" connectableBus="_047a96c0-c766-11e1-8775-005056c00008" p="47.975308026875624" q="9.9914278684376949"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0452ea87-c766-11e1-8775-005056c00008" name="Goblin Town" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04703689-c766-11e1-8775-005056c00008" name="GOB132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04719616-c766-11e1-8775-005056c00008" name="Turner" v="131.95424003041796" angle="3.3832592802427786"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" bus="_04719616-c766-11e1-8775-005056c00008" connectableBus="_04719616-c766-11e1-8775-005056c00008" p="60.942269629984381" q="27.955848623747116"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0463da79-c766-11e1-8775-005056c00008" name="Rohan" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04588fd5-c766-11e1-8775-005056c00008" name="ROH132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04885267-c766-11e1-8775-005056c00008" name="Grant" v="121.71133284156808" angle="-32.352900536864418"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" bus="_04885267-c766-11e1-8775-005056c00008" connectableBus="_04885267-c766-11e1-8775-005056c00008" p="23.664292401444357" q="3.9071833660327946"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046eafe6-c766-11e1-8775-005056c00008" name="Andúnië" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047d07c9-c766-11e1-8775-005056c00008" name="AND220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045163e5-c766-11e1-8775-005056c00008" name="Olive1" v="197.42751522800774" angle="-37.494842077166204"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" bus="_045163e5-c766-11e1-8775-005056c00008" connectableBus="_045163e5-c766-11e1-8775-005056c00008" p="27.102622894098609" q="0"/>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_044be5a3-c766-11e1-8775-005056c00008" name="AND132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047147f0-c766-11e1-8775-005056c00008" name="Olive2" v="120.88283145470595" angle="-41.316013143846703"/>
+            </iidm:busBreakerTopology>
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" bus="_047147f0-c766-11e1-8775-005056c00008" connectableBus="_047147f0-c766-11e1-8775-005056c00008" q="-33.55066492740373">
+                <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
+                <iidm:shuntLinearModel bPerSection="0.00045919999999999999" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_045163e5-c766-11e1-8775-005056c00008" connectableBus1="_045163e5-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" bus2="_047147f0-c766-11e1-8775-005056c00008" connectableBus2="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="208.24762232409532" q1="-9.1427974893613104" p2="-208.2476223240954" q2="23.119674404427105">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0152284160890517"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.98522168458346493"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.97087380525968558"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.9569378265149614"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.94339626201495319"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.93023260140616748"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.91743124316135283"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.90497743289449806"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_61e544bc-df04-4b97-8a18-5a8f66ae2ab7" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_4109402d-315d-4c0e-8d0e-a7a277ad5608" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_7d97fc29-56b8-4cd3-924e-aa67d27306c8" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_23406b6a-ccc0-4233-a063-caf8238c5a4e" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_045ab2b7-c766-11e1-8775-005056c00008" name="Michel Delving" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046ed6f7-c766-11e1-8775-005056c00008" name="MIC132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0485ba50-c766-11e1-8775-005056c00008" name="Wythe" v="130.75678883732778" angle="11.214944196455068"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" bus="_0485ba50-c766-11e1-8775-005056c00008" connectableBus="_0485ba50-c766-11e1-8775-005056c00008" p="21.992618440568958" q="14.991612802462162"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044c0cba-c766-11e1-8775-005056c00008" name="Calembel" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04817490-c766-11e1-8775-005056c00008" name="CAL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045ef874-c766-11e1-8775-005056c00008" name="WestLima" v="119.17956449548436" angle="-30.158098617030788"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" bus="_045ef874-c766-11e1-8775-005056c00008" connectableBus="_045ef874-c766-11e1-8775-005056c00008" p="32.175553359899318" q="8.6283810726095762"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_048481d3-c766-11e1-8775-005056c00008" name="Riverlands" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04664b7a-c766-11e1-8775-005056c00008" name="RVR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045f1f84-c766-11e1-8775-005056c00008" name="BeaverCk" v="129.66677089047261" angle="14.025852160549581"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" bus="_045f1f84-c766-11e1-8775-005056c00008" connectableBus="_045f1f84-c766-11e1-8775-005056c00008" p="23.98198326608766" q="14.981237265452757"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0466e7ba-c766-11e1-8775-005056c00008" name="Standelf" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047b8123-c766-11e1-8775-005056c00008" name="STA220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046c3ee8-c766-11e1-8775-005056c00008" name="Sorenson2" v="198.41670984967604" angle="-28.975375676398123"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0476c631-c766-11e1-8775-005056c00008" name="Sorenson1" v="120.49515717828834" angle="-33.974647138163292"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" bus="_0476c631-c766-11e1-8775-005056c00008" connectableBus="_0476c631-c766-11e1-8775-005056c00008" p="10.741854902300043" q="2.8835816226498787"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_046c3ee8-c766-11e1-8775-005056c00008" connectableBus1="_046c3ee8-c766-11e1-8775-005056c00008" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" bus2="_0476c631-c766-11e1-8775-005056c00008" connectableBus2="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="192.6110170644248" q1="72.890528566492634" p2="-192.61101706442483" q2="-54.245967082096293">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0416666883680561"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.96153844304733771"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.92592589163237438"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_d161a693-b7ea-488b-a945-b567ee43f412" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_f7fdb434-5e1f-4292-9849-2542cf0f4c3d" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_c65fcaa8-aacd-4104-90bc-ba8b3185073e" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_f62f2fc6-4b6c-4571-a8c5-40d6a89ac703" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_04642898-c766-11e1-8775-005056c00008" name="Rómenna" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0457f394-c766-11e1-8775-005056c00008" name="RÓM132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0454e653-c766-11e1-8775-005056c00008" name="Philo" v="135.30000102434011" angle="-6.8912110425469102"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" bus="_0454e653-c766-11e1-8775-005056c00008" connectableBus="_0454e653-c766-11e1-8775-005056c00008" p="-242.28080333051832" q="-204.29323373626812">
+                <iidm:property name="CGMES.GeneratingUnit" value="_e3753d6d-b894-4cce-b6fa-307c50dc107f"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_dff93c01-9c84-4c1f-8529-66c054ed9e37"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
+            </iidm:generator>
+            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" bus="_0454e653-c766-11e1-8775-005056c00008" connectableBus="_0454e653-c766-11e1-8775-005056c00008" p="87.000000987999869" q="30.000000567816016"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04828600-c766-11e1-8775-005056c00008" name="Ost-in-Edhil" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047b0bf4-c766-11e1-8775-005056c00008" name="OST132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04716f02-c766-11e1-8775-005056c00008" name="BetsyLne" v="128.71284780413967" angle="11.875504288304088"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" bus="_04716f02-c766-11e1-8775-005056c00008" connectableBus="_04716f02-c766-11e1-8775-005056c00008" p="10.987418751004515" q="6.9866613390160284"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045fe2d1-c766-11e1-8775-005056c00008" name="Oldtown" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046205b3-c766-11e1-8775-005056c00008" name="OLD132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0483be8a-c766-11e1-8775-005056c00008" name="Reusens" v="124.76207587023077" angle="-0.85303338643378857"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" p="22.000632758849697" q="0"/>
+            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" p="28.000805329445072" q="12.000575240832816"/>
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" q="-5.354557997954533">
+                <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
+                <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0453fbf4-c766-11e1-8775-005056c00008" name="Grey Havens" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047d07c3-c766-11e1-8775-005056c00008" name="GRE132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_048433b2-c766-11e1-8775-005056c00008" name="Holston" v="126.41066819883989" angle="16.44672014752944"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" bus="_048433b2-c766-11e1-8775-005056c00008" connectableBus="_048433b2-c766-11e1-8775-005056c00008" p="84.984207010358205" q="0"/>
+            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" bus="_048433b2-c766-11e1-8775-005056c00008" connectableBus="_048433b2-c766-11e1-8775-005056c00008" p="77.985507609505177" q="41.986994814050796"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04745531-c766-11e1-8775-005056c00008" name="Edhellond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048740f7-c766-11e1-8775-005056c00008" name="EDH132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04716f04-c766-11e1-8775-005056c00008" name="SthPoint" v="125.58909357734716" angle="-3.1806993734697802"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" bus="_04716f04-c766-11e1-8775-005056c00008" connectableBus="_04716f04-c766-11e1-8775-005056c00008" p="46.827768801711542" q="10.932899714279335"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0476ed45-c766-11e1-8775-005056c00008" name="Forlond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04481510-c766-11e1-8775-005056c00008" name="FRL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0447ee09-c766-11e1-8775-005056c00008" name="CapitlHl" v="132.65407701575859" angle="3.5284425584681256"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" bus="_0447ee09-c766-11e1-8775-005056c00008" connectableBus="_0447ee09-c766-11e1-8775-005056c00008" p="38.974921131122038" q="31.965711462761515"/>
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" bus="_0447ee09-c766-11e1-8775-005056c00008" connectableBus="_0447ee09-c766-11e1-8775-005056c00008" q="-20.201475562940431">
+                <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
+                <iidm:shuntLinearModel bPerSection="0.0002296" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04825ef5-c766-11e1-8775-005056c00008" name="Osgiliath" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044fb634-c766-11e1-8775-005056c00008" name="OSG132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0482860b-c766-11e1-8775-005056c00008" name="Chemical" v="131.71120178144204" angle="3.1255959847542365"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" bus="_0482860b-c766-11e1-8775-005056c00008" connectableBus="_0482860b-c766-11e1-8775-005056c00008" p="70.940352548015127" q="25.963605647339229"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0476510a-c766-11e1-8775-005056c00008" name="Ethring" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047eb571-c766-11e1-8775-005056c00008" name="ETH132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04684743-c766-11e1-8775-005056c00008" name="JacksnRd" v="120.61196518915285" angle="-43.454638702406655"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" bus="_04684743-c766-11e1-8775-005056c00008" connectableBus="_04684743-c766-11e1-8775-005056c00008" p="18.524917266504513" q="1.9173487846917963"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047edc88-c766-11e1-8775-005056c00008" name="Minas Ithil" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0468bc77-c766-11e1-8775-005056c00008" name="MNI132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04502b6a-c766-11e1-8775-005056c00008" name="Saltvlle" v="130.56189905133368" angle="16.008532918927727"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" bus="_04502b6a-c766-11e1-8775-005056c00008" connectableBus="_04502b6a-c766-11e1-8775-005056c00008" p="64.965702733993936" q="9.9912073760687061"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0452ea86-c766-11e1-8775-005056c00008" name="Frogmorton" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048c22fa-c766-11e1-8775-005056c00008" name="FRO132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04520021-c766-11e1-8775-005056c00008" name="Trenton" v="129.18970971624211" angle="-17.727124152663123"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" bus="_04520021-c766-11e1-8775-005056c00008" connectableBus="_04520021-c766-11e1-8775-005056c00008" p="12.900697285602186" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045dbff3-c766-11e1-8775-005056c00008" name="Nargothrond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047eb579-c766-11e1-8775-005056c00008" name="NAR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0471bd2a-c766-11e1-8775-005056c00008" name="HickryCk" v="117.70727485147574" angle="-44.944899605880039"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" bus="_0471bd2a-c766-11e1-8775-005056c00008" connectableBus="_0471bd2a-c766-11e1-8775-005056c00008" p="37.934683682975312" q="9.5488946089997633"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045386c0-c766-11e1-8775-005056c00008" name="Kings Landing" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04854527-c766-11e1-8775-005056c00008" name="GOD220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047f2aa7-c766-11e1-8775-005056c00008" name="Tidd2" v="213.25572284008189" angle="-4.2461966005136373"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_0455a9a2-c766-11e1-8775-005056c00008" name="KGL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045645e7-c766-11e1-8775-005056c00008" name="Tidd1" v="130.02000025456644" angle="-7.371216522477825"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" bus="_045645e7-c766-11e1-8775-005056c00008" connectableBus="_045645e7-c766-11e1-8775-005056c00008" p="-177.96848199831098" q="-72.382427735374506">
+                <iidm:property name="CGMES.GeneratingUnit" value="_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_29df1e0b-36ca-4536-97b4-6f98b84d49d8"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-90" maxQ="255"/>
+            </iidm:generator>
+            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" bus="_045645e7-c766-11e1-8775-005056c00008" connectableBus="_045645e7-c766-11e1-8775-005056c00008" p="277.00000081350834" q="113.00000055310733"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_047f2aa7-c766-11e1-8775-005056c00008" connectableBus1="_047f2aa7-c766-11e1-8775-005056c00008" voltageLevelId1="_04854527-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="140.46576506158516" q1="68.53183897554797" p2="-140.46576506158519" q2="-59.283830114767902">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0416666883680561"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.96153844304733771"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.92592589163237438"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.8928570950255128"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.86206890606421327"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.83333326388889462"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.80645153485952892"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.78124991455079051"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.75757566574840418"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.73529402032873259"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.71428561224491249"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.69444433834878172"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.6756755661066649"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.65789462430749834"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.64102552596977735"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.62499988281252195"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.60975597858419928"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.59523797477326701"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.58139522714983605"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.56818169550622477"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.55555543209879288"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.54347813681477308"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.53191476912633062"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.52083320855037707"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.51020395668474527"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.49999987500003124"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.49019595347946271"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.48076910595417433"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.47169798860807843"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.46296283864886734"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_67e78c48-0ca2-48d3-8a23-d06c0fcd887e" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_5629d2df-9e35-47ae-8a33-c8276f9343d9" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_1afd1e4c-1377-424b-a866-7f6cba69be6c" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_f2daef4d-6f1a-44d1-9c9b-228acff12575" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_0488eea4-c766-11e1-8775-005056c00008" name="Tuckborough" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04876804-c766-11e1-8775-005056c00008" name="TUC132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04494d93-c766-11e1-8775-005056c00008" name="Wooster" v="124.90108482737332" angle="-12.842353617140809"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" bus="_04494d93-c766-11e1-8775-005056c00008" connectableBus="_04494d93-c766-11e1-8775-005056c00008" p="23.001461234467968" q="11.001164776778294"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046eafe3-c766-11e1-8775-005056c00008" name="Alqualondë" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04767817-c766-11e1-8775-005056c00008" name="ALQ132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04769f21-c766-11e1-8775-005056c00008" name="Wagenhls" v="125.58074836381057" angle="-12.068567384248698"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" bus="_04769f21-c766-11e1-8775-005056c00008" connectableBus="_04769f21-c766-11e1-8775-005056c00008" p="63.000459097508745" q="22.000267200257316"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045ab2b4-c766-11e1-8775-005056c00008" name="Menegroth" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04851e1b-c766-11e1-8775-005056c00008" name="MEN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045b4ef9-c766-11e1-8775-005056c00008" name="Concord" v="117.54181913500722" angle="-42.877260268929753"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" bus="_045b4ef9-c766-11e1-8775-005056c00008" connectableBus="_045b4ef9-c766-11e1-8775-005056c00008" p="33.09802578721947" q="15.298843577963158"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0450c7a8-c766-11e1-8775-005056c00008" name="Erech" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047b3309-c766-11e1-8775-005056c00008" name="ERE132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04675ce7-c766-11e1-8775-005056c00008" name="Delaware" v="122.39145877471903" angle="-29.155611827348597"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" bus="_04675ce7-c766-11e1-8775-005056c00008" connectableBus="_04675ce7-c766-11e1-8775-005056c00008" p="58.216152647658326" q="22.492979342729566"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044f19f8-c766-11e1-8775-005056c00008" name="Dunharrow" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0467ab04-c766-11e1-8775-005056c00008" name="DUN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0474071a-c766-11e1-8775-005056c00008" name="FtWayne" v="117.00081882672012" angle="-36.874321308957356"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" bus="_0474071a-c766-11e1-8775-005056c00008" connectableBus="_0474071a-c766-11e1-8775-005056c00008" p="87.699296547965019" q="28.732754050951943"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047ce0b8-c766-11e1-8775-005056c00008" name="Linhir" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0489b1f8-c766-11e1-8775-005056c00008" name="LIN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047c9297-c766-11e1-8775-005056c00008" name="WNwPhil1" v="128.14303431952823" angle="-10.957212268759191"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" bus="_047c9297-c766-11e1-8775-005056c00008" connectableBus="_047c9297-c766-11e1-8775-005056c00008" p="12.000776990367248" q="3.0003237529737343"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045ef876-c766-11e1-8775-005056c00008" name="Nogrod" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046512f8-c766-11e1-8775-005056c00008" name="NOG132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044ea4c4-c766-11e1-8775-005056c00008" name="Logan" v="129.67159295484885" angle="6.1312305139763357"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" bus="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus="_044ea4c4-c766-11e1-8775-005056c00008" p="53.929434363365239" q="26.941220921283772"/>
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" bus="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus="_044ea4c4-c766-11e1-8775-005056c00008" q="-19.303300878326311">
+                <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
+                <iidm:shuntLinearModel bPerSection="0.0002296" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046f7334-c766-11e1-8775-005056c00008" name="Beauxbatons" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048a7544-c766-11e1-8775-005056c00008" name="BEA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0462a1f3-c766-11e1-8775-005056c00008" name="W.Lancst" v="132.66000361688376" angle="-10.000095193121844"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" p="-22.82808033305183" q="-11.681466098075632">
+                <iidm:property name="CGMES.GeneratingUnit" value="_83fae784-1da1-4055-8108-ba978276d1b6"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_5f711f63-f631-45d3-b26c-33821ab2ee56"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
+            </iidm:generator>
+            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" p="28.000001145101155" q="10.00000068160784"/>
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" q="-10.101640345228546">
+                <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
+                <iidm:shuntLinearModel bPerSection="0.0001148" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0471e435-c766-11e1-8775-005056c00008" name="Carn Dûm" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045d98e1-c766-11e1-8775-005056c00008" name="CAR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04499bb3-c766-11e1-8775-005056c00008" name="Portsmth" v="126.24621293309959" angle="-5.700886470861156"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" bus="_04499bb3-c766-11e1-8775-005056c00008" connectableBus="_04499bb3-c766-11e1-8775-005056c00008" p="65.592088886238827" q="19.794409002786185"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0474a35b-c766-11e1-8775-005056c00008" name="Ephel Brandir" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04636548-c766-11e1-8775-005056c00008" name="EPH132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04723255-c766-11e1-8775-005056c00008" name="DeerCrk" v="122.01623315692166" angle="-32.425583792413541"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" bus="_04723255-c766-11e1-8775-005056c00008" connectableBus="_04723255-c766-11e1-8775-005056c00008" p="-10.828080333051835" q="-45">
+                <iidm:property name="CGMES.GeneratingUnit" value="_e5a479a8-ab8d-4a54-bb52-376874ae2784"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_b55d80d5-720f-46f9-897f-ff8c5eaf8b44"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
+            </iidm:generator>
+            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" bus="_04723255-c766-11e1-8775-005056c00008" connectableBus="_04723255-c766-11e1-8775-005056c00008" p="42.383359679309407" q="26.357768410296345"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04669999-c766-11e1-8775-005056c00008" name="Staddle" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04555b83-c766-11e1-8775-005056c00008" name="STA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044fdd40-c766-11e1-8775-005056c00008" name="Medford" v="122.167534197146" angle="-29.417760051448678"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" bus="_044fdd40-c766-11e1-8775-005056c00008" connectableBus="_044fdd40-c766-11e1-8775-005056c00008" p="21.725013369988858" q="6.8547821839742635"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04731cb4-c766-11e1-8775-005056c00008" name="Diagon Alley" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047f9fdb-c766-11e1-8775-005056c00008" name="DIA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0449e9d4-c766-11e1-8775-005056c00008" name="CollCrnr" v="129.23752426570061" angle="-19.93927783364644"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" bus="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus="_0449e9d4-c766-11e1-8775-005056c00008" p="6.9441385344648578" q="2.9602051871224608"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045fe2da-c766-11e1-8775-005056c00008" name="Ondosto" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044f4108-c766-11e1-8775-005056c00008" name="OND132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047e6750-c766-11e1-8775-005056c00008" name="Caldwell" v="128.86003872814004" angle="7.6425563164868002"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" bus="_047e6750-c766-11e1-8775-005056c00008" connectableBus="_047e6750-c766-11e1-8775-005056c00008" p="41.957750538687904" q="30.948043885685422"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04631727-c766-11e1-8775-005056c00008" name="Rivendell" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046b7b99-c766-11e1-8775-005056c00008" name="RIV132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046c17da-c766-11e1-8775-005056c00008" name="Franklin" v="126.33280566777111" angle="0.79308701742529963"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" bus="_046c17da-c766-11e1-8775-005056c00008" connectableBus="_046c17da-c766-11e1-8775-005056c00008" p="8.000242065435696" q="3.0001512924232334"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04765106-c766-11e1-8775-005056c00008" name="Esgaroth" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04689563-c766-11e1-8775-005056c00008" name="ESG132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04686e54-c766-11e1-8775-005056c00008" name="McKinley" v="116.57592612626463" angle="-35.90742108357653"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" bus="_04686e54-c766-11e1-8775-005056c00008" connectableBus="_04686e54-c766-11e1-8775-005056c00008" p="58.488176519975625" q="32.584192972846679"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046b2d72-c766-11e1-8775-005056c00008" name="Hogwarts" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04479fe2-c766-11e1-8775-005056c00008" name="HOG132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047566a8-c766-11e1-8775-005056c00008" name="TwinBrch" v="121.93338737441483" angle="-43.240445086579555"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" bus="_047566a8-c766-11e1-8775-005056c00008" connectableBus="_047566a8-c766-11e1-8775-005056c00008" p="-100.31232133220733" q="-170">
+                <iidm:property name="CGMES.GeneratingUnit" value="_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_668eb671-5c36-4351-a95d-53ca850581db"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
+            </iidm:generator>
+            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" bus="_047566a8-c766-11e1-8775-005056c00008" connectableBus="_047566a8-c766-11e1-8775-005056c00008" p="45.935062722902543" q="9.6252221022510245"/>
+            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" bus="_047566a8-c766-11e1-8775-005056c00008" connectableBus="_047566a8-c766-11e1-8775-005056c00008" p="20.187158585802557" q="5.7402619863382185">
+                <iidm:currentLimits permanentLimit="1000">
+                    <iidm:temporaryLimit name="_c42b1a7f-971e-44aa-b615-fb7d49f3256c" acceptableDuration="900" value="1150"/>
+                    <iidm:temporaryLimit name="_543c8189-a696-4529-9d26-f06fd03e57ad" acceptableDuration="60" value="1400"/>
+                </iidm:currentLimits>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04499bb4-c766-11e1-8775-005056c00008" name="Annúminas" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04633e3a-c766-11e1-8775-005056c00008" name="ANN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04670ec8-c766-11e1-8775-005056c00008" name="Lincoln" v="116.20251412001241" angle="-36.020992683687275"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" bus="_04670ec8-c766-11e1-8775-005056c00008" connectableBus="_04670ec8-c766-11e1-8775-005056c00008" p="43.854236041732747" q="23.948137081511415"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046f2515-c766-11e1-8775-005056c00008" name="Azkaban" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04644fa4-c766-11e1-8775-005056c00008" name="AZK132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_048c4a07-c766-11e1-8775-005056c00008" name="Hinton" v="134.6192664677647" angle="6.940841836108496"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" bus="_048c4a07-c766-11e1-8775-005056c00008" connectableBus="_048c4a07-c766-11e1-8775-005056c00008" p="41.996796556069278" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04631725-c766-11e1-8775-005056c00008" name="Qarth" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04878f10-c766-11e1-8775-005056c00008" name="QAR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_048b86b5-c766-11e1-8775-005056c00008" name="EastLima1" v="120.65608981566763" angle="-29.120586718098032"/>
+            </iidm:busBreakerTopology>
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" bus="_048b86b5-c766-11e1-8775-005056c00008" connectableBus="_048b86b5-c766-11e1-8775-005056c00008" q="-20.890575033785261">
+                <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
+                <iidm:shuntLinearModel bPerSection="0.00028699999999999998" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_04742e21-c766-11e1-8775-005056c00008" name="QAR220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0451b206-c766-11e1-8775-005056c00008" name="EastLima2" v="194.57684551640543" angle="-23.554850593898401"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_0451b206-c766-11e1-8775-005056c00008" connectableBus1="_0451b206-c766-11e1-8775-005056c00008" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" bus2="_048b86b5-c766-11e1-8775-005056c00008" connectableBus2="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="223.62359452368733" q1="91.246068173509968" p2="-223.62359452368733" q2="-66.798563353997892">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0695187165775399"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.93896713615023475"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.88495575221238942"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.83682008368200833"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.79365079365079361"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.75471698113207553"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.71942446043165464"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.6872852233676976"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_fc89899a-e1ba-48c5-aec0-1d321408483c" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_6ee590e8-2483-491d-a919-ffe1e93a41d3" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_f0cc6f7c-99a3-496d-8d13-1ac44171b1b9" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_c97df399-5a91-4c8b-b72c-496cade334b5" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_0486a4b7-c766-11e1-8775-005056c00008" name="St Mungos" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046f7338-c766-11e1-8775-005056c00008" name="STM132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04531195-c766-11e1-8775-005056c00008" name="N. E." v="120.05653704794874" angle="-41.220636692881527"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" bus="_04531195-c766-11e1-8775-005056c00008" connectableBus="_04531195-c766-11e1-8775-005056c00008" p="24.398276838278356" q="9.602078309210949"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044aad21-c766-11e1-8775-005056c00008" name="Belegost" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04806326-c766-11e1-8775-005056c00008" name="BEL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_048c22f1-c766-11e1-8775-005056c00008" name="SCoshoct" v="126.36199618029507" angle="-12.03739662493434"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" bus="_048c22f1-c766-11e1-8775-005056c00008" connectableBus="_048c22f1-c766-11e1-8775-005056c00008" p="18.002240008963536" q="5.0010370842044045"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04784cda-c766-11e1-8775-005056c00008" name="Gulltown" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047a96c5-c766-11e1-8775-005056c00008" name="GUL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0479102a-c766-11e1-8775-005056c00008" name="WHuntngd" v="123.14634876664867" angle="-3.6504850100916522"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" bus="_0479102a-c766-11e1-8775-005056c00008" connectableBus="_0479102a-c766-11e1-8775-005056c00008" p="32.885622852690169" q="14.913450792715183"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0456bb19-c766-11e1-8775-005056c00008" name="Khazad-dûm" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046a1c00-c766-11e1-8775-005056c00008" name="KHA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045fe2d4-c766-11e1-8775-005056c00008" name="DanRiver" v="129.36006116383206" angle="1.7255261749854356"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" bus="_045fe2d4-c766-11e1-8775-005056c00008" connectableBus="_045fe2d4-c766-11e1-8775-005056c00008" p="-39.82808033305183" q="-20.269478929338071">
+                <iidm:property name="CGMES.GeneratingUnit" value="_fec62959-21c5-4921-90b2-7c85e9f3bfab"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_9db08c95-4586-4a2b-87e3-5a17c944b43a"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045bc420-c766-11e1-8775-005056c00008" name="Minas Morgul" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04664b78-c766-11e1-8775-005056c00008" name="MNM132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04878f11-c766-11e1-8775-005056c00008" name="X5 TRI" v="126.36579153197147" angle="-7.0311385699671947"/>
+            </iidm:busBreakerTopology>
+            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" bus="_04878f11-c766-11e1-8775-005056c00008" connectableBus="_04878f11-c766-11e1-8775-005056c00008" p="6.0034049225814856" q="-1.0617324493815476">
+                <iidm:currentLimits permanentLimit="1000">
+                    <iidm:temporaryLimit name="_d8fc27d8-dd8b-4396-ae7f-b877910f9726" acceptableDuration="900" value="1150"/>
+                    <iidm:temporaryLimit name="_1481884d-3134-4896-ae32-b507830cc47a" acceptableDuration="60" value="1400"/>
+                </iidm:currentLimits>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04595327-c766-11e1-8775-005056c00008" name="Lond Daer Enedh" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0456e220-c766-11e1-8775-005056c00008" name="LON132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04812671-c766-11e1-8775-005056c00008" name="Summerfl" v="134.61047766916181" angle="-2.4516368187706727"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" bus="_04812671-c766-11e1-8775-005056c00008" connectableBus="_04812671-c766-11e1-8775-005056c00008" p="28.001307814012915" q="7.0005449309893528"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047391e8-c766-11e1-8775-005056c00008" name="Durmstrang" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0448d866-c766-11e1-8775-005056c00008" name="DUR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0453d4e4-c766-11e1-8775-005056c00008" name="ClinchRv" v="132.66007770011871" angle="22.803959613226187"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" bus="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus="_0453d4e4-c766-11e1-8775-005056c00008" p="-683.56160666103665" q="-35.77074316373416">
+                <iidm:property name="CGMES.GeneratingUnit" value="_2621b09a-22e3-4630-b3bd-32c102e36741"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_b0d662e5-64c9-4d59-b8e0-9b1ed175769b"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-300" maxQ="850"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044ca8f4-c766-11e1-8775-005056c00008" name="Combe" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045d4ac5-c766-11e1-8775-005056c00008" name="COM132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045fe2d7-c766-11e1-8775-005056c00008" name="Pokagon" v="119.04742045572759" angle="-44.639788696786901"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" bus="_045fe2d7-c766-11e1-8775-005056c00008" connectableBus="_045fe2d7-c766-11e1-8775-005056c00008" p="19.504701763100275" q="8.6316013350576881"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04500458-c766-11e1-8775-005056c00008" name="Eldalondë" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047b8129-c766-11e1-8775-005056c00008" name="ELD132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047e4045-c766-11e1-8775-005056c00008" name="GoshenJt" v="120.30007339216131" angle="-42.108239138563668"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" bus="_047e4045-c766-11e1-8775-005056c00008" connectableBus="_047e4045-c766-11e1-8775-005056c00008" p="13.666267944967784" q="0.96058653102190117"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047d2ed1-c766-11e1-8775-005056c00008" name="Lorien" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048c4a08-c766-11e1-8775-005056c00008" name="LOR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04544a19-c766-11e1-8775-005056c00008" name="S.Tiffin" v="113.45753674226195" angle="-29.998284445488029"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" bus="_04544a19-c766-11e1-8775-005056c00008" connectableBus="_04544a19-c766-11e1-8775-005056c00008" p="36.152311081726722" q="9.6210816894398921"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0478e914-c766-11e1-8775-005056c00008" name="Harrenhal" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0456bb11-c766-11e1-8775-005056c00008" name="HAR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045e0e10-c766-11e1-8775-005056c00008" name="Haviland" v="117.22814385083298" angle="-34.175979406621259"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" bus="_045e0e10-c766-11e1-8775-005056c00008" connectableBus="_045e0e10-c766-11e1-8775-005056c00008" p="22.398257643540163" q="8.6109918067711018"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046ab849-c766-11e1-8775-005056c00008" name="Valmar" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045cfca4-c766-11e1-8775-005056c00008" name="VAL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047d2ed4-c766-11e1-8775-005056c00008" name="SWKammer" v="131.09492354280269" angle="-3.7290655186940254"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" bus="_047d2ed4-c766-11e1-8775-005056c00008" connectableBus="_047d2ed4-c766-11e1-8775-005056c00008" p="78.000538927638601" q="3.0000345467230649"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047343c0-c766-11e1-8775-005056c00008" name="Dol Amroth" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045a1672-c766-11e1-8775-005056c00008" name="DOL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0479fa80-c766-11e1-8775-005056c00008" name="Baileysv" v="130.34714899785993" angle="6.6911058241768835"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" bus="_0479fa80-c766-11e1-8775-005056c00008" connectableBus="_0479fa80-c766-11e1-8775-005056c00008" p="37.958562407452149" q="14.972748336402017"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0476ed41-c766-11e1-8775-005056c00008" name="Fangorn Forest" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044f8f29-c766-11e1-8775-005056c00008" name="FAN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04675ce9-c766-11e1-8775-005056c00008" name="HolstonT" v="128.01989602248156" angle="15.938875608061958"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" bus="_04675ce9-c766-11e1-8775-005056c00008" connectableBus="_04675ce9-c766-11e1-8775-005056c00008" p="9.9967343165747575" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046c17d5-c766-11e1-8775-005056c00008" name="Westerlands" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04791027-c766-11e1-8775-005056c00008" name="WES132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046f9a47-c766-11e1-8775-005056c00008" name="WMedford" v="122.15085707439633" angle="-29.423799556284411"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" bus="_046f9a47-c766-11e1-8775-005056c00008" connectableBus="_046f9a47-c766-11e1-8775-005056c00008" p="7.8989905426970957" q="2.9371351643112327"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0467ab01-c766-11e1-8775-005056c00008" name="Tharbad" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0483be8b-c766-11e1-8775-005056c00008" name="THA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044e56a4-c766-11e1-8775-005056c00008" name="Rockhill" v="119.92417746415347" angle="-29.670998714601488"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" bus="_044e56a4-c766-11e1-8775-005056c00008" connectableBus="_044e56a4-c766-11e1-8775-005056c00008" p="57.548319556628677" q="24.94256270778402"/>
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" bus="_044e56a4-c766-11e1-8775-005056c00008" connectableBus="_044e56a4-c766-11e1-8775-005056c00008" q="-11.548592097384384">
+                <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
+                <iidm:shuntLinearModel bPerSection="0.0001606" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04719613-c766-11e1-8775-005056c00008" name="Caras Galadhon" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04728074-c766-11e1-8775-005056c00008" name="CAR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046a9133-c766-11e1-8775-005056c00008" name="Sprigg" v="129.04987611066602" angle="8.099316161662756"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" bus="_046a9133-c766-11e1-8775-005056c00008" connectableBus="_046a9133-c766-11e1-8775-005056c00008" p="19.969910223779301" q="9.9749377635113579"/>
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" bus="_046a9133-c766-11e1-8775-005056c00008" connectableBus="_046a9133-c766-11e1-8775-005056c00008" q="-9.5593216808783197">
+                <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
+                <iidm:shuntLinearModel bPerSection="0.0001148" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0488eea8-c766-11e1-8775-005056c00008" name="Umbar" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0479d371-c766-11e1-8775-005056c00008" name="UMB132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045868c7-c766-11e1-8775-005056c00008" name="West End" v="114.0615569216131" angle="-30.473964685340263"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" bus="_045868c7-c766-11e1-8775-005056c00008" connectableBus="_045868c7-c766-11e1-8775-005056c00008" p="44.914561777455702" q="0"/>
+            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" bus="_045868c7-c766-11e1-8775-005056c00008" connectableBus="_045868c7-c766-11e1-8775-005056c00008" p="19.528070338024218" q="22.102601539677234"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047343ca-c766-11e1-8775-005056c00008" name="Dorne" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04662460-c766-11e1-8775-005056c00008" name="DOR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0453d4eb-c766-11e1-8775-005056c00008" name="Deer Crk" v="120.71840369055606" angle="-33.46322675465612"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" bus="_0453d4eb-c766-11e1-8775-005056c00008" connectableBus="_0453d4eb-c766-11e1-8775-005056c00008" p="5.8664341165114671" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04745536-c766-11e1-8775-005056c00008" name="Eglarest" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0457f396-c766-11e1-8775-005056c00008" name="EGL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045d23b1-c766-11e1-8775-005056c00008" name="Crooksvl" v="134.10233844490614" angle="-6.9987930891395171"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" bus="_045d23b1-c766-11e1-8775-005056c00008" connectableBus="_045d23b1-c766-11e1-8775-005056c00008" p="33.991470656945467" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0480b143-c766-11e1-8775-005056c00008" name="Newbury" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044d1e26-c766-11e1-8775-005056c00008" name="NEW132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044a5f04-c766-11e1-8775-005056c00008" name="WCambrdg" v="132.17279384191826" angle="-8.7543311872025722"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" bus="_044a5f04-c766-11e1-8775-005056c00008" connectableBus="_044a5f04-c766-11e1-8775-005056c00008" p="17.000999083009415" q="4.0003918049337974"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04640189-c766-11e1-8775-005056c00008" name="Rushey" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04605807-c766-11e1-8775-005056c00008" name="RUS132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0458b6e4-c766-11e1-8775-005056c00008" name="SouthBnd" v="120.29613836712041" angle="-43.101695985018232"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" bus="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus="_0458b6e4-c766-11e1-8775-005056c00008" p="68.229082850130766" q="22.038413384357579"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0453add1-c766-11e1-8775-005056c00008" name="Gondolin" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045c8779-c766-11e1-8775-005056c00008" name="GON220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044e7db1-c766-11e1-8775-005056c00008" name="X9" v="0" angle="0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04745534-c766-11e1-8775-005056c00008" name="Edoras" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04544a18-c766-11e1-8775-005056c00008" name="EDO220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0457f395-c766-11e1-8775-005056c00008" name="Kammer" v="216.54148123591253" angle="-2.6192372664691552"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_0448d867-c766-11e1-8775-005056c00008" name="EDO132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04814d88-c766-11e1-8775-005056c00008" name="W.Kammer" v="131.3400002343752" angle="-2.8243773380899833"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" bus="_04814d88-c766-11e1-8775-005056c00008" connectableBus="_04814d88-c766-11e1-8775-005056c00008" p="-182.96848199831101" q="43.289227468136353">
+                <iidm:property name="CGMES.GeneratingUnit" value="_17852426-f663-4add-9a2b-0a635d51f101"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-90" maxQ="255"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_0457f395-c766-11e1-8775-005056c00008" connectableBus1="_0457f395-c766-11e1-8775-005056c00008" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" bus2="_04814d88-c766-11e1-8775-005056c00008" connectableBus2="_04814d88-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="13.283038074182905" q1="15.939275642317929" p2="-13.283038074182951" q2="-15.823732764607001">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0152284160890517"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.98522168458346493"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.97087380525968558"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.9569378265149614"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.94339626201495319"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.93023260140616748"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.91743124316135283"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.90497743289449806"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.89285720663265766"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.88105733858604451"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_9d8d5d2f-e17b-44ba-8e5c-c743c13b8932" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_dbe87453-c7d1-4a10-8f4e-992b351d4810" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_c2676f61-6c29-44b7-9841-6209f952b0dd" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_f6b1a81c-eda7-4a08-b290-bd29a5ed9fa4" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" bus1="_04723255-c766-11e1-8775-005056c00008" connectableBus1="_04723255-c766-11e1-8775-005056c00008" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" bus2="_04675ce7-c766-11e1-8775-005056c00008" connectableBus2="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-45.817754092650851" q1="11.5383511503102" p2="46.605361463788483" q2="-11.086296858035041">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f69dc237-d327-475e-93f6-25cbffe65d37" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_de6da3cb-8cb5-4900-9c33-8ad45632b535" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" bus1="_045fe2d7-c766-11e1-8775-005056c00008" connectableBus1="_045fe2d7-c766-11e1-8775-005056c00008" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" bus2="_047566a8-c766-11e1-8775-005056c00008" connectableBus2="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-39.025648435449156" q1="-20.398693531533485" p2="39.465557632243495" q2="20.537804186649101">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_09a180b3-124b-4a91-b323-4aad01f45e8a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6bd63dd1-1344-4183-b7bd-af326919f4eb" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" bus1="_04675ce7-c766-11e1-8775-005056c00008" connectableBus1="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" bus2="_046f9a47-c766-11e1-8775-005056c00008" connectableBus2="_046f9a47-c766-11e1-8775-005056c00008" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="6.8420273641855882" q1="0.56781509325975099" p2="-6.8344239957465023" q2="-1.9302126817056984">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_a8e81058-e847-4ff2-adf2-c4129ce23783" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_5f05650a-c63d-46e5-a426-2db4f036929f" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" bus1="_04520021-c766-11e1-8775-005056c00008" connectableBus1="_04520021-c766-11e1-8775-005056c00008" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" bus2="_0472a783-c766-11e1-8775-005056c00008" connectableBus2="_0472a783-c766-11e1-8775-005056c00008" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-35.661603793859229" q1="15.222911191659463" p2="36.46660878820007" q2="-16.597503809944925">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_a65972e6-89bc-4bc2-adaf-0434a8cb1628" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_d2074163-ab09-4251-a1d7-6983091dc4f1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" bus1="_0476c631-c766-11e1-8775-005056c00008" connectableBus1="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" bus2="_04686e54-c766-11e1-8775-005056c00008" connectableBus2="_04686e54-c766-11e1-8775-005056c00008" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="63.374934536806762" q1="38.601485989877723" p2="-62.555924082765358" q2="-36.285873167851612">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f12edde3-3545-483e-8323-461ae7aa0ada" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2b6693c7-4e29-4c2c-91d0-3485bbe8fe87" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" bus1="_0476c631-c766-11e1-8775-005056c00008" connectableBus1="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" bus2="_0453d4eb-c766-11e1-8775-005056c00008" connectableBus2="_0453d4eb-c766-11e1-8775-005056c00008" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="-24.06412696085189" q1="1.96060549960574" p2="24.128145071799313" q2="-2.3906948972006252">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_83e15527-5937-42e4-964e-4c736913e9b0" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_786432da-fa4d-4751-a275-87d0e20529f1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_044a5f04-c766-11e1-8775-005056c00008" connectableBus2="_044a5f04-c766-11e1-8775-005056c00008" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="49.814353058370656" q1="14.34186881892294" p2="-49.124031064173778" q2="-14.321481508888168">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_5f6ea7e2-f472-4dba-a863-10ce21ee9702" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_1f0844a5-ea5c-42b2-abcb-6fac2c426092" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" bus1="_044a8618-c766-11e1-8775-005056c00008" connectableBus1="_044a8618-c766-11e1-8775-005056c00008" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" bus2="_0471bd2a-c766-11e1-8775-005056c00008" connectableBus2="_0471bd2a-c766-11e1-8775-005056c00008" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-30.286963306129401" q1="-12.66174780396295" p2="30.464203627917524" q2="12.393922467326817">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_bd6a7b7b-b30f-440f-bf3e-7d1d8007b0ab" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_4ea43e34-67a3-42b8-9601-2189db7790d4" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" bus1="_04502b6a-c766-11e1-8775-005056c00008" connectableBus1="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" bus2="_04845ac5-c766-11e1-8775-005056c00008" connectableBus2="_04845ac5-c766-11e1-8775-005056c00008" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="50.083078191859556" q1="-9.1578464297004221" p2="-49.758762035623683" q2="9.2009754113877875">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_70154a1f-3853-4c24-8c87-aef442bdefdb" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_23cc194e-9273-46e9-a793-84a9c2911737" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" bus1="_04667289-c766-11e1-8775-005056c00008" connectableBus1="_04667289-c766-11e1-8775-005056c00008" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" bus2="_045c8773-c766-11e1-8775-005056c00008" connectableBus2="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="60.193558003406245" q1="-22.932812287321003" p2="-59.244564936771859" q2="24.229339901070137">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f5c30ce2-41bf-4665-a68c-a4d64962821a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_1a9fe09e-3f63-4904-8e36-aa38c5e16c59" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" bus1="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus1="_0462a1f3-c766-11e1-8775-005056c00008" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" bus2="_044b7072-c766-11e1-8775-005056c00008" connectableBus2="_044b7072-c766-11e1-8775-005056c00008" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-19.198906747150929" q1="-4.1868362315159366" p2="19.420170094228222" q2="0.041373118174494947">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_79d9d9c2-3ecc-40f2-99c0-c26a56c19fe7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_467ba04d-dbad-4fe1-81c8-3bc87b41fcd1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_04862f81-c766-11e1-8775-005056c00008" connectableBus2="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-137.80221628197825" q1="6.1131293279919756" p2="141.06503632589457" q2="7.8755043840298899">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_58073794-ab85-4c83-b59e-07d01d71ec5f" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_d0737ab4-5a3a-46c8-8aeb-789313f0f332" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" bus1="_04716f04-c766-11e1-8775-005056c00008" connectableBus1="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" bus2="_0479102a-c766-11e1-8775-005056c00008" connectableBus2="_0479102a-c766-11e1-8775-005056c00008" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="24.002626208080486" q1="28.888805668236593" p2="-23.771594714684301" q2="-29.185988202276814">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_4ea8b910-752d-4475-8141-89e03e629b4e" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_173dc7ff-ae18-4410-b2e1-a4c2abac8ff6" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" bus1="_045c8773-c766-11e1-8775-005056c00008" connectableBus1="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" bus2="_0479fa80-c766-11e1-8775-005056c00008" connectableBus2="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="45.564696544763692" q1="-15.14153673403141" p2="-44.936567343666212" q2="14.929994522454527">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_15760a98-ef2d-4bd9-9370-acb8533d07b8" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_efde58bf-c92e-496d-b558-d0095a271083" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" bus1="_044b9787-c766-11e1-8775-005056c00008" connectableBus1="_044b9787-c766-11e1-8775-005056c00008" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" bus2="_04812671-c766-11e1-8775-005056c00008" connectableBus2="_04812671-c766-11e1-8775-005056c00008" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-19.981717635212416" q1="-15.670522412345655" p2="20.136885191717401" q2="13.218922574239109">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_bb70f086-9826-4662-b5f7-d88e35724d27" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_8a81d4ae-2bc8-4038-8650-27a6150946b1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" bus1="_045d23b1-c766-11e1-8775-005056c00008" connectableBus1="_045d23b1-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-6.9824950146229332" q1="-13.439295787537423" p2="7.0209512972441921" q2="11.894783708759357">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_36231d1d-0ec0-42d3-a72a-d56bd20ed7b0" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_8d6a074c-900d-4a37-830c-5da4c1de1ab5" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" bus1="_0468bc75-c766-11e1-8775-005056c00008" connectableBus1="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" bus2="_044ef2e3-c766-11e1-8775-005056c00008" connectableBus2="_044ef2e3-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="58.33751907951762" q1="10.172221656977912" p2="-56.242108111870678" q2="-8.3048889742851415">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_2da72d83-6a1a-4a6d-a873-847a8741dc7f" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3154dc30-b0e5-4570-8e52-9333bae20ef2" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" bus1="_04719616-c766-11e1-8775-005056c00008" connectableBus1="_04719616-c766-11e1-8775-005056c00008" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" bus2="_0482860b-c766-11e1-8775-005056c00008" connectableBus2="_0482860b-c766-11e1-8775-005056c00008" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="37.273110236520616" q1="2.9908469680257883" p2="-37.220343202097148" q2="-4.0776270587368728">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f6dcf23b-e28d-4722-9b81-e4ae2b782a53" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_cce754c5-b9d5-4105-a431-32da96e4a6cf" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" bus1="_046b066a-c766-11e1-8775-005056c00008" connectableBus1="_046b066a-c766-11e1-8775-005056c00008" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" bus2="_04684743-c766-11e1-8775-005056c00008" connectableBus2="_04684743-c766-11e1-8775-005056c00008" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="3.4269752253696466" q1="-21.835446984633151" p2="-3.4003828544060033" q2="21.49915135081709">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ecaca589-8952-4cab-b3dc-f787858d46a9" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_361a9cc3-fb33-4037-9b9a-c20adb90b66b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" bus1="_04719616-c766-11e1-8775-005056c00008" connectableBus1="_04719616-c766-11e1-8775-005056c00008" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" bus2="_04898ae9-c766-11e1-8775-005056c00008" connectableBus2="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-52.582754178755074" q1="-23.747312448242884" p2="53.546587589162499" q2="24.817340557539065">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_fdae333c-349a-484b-9226-2b694611f4fe" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_da00c66f-a882-4938-923b-f2455f7f9a81" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" bus1="_0482860b-c766-11e1-8775-005056c00008" connectableBus1="_0482860b-c766-11e1-8775-005056c00008" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" bus2="_0447ee09-c766-11e1-8775-005056c00008" connectableBus2="_0447ee09-c766-11e1-8775-005056c00008" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-33.720009923605382" q1="-21.885981582546375" p2="33.807864140233569" q2="21.628787338508744">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_1f58489c-4298-48ca-914f-1a86392e8a4d" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ba4abe9d-8490-4c19-b19b-c9d2c3597fc9" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" bus1="_04597a36-c766-11e1-8775-005056c00008" connectableBus1="_04597a36-c766-11e1-8775-005056c00008" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" bus2="_046783f5-c766-11e1-8775-005056c00008" connectableBus2="_046783f5-c766-11e1-8775-005056c00008" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="34.118062063508042" q1="13.723346328646416" p2="-33.472277948101258" q2="-15.521168874178473">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_e286f134-f966-4dd2-b24b-b8388ca849a5" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2320da74-eda7-4f7f-ade9-1ed0e994f3af" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" bus1="_047e6750-c766-11e1-8775-005056c00008" connectableBus1="_047e6750-c766-11e1-8775-005056c00008" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" bus2="_0479fa80-c766-11e1-8775-005056c00008" connectableBus2="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="21.001711098755028" q1="-27.13083422566045" p2="-20.797238242117277" q2="26.36389469030841">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_489df699-65e3-4b74-b657-04f7e24da3e0" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3bc03415-e95f-47a7-8e92-01089d304a9c" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" bus1="_04719616-c766-11e1-8775-005056c00008" connectableBus1="_04719616-c766-11e1-8775-005056c00008" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" bus2="_04898ae9-c766-11e1-8775-005056c00008" connectableBus2="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-114.40684147350741" q1="-43.077275419273263" p2="116.91556292481087" q2="45.323570955015214">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_bb9699a6-dcec-459a-b50a-7c7ff7419b33" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_f93b6d4c-39fa-4f6f-a42d-c63a4cf21a67" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" bus1="_047147f0-c766-11e1-8775-005056c00008" connectableBus1="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" bus2="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus2="_0458b6e4-c766-11e1-8775-005056c00008" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="36.823385706631193" q1="-5.1269467477807531" p2="-36.490485669958886" q2="4.7948405376185468">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_55d07074-4a4b-419b-819d-8d6048fcfd1c" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3bc4ab96-7a0d-4e18-b9f5-d89f63a82f0a" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" bus1="_04878f11-c766-11e1-8775-005056c00008" connectableBus1="_04878f11-c766-11e1-8775-005056c00008" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" bus2="_0472a783-c766-11e1-8775-005056c00008" connectableBus2="_0472a783-c766-11e1-8775-005056c00008" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="49.656009885735266" q1="-15.502568189905194" p2="-48.367798498903205" q2="16.597531237795">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7a622384-0095-408a-9cc5-b561a4bec039" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_bcb69c6e-125e-449c-acb3-a4deb151668d" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" bus1="_04862f81-c766-11e1-8775-005056c00008" connectableBus1="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" bus2="_04812671-c766-11e1-8775-005056c00008" connectableBus2="_04812671-c766-11e1-8775-005056c00008" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="48.713659126883975" q1="19.95403179680552" p2="-48.138193005546491" q2="-20.219467504680001">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_fd2f6dbe-d54c-4d17-9492-da52445d0640" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b4b8a31d-dc3c-4b51-88ad-a22e070eb96c" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" bus1="_044e56a4-c766-11e1-8775-005056c00008" connectableBus1="_044e56a4-c766-11e1-8775-005056c00008" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" bus2="_046bf0cb-c766-11e1-8775-005056c00008" connectableBus2="_046bf0cb-c766-11e1-8775-005056c00008" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="-30.889964138170779" q1="5.0177528334064538" p2="31.390282316750085" q2="-6.4830461369275048">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_498a5fc8-8519-4545-b941-9e3648608651" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_5585c67a-0839-48e6-8847-4393e1e9b9c7" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" bus1="_048c22f1-c766-11e1-8775-005056c00008" connectableBus1="_048c22f1-c766-11e1-8775-005056c00008" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" bus2="_04494d93-c766-11e1-8775-005056c00008" connectableBus2="_04494d93-c766-11e1-8775-005056c00008" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="8.858254563046227" q1="2.4810470979588808" p2="-8.81524963367076" q2="-5.9834415144751212">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_005c0497-2c3d-4384-b39b-e1c8e4695081" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_e7c9dfab-fb45-4470-964f-4ba9e391f60b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" bus1="_04876809-c766-11e1-8775-005056c00008" connectableBus1="_04876809-c766-11e1-8775-005056c00008" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" bus2="_0483be8a-c766-11e1-8775-005056c00008" connectableBus2="_0483be8a-c766-11e1-8775-005056c00008" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="27.020911426238985" q1="1.2824785378416816" p2="-26.598740862046267" q2="-4.1322096808918749">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_78d5285a-1f72-4d4e-a8ce-d760901cdf1e" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_fff133bf-25fd-46b2-b144-a227c31ee882" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" bus1="_0468bc75-c766-11e1-8775-005056c00008" connectableBus1="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" bus2="_0485ba50-c766-11e1-8775-005056c00008" connectableBus2="_0485ba50-c766-11e1-8775-005056c00008" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.91673506249645" q1="24.88663018070929" p2="22.234631306418319" q2="-26.743797230501155">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_78f10485-1742-4778-93bc-90854ee15eb6" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_217e3c95-24b5-438f-a721-d2257e1a43b4" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" bus1="_045b9d15-c766-11e1-8775-005056c00008" connectableBus1="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" bus2="_047c9297-c766-11e1-8775-005056c00008" connectableBus2="_047c9297-c766-11e1-8775-005056c00008" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-19.389898815808511" q1="-10.722438451789905" p2="19.566504985661197" q2="8.9784163654196671">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_1b2b5b52-3ac1-40eb-af2e-e5a724e34ed4" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_f5547027-3d48-4a53-937b-bd5ba63ef70d" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" bus1="_045d23b1-c766-11e1-8775-005056c00008" connectableBus1="_045d23b1-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" bus2="_044a8615-c766-11e1-8775-005056c00008" connectableBus2="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-68.34671387384472" q1="17.595272512192285" p2="72.53606239620261" q2="-11.264577339583923">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_2e74f628-a179-44d3-bd7f-1d262370e8d2" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_e9fec217-cf6f-4d39-9495-26ed10c05100" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" bus1="_04550d63-c766-11e1-8775-005056c00008" connectableBus1="_04550d63-c766-11e1-8775-005056c00008" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" bus2="_045fe2d4-c766-11e1-8775-005056c00008" connectableBus2="_045fe2d4-c766-11e1-8775-005056c00008" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.361512249002921" q1="-20.540714659039615" p2="39.828127438259884" q2="20.26952118201751">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_489598c7-fb80-48bb-abdc-7fbc89ff0fd7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ea48fee0-31b6-4990-a332-25d08b7d731f" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" bus1="_04544a19-c766-11e1-8775-005056c00008" connectableBus1="_04544a19-c766-11e1-8775-005056c00008" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" bus2="_04577e63-c766-11e1-8775-005056c00008" connectableBus2="_04577e63-c766-11e1-8775-005056c00008" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-45.588307554255358" q1="1.6636145238851179" p2="46.746464729250015" q2="-0.45193661820809305">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_91e7cb96-de23-4948-881e-3112959809d0" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_063af52c-fe10-4c1e-85d4-dd80dcc1d2f9" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" bus1="_04898ae9-c766-11e1-8775-005056c00008" connectableBus1="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" bus2="_048c4a07-c766-11e1-8775-005056c00008" connectableBus2="_048c4a07-c766-11e1-8775-005056c00008" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="-5.3907111425437328" q1="8.4724622119109014" p2="5.4577011757409046" q2="-13.960684825840808">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_b3ada113-b597-41a3-b96c-e2d6413ccd2b" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_c05229ce-6abb-4209-ad4f-0dcd4a070f28" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" bus1="_04549837-c766-11e1-8775-005056c00008" connectableBus1="_04549837-c766-11e1-8775-005056c00008" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-32.61931003909573" q1="-6.8380712519806375" p2="33.215459370986139" q2="3.9277782212868546">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f947c23d-f412-4092-bee0-955d804a356e" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ac528cbe-6fc1-41dd-ba9d-d8b7a4c77576" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" bus1="_04502b6a-c766-11e1-8775-005056c00008" connectableBus1="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" bus2="_045c8773-c766-11e1-8775-005056c00008" connectableBus2="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="68.232563030499094" q1="-16.870903889938862" p2="-65.834644936927049" q2="20.78578550405302">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_288185b8-2129-4450-a2c7-ad8080ce1f0a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6ac84228-6b04-4b10-b560-29655c8e93b4" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" bus1="_048b86b5-c766-11e1-8775-005056c00008" connectableBus1="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" bus2="_04778983-c766-11e1-8775-005056c00008" connectableBus2="_04778983-c766-11e1-8775-005056c00008" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="27.824570052360286" q1="24.66161289002018" p2="-27.271591866782419" q2="-24.996378456806507">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_dfe3b6e2-9b9f-400e-93a7-90b35c43d3ea" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2ccdc288-c132-40d1-a928-3887bec4ff67" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" bus1="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus1="_0462a1f3-c766-11e1-8775-005056c00008" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" bus2="_045d23b1-c766-11e1-8775-005056c00008" connectableBus2="_045d23b1-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-40.706243209739718" q1="3.0399306832408222" p2="41.33773810608384" q2="-4.1559765490376455">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_81e5d0c5-7cb3-42c7-829e-11059f8a64c3" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_06ca3245-2668-448f-a5c6-961924217a5c" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0473e004-c766-11e1-8775-005056c00008" name="30-38" r="2.2457600000000002" x="26.1360016" g1="0" b1="0.00043595040000000003" g2="0" b2="0.00043595040000000003" bus1="_046c3ee8-c766-11e1-8775-005056c00008" connectableBus1="_046c3ee8-c766-11e1-8775-005056c00008" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" bus2="_0451b206-c766-11e1-8775-005056c00008" connectableBus2="_0451b206-c766-11e1-8775-005056c00008" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="-135.46808844640714" q1="30.233930421888427" p2="136.64307651131381" q2="-50.227660991384347">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_29165bcc-a0d7-4427-a8b8-8393eb928631" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" bus1="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus1="_044ea4c4-c766-11e1-8775-005056c00008" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" bus2="_046a9133-c766-11e1-8775-005056c00008" connectableBus2="_046a9133-c766-11e1-8775-005056c00008" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-78.347585933620508" q1="36.281210836369169" p2="79.22857668197355" q2="-37.044066411656175">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_31992d9c-cc50-4558-b52a-f9a597797818" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_dfbd2f07-76ab-41e3-910f-dc706979ea4b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" bus1="_046b7b91-c766-11e1-8775-005056c00008" connectableBus1="_046b7b91-c766-11e1-8775-005056c00008" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" bus2="_046c17da-c766-11e1-8775-005056c00008" connectableBus2="_046c17da-c766-11e1-8775-005056c00008" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.387675751808338" q1="-0.39774600487644424" p2="-20.340246027224637" q2="-0.169903631629302">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ce219edd-f122-4f03-ae4f-0dd3493375e7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_11451cec-81c7-4f83-a7db-df7dcaffa94e" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" bus1="_04499bb3-c766-11e1-8775-005056c00008" connectableBus1="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" bus2="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus2="_0486f2d6-c766-11e1-8775-005056c00008" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="-4.0901455170444097" q1="11.077703834118765" p2="4.167277400826535" q2="-13.85392662208568">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_fa81f928-3439-4353-ac4c-3785ae142ba2" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_37a5cc00-bd7f-4ec7-a77c-e140e23450d2" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" bus1="_04719616-c766-11e1-8775-005056c00008" connectableBus1="_04719616-c766-11e1-8775-005056c00008" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" bus2="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus2="_044ea4c4-c766-11e1-8775-005056c00008" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-42.468583976693587" q1="32.34216899742767" p2="43.402107751142935" q2="-37.698288361772519">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_1f7aa218-1550-426b-9fd1-6361f5c3e363" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_e9798d58-b518-4fab-984c-c72076dfc2ae" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" bus1="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus1="_0449e9d4-c766-11e1-8775-005056c00008" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" bus2="_04520021-c766-11e1-8775-005056c00008" connectableBus2="_04520021-c766-11e1-8775-005056c00008" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="-69.3594507099629" q1="18.816980907418124" p2="70.100279607072977" q2="-20.88904554321828">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_8b924c6b-d010-4981-b109-fc33cd937313" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_e8ec73b8-1ecf-4d18-9ef9-80eabf3a4969" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" bus1="_0474071a-c766-11e1-8775-005056c00008" connectableBus1="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" bus2="_0476c631-c766-11e1-8775-005056c00008" connectableBus2="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-100.03864744824078" q1="-22.849766570867413" p2="101.79492174483671" q2="25.070069952280022">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_0a1e553e-a285-429e-a660-00078dd05878" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2ceac3d1-f73d-43db-8d37-9e329f1787bb" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" bus1="_045163e5-c766-11e1-8775-005056c00008" connectableBus1="_045163e5-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" bus2="_046c3ee8-c766-11e1-8775-005056c00008" connectableBus2="_046c3ee8-c766-11e1-8775-005056c00008" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-235.35029711192834" q1="9.1432441492300001" p2="238.36235164600285" q2="-15.522588050281893">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_2e5a9b0c-24d7-4bb6-9761-484be58c5bf6" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ca795ad3-97e5-4416-aaba-53cce27f6434" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_044a8615-c766-11e1-8775-005056c00008" connectableBus2="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-57.800852841472995" q1="16.396185104758416" p2="61.336610820992775" q2="-13.55033307595083">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_4f55c6a7-4a84-47ac-84a2-f7da319866f4" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_c42dc3ef-3a2e-4070-8efb-78e5c0cd5554" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" bus1="_045b4ef9-c766-11e1-8775-005056c00008" connectableBus1="_045b4ef9-c766-11e1-8775-005056c00008" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" bus2="_0474071a-c766-11e1-8775-005056c00008" connectableBus2="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="-29.999916009871981" q1="9.9116418370704604" p2="30.988564389659107" q2="-11.611271600214909">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_40c3caa3-b6ce-4e62-ada3-2053aaadb18b" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ad988fd9-9270-4230-95a2-1858f32259df" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" bus1="_044a8615-c766-11e1-8775-005056c00008" connectableBus1="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" bus2="_04499bb3-c766-11e1-8775-005056c00008" connectableBus2="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="146.50314985804638" q1="34.985869721383537" p2="-140.0095248635489" q2="-19.610464706607182">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f71ac0ab-1003-49e3-baae-6860eaa27ea1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_519e3ecb-3561-4d11-ac6b-172a0b4b09b2" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" bus1="_04670ec8-c766-11e1-8775-005056c00008" connectableBus1="_04670ec8-c766-11e1-8775-005056c00008" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" bus2="_0474f17a-c766-11e1-8775-005056c00008" connectableBus2="_0474f17a-c766-11e1-8775-005056c00008" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-28.05655117440482" q1="1.2459879308403421" p2="28.314393405337924" q2="-2.3731481472014857">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_e0ff2082-d064-46f0-89c2-f6597d7c5acb" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b88528bf-cb1c-4c00-ad79-d5937197d40c" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" bus1="_045c8773-c766-11e1-8775-005056c00008" connectableBus1="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" bus2="_047e6750-c766-11e1-8775-005056c00008" connectableBus2="_047e6750-c766-11e1-8775-005056c00008" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="63.51000429878512" q1="4.5582218627528412" p2="-62.95946239550814" q2="-3.8172111588815962">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_9b58679f-8c7f-489f-884a-30224849053b" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b70e76a1-6e79-4fb6-b487-dffa9bfeab7b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" bus1="_047566a8-c766-11e1-8775-005056c00008" connectableBus1="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" bus2="_04531195-c766-11e1-8775-005056c00008" connectableBus2="_04531195-c766-11e1-8775-005056c00008" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="-29.440576339970328" q1="22.945028539267597" p2="29.797338681188695" q2="-23.339691803898027">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_25cb43d7-517b-4c25-b213-a01c4afe495d" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_af73f526-c58b-40e7-8e1c-14f05a39f6a2" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" bus1="_0468bc75-c766-11e1-8775-005056c00008" connectableBus1="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" bus2="_04597a36-c766-11e1-8775-005056c00008" connectableBus2="_04597a36-c766-11e1-8775-005056c00008" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="106.50794887844719" q1="-18.503158635818849" p2="-104.71480844386384" q2="18.881133969633833">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ce5f31b6-0de2-41fb-8091-c2d5742b1828" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_1631e50b-21a3-470b-803b-f9665b6fcd60" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" bus1="_04483c26-c766-11e1-8775-005056c00008" connectableBus1="_04483c26-c766-11e1-8775-005056c00008" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" bus2="_04675ce7-c766-11e1-8775-005056c00008" connectableBus2="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="17.114433018614939" q1="3.8912497813227391" p2="-17.031862809412136" q2="-5.2890463882274199">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_cd4a9202-6aaa-4709-8293-bc142c0c9bc0" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_52eb4b09-42bb-4106-ac26-fe1059639d3a" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" bus1="_045645e7-c766-11e1-8775-005056c00008" connectableBus1="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" bus2="_04814d88-c766-11e1-8775-005056c00008" connectableBus2="_04814d88-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-50.373970812874035" q1="4.6224929803982464" p2="51.246129628474414" q2="-4.4368472809656012">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_13d74b35-2eae-4bb7-9968-655ba9ecd015" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b5a7dea0-bfce-4548-a04d-7bb7b6d9f80a" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" bus1="_0468bc75-c766-11e1-8775-005056c00008" connectableBus1="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" bus2="_046783f5-c766-11e1-8775-005056c00008" connectableBus2="_046783f5-c766-11e1-8775-005056c00008" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="53.580108564056225" q1="11.140300197106601" p2="-52.243578736821448" q2="-10.440740846395791">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_80225115-e6ed-47cd-b7d2-04f198d2417f" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_17a10cd0-b653-4dcf-bdc3-4d5005ea9591" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" bus1="_04716f04-c766-11e1-8775-005056c00008" connectableBus1="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" bus2="_04719616-c766-11e1-8775-005056c00008" connectableBus2="_04719616-c766-11e1-8775-005056c00008" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-55.348098452345376" q1="-5.4447153472798018" p2="57.388734672751461" q2="7.4917462758783691">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f64d2e1f-164f-4cd3-b7bd-9be3300eacb1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6f81df11-7e71-4b6e-a6ee-a8c5f72f4ba5" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" bus1="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus1="_0449e9d4-c766-11e1-8775-005056c00008" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" bus2="_04675ce7-c766-11e1-8775-005056c00008" connectableBus2="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="131.09579461249274" q1="12.539683288651304" p2="-125.30332532746777" q2="-2.1354855427756836">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ac71ed2f-6a14-4b3d-aa1b-b7a3cd071a96" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_a8f6a7d2-e58d-4671-a776-97be7291355e" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" bus1="_0479fa80-c766-11e1-8775-005056c00008" connectableBus1="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" bus2="_04667284-c766-11e1-8775-005056c00008" connectableBus2="_04667284-c766-11e1-8775-005056c00008" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="8.1114004664445076" q1="-26.423488540852912" p2="-7.9865841358174485" q2="24.67075200378331">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_b6767a5e-0078-4311-b973-464b8f35bbfd" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ea6d39aa-df95-4d3e-b7b6-a800e552e72a" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" bus1="_04689567-c766-11e1-8775-005056c00008" connectableBus1="_04689567-c766-11e1-8775-005056c00008" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" bus2="_04483c26-c766-11e1-8775-005056c00008" connectableBus2="_04483c26-c766-11e1-8775-005056c00008" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="160.81819716799041" q1="51.579331885867063" p2="-152.27461955165907" q2="-25.223778058342273">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_8a1cb557-29ed-49ae-9120-65b4bdb8d2b1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_d9d53af2-5ffa-4f2a-a4e6-ed22371332d6" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" bus1="_04550d63-c766-11e1-8775-005056c00008" connectableBus1="_04550d63-c766-11e1-8775-005056c00008" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" bus2="_0482d420-c766-11e1-8775-005056c00008" connectableBus2="_0482d420-c766-11e1-8775-005056c00008" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.356229448865321" q1="11.007931742292437" p2="-68.001794597569798" q2="-13.000564504274484">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_e55ac0b9-b111-4207-b7ee-59ac708a4e23" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_d50299b9-a055-408a-aa1e-2e93a715120f" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" bus1="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" bus2="_04502b6a-c766-11e1-8775-005056c00008" connectableBus2="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="232.87506408046789" q1="-2.9587541750934254" p2="-227.5595064608726" q2="24.625373707727217">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_4f767c6c-7f3a-4cb0-8a7d-04b1b4897817" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_eee9ca2b-764f-4ab8-a745-405338044743" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_04549837-c766-11e1-8775-005056c00008" connectableBus2="_04549837-c766-11e1-8775-005056c00008" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="33.556002179728154" q1="12.037437963239659" p2="-32.416277259317205" q2="-15.384541131255316">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_c1091068-8e12-44e2-bdc4-44450556f80f" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_690202a4-aad2-4ad3-8842-961b39e37709" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" bus1="_045868c7-c766-11e1-8775-005056c00008" connectableBus1="_045868c7-c766-11e1-8775-005056c00008" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" bus2="_04544a19-c766-11e1-8775-005056c00008" connectableBus2="_04544a19-c766-11e1-8775-005056c00008" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="-9.395465607323267" q1="10.512971926241427" p2="9.4359742042785886" q2="-11.284535498367722">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_3d919b23-d14b-4639-a104-ce09f5d78235" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_34f2ef7c-32da-4444-b989-d02f5f931c50" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" bus1="_04778983-c766-11e1-8775-005056c00008" connectableBus1="_04778983-c766-11e1-8775-005056c00008" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" bus2="_045868c7-c766-11e1-8775-005056c00008" connectableBus2="_045868c7-c766-11e1-8775-005056c00008" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="0.92659611886591609" q1="14.437691936930294" p2="-0.87205116078989531" q2="-15.431468913279389">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_d8fb151e-0854-45a9-8df9-177e6bfebf52" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_38d58455-5205-46bb-8e44-c66873f62938" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" bus1="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" bus2="_04502b6a-c766-11e1-8775-005056c00008" connectableBus2="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="73.466593306986454" q1="-5.8316383508417005" p2="-71.361049398988754" q2="10.18613630138625">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_135d109b-ce06-4ee9-9fdc-bc39b1cd4791" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_0cce41c7-b99f-4fec-93d2-73ea24433fa1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" bus1="_045e0e10-c766-11e1-8775-005056c00008" connectableBus1="_045e0e10-c766-11e1-8775-005056c00008" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" bus2="_048b86b5-c766-11e1-8775-005056c00008" connectableBus2="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-50.185160561469843" q1="-0.79436599710359379" p2="51.510586409977854" q2="2.357243762341374">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f5fb6f64-e16e-422b-b721-de1a781e8c01" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_343677c6-7477-4bf6-a12c-2c7e4a684d6f" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" bus1="_04876809-c766-11e1-8775-005056c00008" connectableBus1="_04876809-c766-11e1-8775-005056c00008" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" bus2="_046b7b91-c766-11e1-8775-005056c00008" connectableBus2="_046b7b91-c766-11e1-8775-005056c00008" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.52991404394411" q1="-0.72230340256419368" p2="-22.38773462286656" q2="-0.60230247477752208">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_072c26b8-9b37-418f-b9a6-338f9a198a84" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_74cf84b9-e14f-4f81-9e8b-3a791cd474a0" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" bus1="_044e56a4-c766-11e1-8775-005056c00008" connectableBus1="_044e56a4-c766-11e1-8775-005056c00008" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" bus2="_048b86b5-c766-11e1-8775-005056c00008" connectableBus2="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-92.490932232106317" q1="-28.40024356661467" p2="92.780559330771666" q2="28.646551598386793">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_1ee3b9bf-743b-4bcb-b6a3-faa02fc44cc1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_8e90bf2e-3be4-41be-a84e-c1d4e709f8a1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" bus1="_04814d88-c766-11e1-8775-005056c00008" connectableBus1="_04814d88-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" bus2="_044b9787-c766-11e1-8775-005056c00008" connectableBus2="_044b9787-c766-11e1-8775-005056c00008" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="30.939239882220409" q1="-14.59820953525648" p2="-30.842991090154008" q2="14.064390957400736">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_b653b5eb-5efc-4bcc-9e10-1eb6bfa6f57c" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_39a23399-348e-44d9-8032-8fc62e6c7d63" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" bus1="_0485ba50-c766-11e1-8775-005056c00008" connectableBus1="_0485ba50-c766-11e1-8775-005056c00008" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" bus2="_04845ac5-c766-11e1-8775-005056c00008" connectableBus2="_04845ac5-c766-11e1-8775-005056c00008" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.227253568130273" q1="11.752186078699305" p2="44.761281881533343" q2="-12.198454942953388">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_6be4027d-eae3-4d93-8b3a-bd3ecbefb0a1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_0501dacc-29fc-44a2-8cad-31a20b011d25" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" bus1="_0455a9a6-c766-11e1-8775-005056c00008" connectableBus1="_0455a9a6-c766-11e1-8775-005056c00008" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" bus2="_046c3ee8-c766-11e1-8775-005056c00008" connectableBus2="_046c3ee8-c766-11e1-8775-005056c00008" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="304.33511190967175" q1="98.939893899343019" p2="-295.50528026402071" q2="-87.601870938098699">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_0b8a340a-b8d4-4498-8223-9e70f54345ff" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_c95a66fd-913c-48c7-b8ef-cf3007c60af6" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" bus1="_04577e63-c766-11e1-8775-005056c00008" connectableBus1="_04577e63-c766-11e1-8775-005056c00008" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-89.123064984783269" q1="-8.9821757309860359" p2="96.491300872216129" q2="34.422729003037922">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_1aa29312-557e-4a5f-965c-219d32569822" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6cd83bc2-204f-44d5-afd4-fbfef8d2146f" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" bus1="_04876809-c766-11e1-8775-005056c00008" connectableBus1="_04876809-c766-11e1-8775-005056c00008" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" bus2="_044ef2e3-c766-11e1-8775-005056c00008" connectableBus2="_044ef2e3-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="10.510281254425962" q1="5.8087649802565098" p2="-10.487382065957354" q2="-7.0483927560012525">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_6a482321-ff03-47e5-8d69-0a211cec9016" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_487e1317-48f9-4747-b931-f3f79e95f55a" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" bus1="_047d2ed4-c766-11e1-8775-005056c00008" connectableBus1="_047d2ed4-c766-11e1-8775-005056c00008" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" bus2="_04814d88-c766-11e1-8775-005056c00008" connectableBus2="_04814d88-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-113.71761386883554" q1="8.7739395158135896" p2="114.0661527434917" q2="-8.4304291328541332">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_8f379d20-b516-4eec-b535-925586132d69" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3c55a929-a755-409b-af5f-bae188892af1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" bus1="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus1="_0449e9d4-c766-11e1-8775-005056c00008" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" bus2="_04689567-c766-11e1-8775-005056c00008" connectableBus2="_04689567-c766-11e1-8775-005056c00008" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-141.70664727846639" q1="-56.572483189532875" p2="145.42198083055231" q2="66.721568730869322">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_3e4b7d9a-4e85-4b10-9dba-a83fb76bf6b7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_9658628a-596f-41a9-96a7-c5a8aaf5400c" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" bus1="_04670ec8-c766-11e1-8775-005056c00008" connectableBus1="_04670ec8-c766-11e1-8775-005056c00008" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" bus2="_044e56a4-c766-11e1-8775-005056c00008" connectableBus2="_044e56a4-c766-11e1-8775-005056c00008" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="-35.021185435149071" q1="0.15134500222341307" p2="36.217881625411593" q2="-1.2778742902287477">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7d1b5b44-e965-446d-b0a2-2abd8f995343" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b69ab61b-751d-487a-a538-2d47eea7572e" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" bus1="_045645e7-c766-11e1-8775-005056c00008" connectableBus1="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" bus2="_047d2ed4-c766-11e1-8775-005056c00008" connectableBus2="_047d2ed4-c766-11e1-8775-005056c00008" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-41.772103994932351" q1="3.1389751008837399" p2="42.350262859856265" q2="-4.1727301637590939">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_37b8abba-f482-471a-a82d-65606ca1d4d5" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_a38d4859-b54a-482f-a2ad-0b4ce4c4da2a" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" bus1="_0474071a-c766-11e1-8775-005056c00008" connectableBus1="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" bus2="_04670ec8-c766-11e1-8775-005056c00008" connectableBus2="_04670ec8-c766-11e1-8775-005056c00008" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="-23.137333679345112" q1="20.475257606520945" p2="23.285640211822358" q2="-20.776429818140947">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_beec41ff-5166-438d-8178-950089f889c8" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_15d16bd2-d87c-4584-93d2-b294dc1be116" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" bus1="_048433b2-c766-11e1-8775-005056c00008" connectableBus1="_048433b2-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" bus2="_04675ce9-c766-11e1-8775-005056c00008" connectableBus2="_04675ce9-c766-11e1-8775-005056c00008" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="5.1426465952336633" q1="-16.465340972297085" p2="-5.0689197225347771" q2="14.720250643228979">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ff16ab37-609f-4d89-97e0-8f4fd8cfa2e3" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_7d2a67fb-9d8c-4745-a67e-ce6ade5e520e" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" bus1="_0461b794-c766-11e1-8775-005056c00008" connectableBus1="_0461b794-c766-11e1-8775-005056c00008" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" bus2="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus2="_0449e9d4-c766-11e1-8775-005056c00008" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-70.914713903038034" q1="-16.088705652393742" p2="73.026144360358899" q2="22.255643944178097">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_55a45a23-6031-4a23-956f-992afb08c743" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6477d99a-dd64-4083-8f56-1396610879f0" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" bus1="_046a9133-c766-11e1-8775-005056c00008" connectableBus1="_046a9133-c766-11e1-8775-005056c00008" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" bus2="_045f1f84-c766-11e1-8775-005056c00008" connectableBus2="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-61.683197012694279" q1="16.639511761617669" p2="63.54563026989544" q2="-13.571400438113207">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ad873b1b-014a-4c65-b7cd-22ebb86236bc" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_38cb3e5b-af1a-4684-aa2f-242826ed460c" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" bus1="_0476c631-c766-11e1-8775-005056c00008" connectableBus1="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" bus2="_04723255-c766-11e1-8775-005056c00008" connectableBus2="_04723255-c766-11e1-8775-005056c00008" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-15.179110858859223" q1="-3.5918159132212897" p2="15.312291317601037" q2="0.66394857326956547">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_55a3f358-a56b-467d-96f8-1bfbe09799dc" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_9066b19a-f404-42c3-88ce-51d375f6fdb5" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" bus1="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" bus2="_048433b2-c766-11e1-8775-005056c00008" connectableBus2="_048433b2-c766-11e1-8775-005056c00008" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.973340316165491" q1="9.2658748621982205" p2="-58.055670749110668" q2="-7.3936222652301726">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_d228fae3-2cfd-42c2-85bf-6ed2417949ef" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_924b4a0b-bef5-432a-ad87-ab5c10d9c019" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" bus1="_04499bb3-c766-11e1-8775-005056c00008" connectableBus1="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" bus2="_04716f04-c766-11e1-8775-005056c00008" connectableBus2="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-24.871337118585959" q1="9.9040229214590862" p2="25.223198478483177" q2="-12.020755479048953">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_30aabccf-8ec8-46a2-a3a1-ba354c62f10a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_d432d118-553c-4f4c-a734-e98e0762ec40" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" bus1="_044a5f04-c766-11e1-8775-005056c00008" connectableBus1="_044a5f04-c766-11e1-8775-005056c00008" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" bus2="_047c9297-c766-11e1-8775-005056c00008" connectableBus2="_047c9297-c766-11e1-8775-005056c00008" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="32.123031948273464" q1="10.321089704202974" p2="-31.567281979577139" q2="-11.978740120157189">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_aff34ffe-0ef8-42ff-99bd-8e286c8073a8" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2f32bda4-7275-4485-9901-12f8cff9e4a1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" bus1="_047147f0-c766-11e1-8775-005056c00008" connectableBus1="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" bus2="_046b066a-c766-11e1-8775-005056c00008" connectableBus2="_046b066a-c766-11e1-8775-005056c00008" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="54.478901658653832" q1="-0.069166885776078546" p2="-54.057726084421034" q2="0.79334803230913797">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_3678bd5d-c47e-4eb0-8620-7f9e24a10618" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b3b0e81b-a434-4e9c-ad94-1161ff47b077" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" bus1="_04769f21-c766-11e1-8775-005056c00008" connectableBus1="_04769f21-c766-11e1-8775-005056c00008" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-36.72579059471682" q1="-7.8578444719394929" p2="37.446718299466554" q2="5.8466830565061825">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_4a915430-984f-4a53-9533-53efa325d9e5" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6db0d250-4a2e-4169-abf0-f842aeca485d" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" bus1="_044a8618-c766-11e1-8775-005056c00008" connectableBus1="_044a8618-c766-11e1-8775-005056c00008" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" bus2="_045fe2d7-c766-11e1-8775-005056c00008" connectableBus2="_045fe2d7-c766-11e1-8775-005056c00008" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-19.317755266359704" q1="-13.117433576366677" p2="19.52074433158354" q2="11.767292999383944">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ebd82352-16ad-454f-8920-32a110d327d1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_9f39cb45-314c-445e-b177-909854a9ce45" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" bus1="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus1="_0458b6e4-c766-11e1-8775-005056c00008" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" bus2="_047566a8-c766-11e1-8775-005056c00008" connectableBus2="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-6.5032753408317383" q1="-55.893325313108178" p2="6.7284498216984732" q2="56.212437783251133">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_c0261082-5d30-4965-882d-3c1719e82054" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_70fad3e1-4529-4a7f-9e6c-8ab249d65460" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" connectableBus1="_045163e5-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" connectableBus2="_044e7db1-c766-11e1-8775-005056c00008" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="0" q1="-0" p2="0" q2="0">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_0ea6e870-9b01-4226-80d3-5ff1a2f88c40" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_205e5d8a-f05a-479d-adaa-3514f48f6857" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" bus1="_0457f395-c766-11e1-8775-005056c00008" connectableBus1="_0457f395-c766-11e1-8775-005056c00008" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" bus2="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus2="_0458ddf2-c766-11e1-8775-005056c00008" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-154.17237074521364" q1="-68.785228874016852" p2="154.90281596597796" q2="39.387974655374371">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_09341906-df9b-4a95-a073-d9e12f3841be" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_8cee2b62-2953-439b-ba4b-4a48d55116c0" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" bus1="_04549837-c766-11e1-8775-005056c00008" connectableBus1="_04549837-c766-11e1-8775-005056c00008" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" bus2="_045b9d15-c766-11e1-8775-005056c00008" connectableBus2="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="19.220366620294111" q1="4.8402784270480836" p2="-19.208420320849147" q2="-5.4656471460967593">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_665fcc7f-38d1-4204-95fa-0c63c2a2ddc5" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_640627c7-0672-413e-8dc8-c9965709a5cb" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" bus1="_04716f02-c766-11e1-8775-005056c00008" connectableBus1="_04716f02-c766-11e1-8775-005056c00008" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" bus2="_045f1f84-c766-11e1-8775-005056c00008" connectableBus2="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-49.717506677028176" q1="12.896155111562003" p2="50.560354520728424" q2="-12.289230843816041">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_eeb51357-560f-40d7-89d7-4fdfd53a167f" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_8b888209-5038-4b98-80fc-062b5ea55747" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" bus1="_044e56a4-c766-11e1-8775-005056c00008" connectableBus1="_044e56a4-c766-11e1-8775-005056c00008" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" bus2="_0480d858-c766-11e1-8775-005056c00008" connectableBus2="_0480d858-c766-11e1-8775-005056c00008" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="29.614563323436499" q1="11.266727694357485" p2="-29.508057810739086" q2="-11.404658307485011">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_52f8cd12-1364-4ef3-ae3d-0285817f0354" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_c0a08025-3a61-4d24-9944-f3ef0b079f64" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" bus1="_04520021-c766-11e1-8775-005056c00008" connectableBus1="_04520021-c766-11e1-8775-005056c00008" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" bus2="_04499bb3-c766-11e1-8775-005056c00008" connectableBus2="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="-47.339381431714941" q1="5.6661791855013757" p2="47.39365415500334" q2="-5.1089968933125496">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_66b89c81-20ba-41de-82a2-f999d5085ebd" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_32793450-bbfd-4dcd-a911-89e199600780" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" bus1="_045f1f84-c766-11e1-8775-005056c00008" connectableBus1="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" bus2="_04689561-c766-11e1-8775-005056c00008" connectableBus2="_04689561-c766-11e1-8775-005056c00008" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="13.316269030644746" q1="-3.4364016543157487" p2="-13.250345546804773" q2="1.010077945749394">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_a9a5c23c-642d-4ae6-9eda-818565194dc7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2ec4bef5-7abb-4f52-bb62-49ee474d672b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" bus1="_04531195-c766-11e1-8775-005056c00008" connectableBus1="_04531195-c766-11e1-8775-005056c00008" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" bus2="_0476c631-c766-11e1-8775-005056c00008" connectableBus2="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-54.195821713202875" q1="13.737872963673551" p2="55.942498876883874" q2="-10.67785293275772">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_142dbec6-04c3-4fb9-becf-7e45d36725bc" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_9280074c-8555-49ff-9e62-8ed8f7d95060" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" bus1="_044b9787-c766-11e1-8775-005056c00008" connectableBus1="_044b9787-c766-11e1-8775-005056c00008" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" bus2="_04862f81-c766-11e1-8775-005056c00008" connectableBus2="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-32.821678548110441" q1="-18.592767254107152" p2="33.462705343636969" q2="15.42818467349294">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_c3ef7069-26cb-4184-bb94-4ac49df0603d" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ace48562-0a49-4b76-ae82-c896a00b04f9" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" bus1="_047ba835-c766-11e1-8775-005056c00008" connectableBus1="_047ba835-c766-11e1-8775-005056c00008" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" bus2="_04719616-c766-11e1-8775-005056c00008" connectableBus2="_04719616-c766-11e1-8775-005056c00008" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-76.958850814189418" q1="-20.558860397982258" p2="80.212887852126826" q2="27.989523783801605">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_bc06dfbb-eb99-4db7-8c9d-ec079e03009f" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3f744dba-88dc-4d89-90d4-a6f196054b28" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" bus1="_047d2ed4-c766-11e1-8775-005056c00008" connectableBus1="_047d2ed4-c766-11e1-8775-005056c00008" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" bus2="_044b9787-c766-11e1-8775-005056c00008" connectableBus2="_044b9787-c766-11e1-8775-005056c00008" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-6.633187981312644" q1="-7.6012438905537323" p2="6.6445729914634422" q2="6.1983489524110889">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7da82087-b318-404c-9514-65732f211e14" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_43f91aaf-c5f4-4995-85a2-37afac616331" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" bus1="_04483c26-c766-11e1-8775-005056c00008" connectableBus1="_04483c26-c766-11e1-8775-005056c00008" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" bus2="_046c8d0b-c766-11e1-8775-005056c00008" connectableBus2="_046c8d0b-c766-11e1-8775-005056c00008" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="42.067198280014829" q1="2.1701389500366264" p2="-41.677948538546808" q2="-2.2978399278948847">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_611015af-1467-451a-a0ba-6c093df0fde0" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2c20e8bd-84e6-4a1e-b88e-071f631327cb" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" bus1="_04725962-c766-11e1-8775-005056c00008" connectableBus1="_04725962-c766-11e1-8775-005056c00008" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" bus2="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus2="_0462a1f3-c766-11e1-8775-005056c00008" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-53.462412827856845" q1="-11.847059185719095" p2="54.733307754734675" q2="12.930011472981956">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7a4b30c3-e92f-4a39-aeff-e9554d8ce96e" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6ad31f7e-233f-4801-898f-9ffc883ec724" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" bus1="_04686e54-c766-11e1-8775-005056c00008" connectableBus1="_04686e54-c766-11e1-8775-005056c00008" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" bus2="_04670ec8-c766-11e1-8775-005056c00008" connectableBus2="_04670ec8-c766-11e1-8775-005056c00008" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="4.0673025751563179" q1="3.702156685107024" p2="-4.0624612174908803" q2="-4.5686880642315737">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_917c1ba3-4b76-4e83-a631-84a088996b57" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_a025c9d8-58f9-4320-a1fe-73ecc68d4147" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" bus1="_044e7db1-c766-11e1-8775-005056c00008" connectableBus1="_044e7db1-c766-11e1-8775-005056c00008" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" bus2="_047ba832-c766-11e1-8775-005056c00008" connectableBus2="_047ba832-c766-11e1-8775-005056c00008" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="0" q1="0" p2="0" q2="0">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_a0202601-e216-4568-ab78-b4fe21fd1fba" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b7fac0a3-c5af-48b9-af49-261fd8d46e00" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" bus1="_045f1f84-c766-11e1-8775-005056c00008" connectableBus1="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" bus2="_047a96c0-c766-11e1-8775-005056c00008" connectableBus2="_047a96c0-c766-11e1-8775-005056c00008" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-65.108893121607238" q1="10.853636402324726" p2="66.018287678120885" q2="-8.8874304566237772">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_1662e4d0-c8bc-4830-a853-01d4c6f3c737" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_51646744-d343-42b5-8ba7-fcedc7cc3a98" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" bus1="_044a8615-c766-11e1-8775-005056c00008" connectableBus1="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" bus2="_04719616-c766-11e1-8775-005056c00008" connectableBus2="_04719616-c766-11e1-8775-005056c00008" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="26.795074376611804" q1="22.625426358255002" p2="-26.358822554492097" q2="-31.945549540111401">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_2dd1be0d-4305-4e5a-af1e-424eda4251b7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_76311a15-b79a-4439-a7ce-47afa8fa6fe2" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" bus1="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus1="_0458b6e4-c766-11e1-8775-005056c00008" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" bus2="_045b4ef9-c766-11e1-8775-005056c00008" connectableBus2="_045b4ef9-c766-11e1-8775-005056c00008" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="3.2691082394943143" q1="24.248051608016436" p2="-3.0984439134550454" q2="-25.210161801862359">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7bf0d6eb-6015-4b67-b5f5-7e9417da9602" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_efbf8de7-4b84-4834-bb7c-6250b6072211" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" bus1="_04597a36-c766-11e1-8775-005056c00008" connectableBus1="_04597a36-c766-11e1-8775-005056c00008" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" bus2="_04876809-c766-11e1-8775-005056c00008" connectableBus2="_04876809-c766-11e1-8775-005056c00008" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="44.745216109299506" q1="12.296312192424006" p2="-43.586771454001401" q2="-12.759620481170709">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_77f8dc85-1e26-4f69-8f9d-2e85760a932b" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_22b6919a-a7a0-49fc-9e90-329069c55055" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" bus1="_04725962-c766-11e1-8775-005056c00008" connectableBus1="_04725962-c766-11e1-8775-005056c00008" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-66.944300710518846" q1="-4.0035629244253021" p2="70.232625753582539" q2="8.5419063566087381">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_3ad3799b-5f8c-4ba0-9e85-81d48157adf6" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_8b91f4fd-4038-45b7-870c-fbc08592b95a" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" bus1="_047a96c0-c766-11e1-8775-005056c00008" connectableBus1="_047a96c0-c766-11e1-8775-005056c00008" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" bus2="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus2="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-113.99360695738063" q1="-1.1040001543574318" p2="115.85368538298067" q2="8.7161750450379376">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_6dd129f4-2730-4d27-b5dd-b91c16fc6588" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_970bc323-73bf-440d-a3c5-00aebc3a1992" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" bus1="_04898ae9-c766-11e1-8775-005056c00008" connectableBus1="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" bus2="_044b7076-c766-11e1-8775-005056c00008" connectableBus2="_044b7076-c766-11e1-8775-005056c00008" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="4.0496106885924466" q1="13.789687564887371" p2="-3.9942467044620815" q2="-16.582111721587612">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_70ad4f3f-a659-48e9-8383-8ac70b8bce31" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_cb084dc7-1b26-415f-9495-4695df661912" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" bus1="_04675ce9-c766-11e1-8775-005056c00008" connectableBus1="_04675ce9-c766-11e1-8775-005056c00008" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" bus2="_04502b6a-c766-11e1-8775-005056c00008" connectableBus2="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-4.9278172328023668" q1="-14.720251400244443" p2="5.009315957888445" q2="11.852585173285361">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_a688473b-de97-456e-afb7-e65c079e3b34" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3a165a76-f6ba-461b-84d6-159a5e0b5077" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" bus1="_04684743-c766-11e1-8775-005056c00008" connectableBus1="_04684743-c766-11e1-8775-005056c00008" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" bus2="_047566a8-c766-11e1-8775-005056c00008" connectableBus2="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-15.124657078376281" q1="-23.416235678172693" p2="15.203136806700849" q2="22.988046026768579">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_bed061b3-3663-40ad-956f-90cda64cbaab" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b19bc945-cc51-4d77-8eaa-3f6afe2d9316" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" bus1="_048c4a07-c766-11e1-8775-005056c00008" connectableBus1="_048c4a07-c766-11e1-8775-005056c00008" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" bus2="_0468bc75-c766-11e1-8775-005056c00008" connectableBus2="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-47.454503638099268" q1="13.960684053719893" p2="47.883607425976372" q2="-14.262885152921978">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_1bb497d6-1d54-49c9-bdd5-c8634a07cfb5" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_a9e283ed-fcad-4f4c-ab57-8531875bb098" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" bus1="_046f9a47-c766-11e1-8775-005056c00008" connectableBus1="_046f9a47-c766-11e1-8775-005056c00008" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" bus2="_044fdd40-c766-11e1-8775-005056c00008" connectableBus2="_044fdd40-c766-11e1-8775-005056c00008" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-1.0645986309095825" q1="-1.006870168947815" p2="1.0646502839489358" q2="0.77072249864040077">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_683d7e84-46ea-46ad-9327-754235536ac4" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_c59e4022-b1c0-4811-a32e-f54656bff32d" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" bus1="_046a9133-c766-11e1-8775-005056c00008" connectableBus1="_046a9133-c766-11e1-8775-005056c00008" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" bus2="_04716f02-c766-11e1-8775-005056c00008" connectableBus2="_04716f02-c766-11e1-8775-005056c00008" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-37.515289920789918" q1="19.988936045817653" p2="38.730087437778842" q2="-19.882817207839455">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_204653d4-8c5b-43bc-9283-a2a842f366a9" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_1268eb09-e233-44ce-b8af-22dc30eb16ad" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" bus1="_047e4045-c766-11e1-8775-005056c00008" connectableBus1="_047e4045-c766-11e1-8775-005056c00008" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" bus2="_0474071a-c766-11e1-8775-005056c00008" connectableBus2="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="-30.828035550438244" q1="20.730476932024949" p2="31.881735909752663" q2="-21.333926669908397">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ff77fc37-c585-41b5-90d2-a44430227501" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_9c0c454b-ecc3-40f6-b505-f32fec412522" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" bus1="_04898ae9-c766-11e1-8775-005056c00008" connectableBus1="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" bus2="_0479fa80-c766-11e1-8775-005056c00008" connectableBus2="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-0.31879931669043859" q1="27.437360074149186" p2="0.61721529139593767" q2="-30.991833611010332">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_d63c0548-9f5e-4d60-bae2-0566a6473e46" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_1432f4d6-9299-4b0d-bd7f-16e059f9de66" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" bus1="_045b9d15-c766-11e1-8775-005056c00008" connectableBus1="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-31.338814520506169" q1="-3.0762602933298195" p2="32.205829575227071" q2="0.61783035384478802">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_08a97648-23dd-422a-a403-bdb89143a421" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_193f6952-4267-4cc8-a541-726c095028ba" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" bus1="_04502b6a-c766-11e1-8775-005056c00008" connectableBus1="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" bus2="_0468bc75-c766-11e1-8775-005056c00008" connectableBus2="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.976955065938391" q1="-17.395443139809391" p2="-35.920566956869614" q2="17.454837075804054">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_07757788-2dda-494c-9038-c1d010214558" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_579249ce-1c81-4d29-8d3f-5fc627a18f99" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" bus1="_046bf0cb-c766-11e1-8775-005056c00008" connectableBus1="_046bf0cb-c766-11e1-8775-005056c00008" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" bus2="_047c4478-c766-11e1-8775-005056c00008" connectableBus2="_047c4478-c766-11e1-8775-005056c00008" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-49.018217029010536" q1="-0.2773952930523127" p2="50.778179940947155" q2="2.1299519250869317">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f1be8c91-71cf-4d95-bcee-a6e3c19c9a0a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3d2cb4b5-ee82-4866-9855-4a5f4803cd3b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" bus1="_046c17da-c766-11e1-8775-005056c00008" connectableBus1="_046c17da-c766-11e1-8775-005056c00008" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" bus2="_04550d63-c766-11e1-8775-005056c00008" connectableBus2="_04550d63-c766-11e1-8775-005056c00008" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.340002138871382" q1="-2.8302470713353234" p2="-12.29268475773207" q2="1.1135563340026582">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_4895e133-ecd4-4a69-b358-c2d8d11bd39d" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6fc48d8d-05f8-4104-a6a2-3686d430a091" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" bus1="_044aad28-c766-11e1-8775-005056c00008" connectableBus1="_044aad28-c766-11e1-8775-005056c00008" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" bus2="_0453d4e3-c766-11e1-8775-005056c00008" connectableBus2="_0453d4e3-c766-11e1-8775-005056c00008" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-154.21155671881806" q1="-3.4774698491033442" p2="154.65263799190558" q2="-71.67153141408707">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_4428a1f2-00f5-474c-b891-600c8f530e1f" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_191836a1-39cd-402b-8dcf-4f3867c45bd0" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" bus1="_045f1f84-c766-11e1-8775-005056c00008" connectableBus1="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" bus2="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus2="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-86.295346834855096" q1="3.4621590711448547" p2="88.147912359912254" q2="5.3064051894178235">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_4d831a76-7147-4776-a08a-9b166d2dcc7d" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_66cbdeeb-a4e4-4bfc-aec1-9fb7a2d2b6bc" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" bus1="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" bus2="_048433b2-c766-11e1-8775-005056c00008" connectableBus2="_048433b2-c766-11e1-8775-005056c00008" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="113.24574998493108" q1="21.273250268738682" p2="-110.05673528240894" q2="-18.128028634491201">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_2eff6ba2-5d90-4d71-bcc6-a0c31c1d028d" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_8489e809-6588-4ed2-a9a4-43c44a0d47da" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" bus1="_044b7076-c766-11e1-8775-005056c00008" connectableBus1="_044b7076-c766-11e1-8775-005056c00008" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" bus2="_0468bc75-c766-11e1-8775-005056c00008" connectableBus2="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-30.00271335667254" q1="8.5833052333357269" p2="30.390605010417389" q2="-11.787438790509466">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_a27844ae-f43e-4dea-82b7-bbfa8265a2d2" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_620beaaf-63c8-4020-bea5-c3609c0eaadf" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" bus1="_046c8d0b-c766-11e1-8775-005056c00008" connectableBus1="_046c8d0b-c766-11e1-8775-005056c00008" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" bus2="_04885267-c766-11e1-8775-005056c00008" connectableBus2="_04885267-c766-11e1-8775-005056c00008" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="24.895071715124487" q1="-4.5536268730897032" p2="-24.71973174252221" q2="3.2225713824724402">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" bus1="_0471bd2a-c766-11e1-8775-005056c00008" connectableBus1="_0471bd2a-c766-11e1-8775-005056c00008" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" bus2="_047147f0-c766-11e1-8775-005056c00008" connectableBus2="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-49.48811694072392" q1="-8.4331815109386721" p2="50.246553006961591" q2="9.5119588245207218">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_751f81c5-bc0f-47d9-8bf1-215d33c20a33" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_828ca44c-560b-4f94-b825-21e237285fae" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" bus1="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus1="_044ea4c4-c766-11e1-8775-005056c00008" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" bus2="_0479fa80-c766-11e1-8775-005056c00008" connectableBus2="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-18.983956340047865" q1="-6.2208476107186748" p2="19.046625838621416" q2="1.1486814101200227">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_c0d073c0-9e3c-443a-898c-1b775bffd91a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_233b7735-85f4-4a6f-9d87-15129fe42ef5" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" bus1="_0451b206-c766-11e1-8775-005056c00008" connectableBus1="_0451b206-c766-11e1-8775-005056c00008" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" bus2="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus2="_0458ddf2-c766-11e1-8775-005056c00008" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-360.26667103500131" q1="-41.018407182125841" p2="375.21649393111352" q2="110.88507294293728">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_bbea6b5b-db2c-40f6-afef-3da510b3b212" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_990ce3c5-c90c-41b9-abee-fb803d9df3a5" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" bus1="_044ef2e3-c766-11e1-8775-005056c00008" connectableBus1="_044ef2e3-c766-11e1-8775-005056c00008" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" bus2="_0483be8a-c766-11e1-8775-005056c00008" connectableBus2="_0483be8a-c766-11e1-8775-005056c00008" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.727736248333617" q1="-0.64779713141416539" p2="-23.402707964663598" q2="-2.5138053885043758">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_9bb71092-9fe9-497f-9296-4a8b4d9b2bf6" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_1372c3b0-62d7-47d7-a8c0-ed8e10bc1f1a" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" bus1="_04483c26-c766-11e1-8775-005056c00008" connectableBus1="_04483c26-c766-11e1-8775-005056c00008" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" bus2="_044fdd40-c766-11e1-8775-005056c00008" connectableBus2="_044fdd40-c766-11e1-8775-005056c00008" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="22.897986755826487" q1="6.4076197700998998" p2="-22.789744064140656" q2="-7.6253603580930456">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_e8ff318f-6a55-4c01-9fcf-9cfe688188ce" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_64cfd0fb-1d8e-45d2-a52f-469238dfc0c6" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" bus1="_047566a8-c766-11e1-8775-005056c00008" connectableBus1="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" bus2="_047e4045-c766-11e1-8775-005056c00008" connectableBus2="_047e4045-c766-11e1-8775-005056c00008" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="-16.971988249727673" q1="20.785739558644114" p2="17.161694262704959" q2="-21.690875804136439">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_cd9654e8-0619-442a-898e-2fc144b2abec" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_efe2501d-bcee-42ff-a037-3d8a280487b0" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" bus1="_047ba835-c766-11e1-8775-005056c00008" connectableBus1="_047ba835-c766-11e1-8775-005056c00008" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" bus2="_0479102a-c766-11e1-8775-005056c00008" connectableBus2="_0479102a-c766-11e1-8775-005056c00008" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="9.1713013778368033" q1="-15.253887285188208" p2="-9.1140257383985421" q2="14.272536931929622">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_9c2c041c-d52f-4062-836d-c76e124232b0" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2ae204bf-78cc-49cb-b886-a933b33057e4" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" bus1="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus1="_0486f2d6-c766-11e1-8775-005056c00008" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" bus2="_04716f04-c766-11e1-8775-005056c00008" connectableBus2="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-71.862923207779204" q1="-2.3206306889373001" p2="72.581167713051087" q2="3.7658856787282917">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_340906fe-83b3-451f-8724-1708b8dc630b" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_e822432e-79af-4bba-8f40-5250468f81a0" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" bus1="_0471bd2a-c766-11e1-8775-005056c00008" connectableBus1="_0471bd2a-c766-11e1-8775-005056c00008" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" bus2="_047566a8-c766-11e1-8775-005056c00008" connectableBus2="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-18.911105176033534" q1="-13.509153221185827" p2="19.21490787257423" q2="11.167087932157049">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_00e770fb-802e-479b-ae76-a52f5614bc15" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_c437e52c-43d7-4ae9-87ad-dc19396dc6ff" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_046a4314-c766-11e1-8775-005056c00008" connectableBus2="_046a4314-c766-11e1-8775-005056c00008" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="61.922464097893616" q1="21.398306470186846" p2="-59.899874348734642" q2="-19.093343652883714">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_3904e93a-ed7a-4222-9cbc-575270ef2037" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_90dcdbe1-437b-443f-b0b5-c2353f7c6954" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" bus1="_045868c7-c766-11e1-8775-005056c00008" connectableBus1="_045868c7-c766-11e1-8775-005056c00008" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" bus2="_04577e63-c766-11e1-8775-005056c00008" connectableBus2="_04577e63-c766-11e1-8775-005056c00008" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-36.277150214902612" q1="3.631511918220387" p2="37.276796841218804" q2="-3.878244212293759">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_b9ea0da8-57a8-46d3-bfa0-dc21a2f40ee7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_9b8510fa-bd0e-4e63-8f4c-0e5443a3eb63" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" bus1="_04675ce7-c766-11e1-8775-005056c00008" connectableBus1="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" bus2="_0453d4eb-c766-11e1-8775-005056c00008" connectableBus2="_0453d4eb-c766-11e1-8775-005056c00008" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="30.671405076026648" q1="-4.5495718931712155" p2="-29.994586873932334" q2="2.390759415203342">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7a4d98b5-2e0c-4af5-b1d0-c41bea482943" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_336bfd86-a922-4154-9e06-cd87382cdc5f" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" bus1="_046a4314-c766-11e1-8775-005056c00008" connectableBus1="_046a4314-c766-11e1-8775-005056c00008" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" bus2="_0467f927-c766-11e1-8775-005056c00008" connectableBus2="_0467f927-c766-11e1-8775-005056c00008" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="15.867248816134499" q1="4.4095139819713287" p2="-15.791133835477627" q2="-5.854066169388636">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_9c6f5c6b-1c48-486d-817d-544297fbef05" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2be10dec-f0ac-470d-83f7-a2a4e70f3491" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" bus1="_04885267-c766-11e1-8775-005056c00008" connectableBus1="_04885267-c766-11e1-8775-005056c00008" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" bus2="_04723255-c766-11e1-8775-005056c00008" connectableBus2="_04723255-c766-11e1-8775-005056c00008" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="1.0553675716725517" q1="-7.1295784722334163" p2="-1.0493922689441118" q2="6.4404676393053331">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ee57814f-f263-4a45-87db-86c93966cf99" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_f0e21213-6535-44a7-89b6-3063f8738d6b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" bus1="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus1="_0458ddf2-c766-11e1-8775-005056c00008" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" bus2="_044aad28-c766-11e1-8775-005056c00008" connectableBus2="_044aad28-c766-11e1-8775-005056c00008" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-133.42574629203514" q1="20.720075828154236" p2="133.70727380765445" q2="-81.489432683435453">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_be72c97f-9801-4b6e-acc0-fd79b256c7ab" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ab31cd46-6d0c-4d9c-95f1-396a45a237e1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_04549837-c766-11e1-8775-005056c00008" connectableBus2="_04549837-c766-11e1-8775-005056c00008" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="33.465981978620079" q1="13.741934238503074" p2="-32.472110600587222" q2="-17.049470840349855">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_c929168a-b558-48fa-aa86-314a35dd7d82" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_1bf78539-b6fa-4d8b-ba8e-9b5970019be6" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" bus1="_04499bb3-c766-11e1-8775-005056c00008" connectableBus1="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" bus2="_04878f11-c766-11e1-8775-005056c00008" connectableBus2="_04878f11-c766-11e1-8775-005056c00008" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="55.985269127706118" q1="-16.056642673408426" p2="-55.659414808316775" q2="16.564300639286639">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_173c0b25-4aa7-4c49-a38e-daf8ddd9b8b7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_08ff3ae4-d1dd-49f7-9eda-32ffc8eb0010" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" bus1="_04769f21-c766-11e1-8775-005056c00008" connectableBus1="_04769f21-c766-11e1-8775-005056c00008" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" bus2="_045b9d15-c766-11e1-8775-005056c00008" connectableBus2="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-19.590718203773616" q1="-9.9539207629472735" p2="19.616573088974175" q2="9.6945019547357507">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f19aeba4-5612-451d-a2d5-8f8415f42907" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_94316214-afd8-4c0d-bca4-916acb92af85" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" bus1="_045ef874-c766-11e1-8775-005056c00008" connectableBus1="_045ef874-c766-11e1-8775-005056c00008" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" bus2="_048b86b5-c766-11e1-8775-005056c00008" connectableBus2="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-32.893210543242958" q1="-13.30547238455822" p2="33.061208303114114" q2="12.976710538373959">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_a9ea718f-3a70-4590-bdc8-a638045c7097" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_4ea6b532-d914-4b0c-97ee-9f02a14a40b3" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" bus1="_04555b87-c766-11e1-8775-005056c00008" connectableBus1="_04555b87-c766-11e1-8775-005056c00008" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" bus2="_047147f0-c766-11e1-8775-005056c00008" connectableBus2="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-66.604613193500214" q1="-5.8639445558653911" p2="66.698781951846883" q2="6.1151453320133502">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7ecdb83b-300c-47f9-a746-141b4e88f5d1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2a95fb2b-6661-46e7-a9f6-fe63c1b7433c" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" bus1="_0474f17a-c766-11e1-8775-005056c00008" connectableBus1="_0474f17a-c766-11e1-8775-005056c00008" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" bus2="_045a1670-c766-11e1-8775-005056c00008" connectableBus2="_045a1670-c766-11e1-8775-005056c00008" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-45.906366822086" q1="-0.51418092899421508" p2="46.397698595703197" q2="1.0784121475761048">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_9c62dbd2-5c0b-4651-9a3e-60685bcfdf52" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_4b67f5f5-f0e1-4bfb-9d57-4d3474720a45" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" bus1="_046783f5-c766-11e1-8775-005056c00008" connectableBus1="_046783f5-c766-11e1-8775-005056c00008" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" bus2="_04876809-c766-11e1-8775-005056c00008" connectableBus2="_04876809-c766-11e1-8775-005056c00008" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="47.715218532119209" q1="0.96122406995961429" p2="-47.474769123689597" q2="-0.97065361808154094">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_d4cfc077-4796-4a02-b938-a43c0f88d615" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_1ca40dc7-6736-4fa8-b4cb-ca696949e421" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" bus1="_047c4478-c766-11e1-8775-005056c00008" connectableBus1="_047c4478-c766-11e1-8775-005056c00008" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" bus2="_04725962-c766-11e1-8775-005056c00008" connectableBus2="_04725962-c766-11e1-8775-005056c00008" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-66.607362361315026" q1="-0.99788932890272075" p2="67.712922751083426" q2="3.3931109506163351">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_9ba5e8b2-6a11-456a-aac4-3a733a324ddf" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ba738481-ddba-4ebe-a218-8aad0b537f5b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" bus1="_04555b87-c766-11e1-8775-005056c00008" connectableBus1="_04555b87-c766-11e1-8775-005056c00008" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" bus2="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus2="_0458b6e4-c766-11e1-8775-005056c00008" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="28.717234340881092" q1="-5.5702898993470891" p2="-28.505042379760198" q2="4.8128187296650857">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_16d1fe69-1ba4-46ed-870c-952d884df26b" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b1d87c24-e527-4174-aa04-cd0b9de271ea" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" bus1="_04502b6a-c766-11e1-8775-005056c00008" connectableBus1="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" bus2="_04667289-c766-11e1-8775-005056c00008" connectableBus2="_04667289-c766-11e1-8775-005056c00008" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="73.652926197969109" q1="-13.231113672428723" p2="-72.183313184150848" q2="15.942770505970655">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_341ddbb0-3a2a-4eb9-bc29-2e0f7900c00a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_4e1daf8e-7708-4b96-8d3f-67f58f2505f9" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" bus1="_04577e63-c766-11e1-8775-005056c00008" connectableBus1="_04577e63-c766-11e1-8775-005056c00008" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-89.123064984783269" q1="-8.9821757309860359" p2="96.491300872216129" q2="34.422729003037922">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_9f7663d9-452e-4006-88ac-295dc5108fe7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_c58940cb-bd36-4dfc-9615-11716dd652a7" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" bus1="_044a8615-c766-11e1-8775-005056c00008" connectableBus1="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" bus2="_04716f04-c766-11e1-8775-005056c00008" connectableBus2="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="119.21677150218024" q1="31.731683686263956" p2="-113.28665924278228" q2="-26.122119058007826">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f2cd1019-50d4-4961-a413-a74f33221b99" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3c9a454c-10ee-4c72-a059-77f723f5b7c7" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" bus1="_0447ee09-c766-11e1-8775-005056c00008" connectableBus1="_0447ee09-c766-11e1-8775-005056c00008" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" bus2="_04898ae9-c766-11e1-8775-005056c00008" connectableBus2="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-72.782785065086429" q1="-33.393023742539867" p2="73.763679717738597" q2="35.864040492903385">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7452c739-95b4-4967-9703-6790355cb281" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_270a7d04-9ff9-4178-8b72-b610735a72ac" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" bus1="_046a4314-c766-11e1-8775-005056c00008" connectableBus1="_046a4314-c766-11e1-8775-005056c00008" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" bus2="_048c22f1-c766-11e1-8775-005056c00008" connectableBus2="_048c22f1-c766-11e1-8775-005056c00008" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="27.03068874117087" q1="6.682310558985308" p2="-26.860494576350614" q2="-7.4820841913054821">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_701af727-7df8-4c87-9615-f7ade9c35e3a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_9d1eb182-ceb5-426e-9440-5f4d426a31cb" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" bus1="_04494d93-c766-11e1-8775-005056c00008" connectableBus1="_04494d93-c766-11e1-8775-005056c00008" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" bus2="_04549837-c766-11e1-8775-005056c00008" connectableBus2="_04549837-c766-11e1-8775-005056c00008" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-14.186211600878233" q1="-5.0177232635012183" p2="14.249198030877297" q2="2.508499164657898">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7f361a6a-3949-46c7-a8dd-e212dd07dfcc" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_735ac8df-6a6a-43f0-86f2-49d3280c9a3b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" bus1="_04549837-c766-11e1-8775-005056c00008" connectableBus1="_04549837-c766-11e1-8775-005056c00008" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" bus2="_04769f21-c766-11e1-8775-005056c00008" connectableBus2="_04769f21-c766-11e1-8775-005056c00008" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="6.6942938825255442" q1="2.3964745642602412" p2="-6.6839502969736646" q2="-4.1885019652090101">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_83d1a365-5ebd-48e1-b477-f4bdcb1c880b" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_52aadf8d-53f2-4827-8c70-421bdf1ba822" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" bus1="_04898ae9-c766-11e1-8775-005056c00008" connectableBus1="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" bus2="_04667284-c766-11e1-8775-005056c00008" connectableBus2="_04667284-c766-11e1-8775-005056c00008" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="7.2025401160942968" q1="32.003440442690803" p2="-7.0052761797801937" q2="-33.662613388674423">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_77813798-83ae-4088-a129-0c46810ef5f1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_fece5807-6af8-4161-8de8-8f8473d92f11" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" bus1="_04597a36-c766-11e1-8775-005056c00008" connectableBus1="_04597a36-c766-11e1-8775-005056c00008" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" bus2="_04550d63-c766-11e1-8775-005056c00008" connectableBus2="_04550d63-c766-11e1-8775-005056c00008" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="58.163919573996203" q1="18.442030147823001" p2="-56.70298812256285" q2="-16.114798166288281">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_07a99745-5437-4372-a0a7-3b4704c6e20c" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3eacc034-737e-41de-a7b6-b610d3bd0921" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" bus1="_045b9d15-c766-11e1-8775-005056c00008" connectableBus1="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" bus2="_0467f927-c766-11e1-8775-005056c00008" connectableBus2="_0467f927-c766-11e1-8775-005056c00008" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-3.7790073761938361" q1="-5.0366268003341252" p2="3.7902283559910233" q2="2.8536888755197767">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_5e786d5a-d8b0-4e68-8b0e-80418c4a25da" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_0d0c3ec5-798a-48a4-9bc8-d19c57128a13" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" bus1="_0474071a-c766-11e1-8775-005056c00008" connectableBus1="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" bus2="_045e0e10-c766-11e1-8775-005056c00008" connectableBus2="_045e0e10-c766-11e1-8775-005056c00008" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="-27.394094339428747" q1="6.5878219685541568" p2="27.786810076823549" q2="-7.8164461845613502">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_92371c95-ca5e-4604-96b0-3ee21aa98f9b" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_5b0395f4-534d-4975-a1af-e0b6ef439193" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" bus1="_045ef874-c766-11e1-8775-005056c00008" connectableBus1="_045ef874-c766-11e1-8775-005056c00008" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" bus2="_0480d858-c766-11e1-8775-005056c00008" connectableBus2="_0480d858-c766-11e1-8775-005056c00008" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="0.71761603900292026" q1="4.6773021782216677" p2="-0.71697233058483079" q2="-4.8927054831547423">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7100ff8d-0038-4fea-b382-1114fdbbbb80" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_74c4b341-7b99-4a81-b88a-2ed3b0c4b1de" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0475dbd8-c766-11e1-8775-005056c00008" name="63-64" r="0.83248" x="9.6799990000000005" g1="0" b1="0.00022314049999999999" g2="0" b2="0.00022314049999999999" bus1="_047f2aa7-c766-11e1-8775-005056c00008" connectableBus1="_047f2aa7-c766-11e1-8775-005056c00008" voltageLevelId1="_04854527-c766-11e1-8775-005056c00008" bus2="_0457f395-c766-11e1-8775-005056c00008" connectableBus2="_0457f395-c766-11e1-8775-005056c00008" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-140.46576506158505" q1="-68.53183897554706" p2="140.88933267103064" q2="52.845953231698005">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_eb59d486-fc89-4f4e-9fa7-ec08a3c9cf64" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ae4eadea-f3fc-4ac6-8899-c1698ece7a89" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" bus1="_048b86b5-c766-11e1-8775-005056c00008" connectableBus1="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" bus2="_045868c7-c766-11e1-8775-005056c00008" connectableBus2="_045868c7-c766-11e1-8775-005056c00008" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="18.44667042746461" q1="19.047019598661556" p2="-17.898045523674206" q2="-20.81531741950748">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7c0938b3-2f8c-437c-8ed9-3d743f305160" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_e98d56fe-a54b-45e4-acff-0ac310beb3dd" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" bus1="_044b7072-c766-11e1-8775-005056c00008" connectableBus1="_044b7072-c766-11e1-8775-005056c00008" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-39.419474317704776" q1="4.58190767985083" p2="39.691286805072316" q2="-5.1309255185197244">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_472d8096-6f57-454e-a3d8-3f306b4f4f27" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_f2e58700-2366-46e0-8408-9472d85acd23" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" bus1="_045b9d15-c766-11e1-8775-005056c00008" connectableBus1="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-29.901148527047873" q1="-3.393785146953729" p2="30.712316060564444" q2="0.51250734254537844">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_3b9aa0d5-4cdd-4527-91e2-89d797598afe" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_89654167-95a6-4c76-aad7-63a881116e17" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" bus1="_045c8773-c766-11e1-8775-005056c00008" connectableBus1="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" bus2="_0468bc75-c766-11e1-8775-005056c00008" connectableBus2="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-13.970678615398624" q1="-50.409760058133735" p2="14.418476644394341" q2="45.805882680766977">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_45d8a8d9-59e4-412f-8e4e-ac26b87c52b6" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_216c0f3b-03e8-4b7d-96fc-a5f891331f7f" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_04862f81-c766-11e1-8775-005056c00008" connectableBus2="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-137.80221628197825" q1="6.1131293279919756" p2="141.06503632589457" q2="7.8755043840298899">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_1451f44e-543d-4c6f-b201-d7a52943238a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_32655e4f-e7da-46b0-a908-b601224ddb73" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" bus1="_045a1670-c766-11e1-8775-005056c00008" connectableBus1="_045a1670-c766-11e1-8775-005056c00008" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" bus2="_0461b794-c766-11e1-8775-005056c00008" connectableBus2="_0461b794-c766-11e1-8775-005056c00008" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-60.117802657135158" q1="-8.8134407106625936" p2="61.074153397941124" q2="11.220971425916121">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_a4ca519a-5dee-49fc-9d34-d25e4d3e0430" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_bafaeace-e459-4dc2-87a0-467a9ea25f8d" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+</iidm:network>

--- a/dynaflow/src/test/resources/SmallBusBranch/dynaflow-outputs/contingency1-outputIIDM.xml
+++ b/dynaflow/src/test/resources/SmallBusBranch/dynaflow-outputs/contingency1-outputIIDM.xml
@@ -1,0 +1,2405 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_4" id="urn:uuid:2399cbd2-9a39-11e0-aa80-0800200c9a66_EU" caseDate="2030-01-02T09:00:00+00:00" forecastDistance="7993438" sourceFormat="CGMES">
+    <iidm:property name="CGMESModelDetail" value="bus-branch"/>
+    <iidm:substation id="_047c929a-c766-11e1-8775-005056c00008" name="Godrics Hollow" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0460f448-c766-11e1-8775-005056c00008" name="GOD132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045a1670-c766-11e1-8775-005056c00008" name="Jay" v="99.905017930938826" angle="-76.140206846957625"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" bus="_045a1670-c766-11e1-8775-005056c00008" connectableBus="_045a1670-c766-11e1-8775-005056c00008" p="11.76304351026495" q="5.985164618362278"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04819ba1-c766-11e1-8775-005056c00008" name="Nurmengard" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0476c639-c766-11e1-8775-005056c00008" name="NUR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04483c26-c766-11e1-8775-005056c00008" name="Madison" v="111.82744365733416" angle="-73.814727360096839"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" bus="_04483c26-c766-11e1-8775-005056c00008" connectableBus="_04483c26-c766-11e1-8775-005056c00008" p="59.300047043466755" q="12.070231498435579"/>
+            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" bus="_04483c26-c766-11e1-8775-005056c00008" connectableBus="_04483c26-c766-11e1-8775-005056c00008" p="8.6080713450193667" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04542302-c766-11e1-8775-005056c00008" name="Gringotts" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0450eeb4-c766-11e1-8775-005056c00008" name="GRI132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04549837-c766-11e1-8775-005056c00008" name="Torrey" v="126.06000000283255" angle="-15.489137414509708"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" bus="_04549837-c766-11e1-8775-005056c00008" connectableBus="_04549837-c766-11e1-8775-005056c00008" p="-54.340984149361894" q="-8.0416051810435807">
+                <iidm:property name="CGMES.GeneratingUnit" value="_b97aee41-3115-4cfd-9071-b52fb44d0b66"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_5005c073-28d1-4a7d-b257-649dec43ec73"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-30" maxQ="85"/>
+            </iidm:generator>
+            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" bus="_04549837-c766-11e1-8775-005056c00008" connectableBus="_04549837-c766-11e1-8775-005056c00008" p="113.00000000380864" q="32.000000001797588"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045de701-c766-11e1-8775-005056c00008" name="Needlehole" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04808a33-c766-11e1-8775-005056c00008" name="NEE132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047ba835-c766-11e1-8775-005056c00008" name="Darrah" v="117.52042144828899" angle="-8.9009550235159605"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" bus="_047ba835-c766-11e1-8775-005056c00008" connectableBus="_047ba835-c766-11e1-8775-005056c00008" p="66.803554436108328" q="34.950516444706551"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0472f5a8-c766-11e1-8775-005056c00008" name="Dale" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0467d214-c766-11e1-8775-005056c00008" name="DAL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04845ac5-c766-11e1-8775-005056c00008" name="Smythe" v="130.47007807599709" angle="9.3884011357970607"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" bus="_04845ac5-c766-11e1-8775-005056c00008" connectableBus="_04845ac5-c766-11e1-8775-005056c00008" p="4.9982706587905561" q="2.9982708581729529"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047a48a3-c766-11e1-8775-005056c00008" name="Hogsmeade" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047e675c-c766-11e1-8775-005056c00008" name="HOG132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045b9d15-c766-11e1-8775-005056c00008" name="Sunnysde" v="125.88411525429728" angle="-15.530234755325715"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" bus="_045b9d15-c766-11e1-8775-005056c00008" connectableBus="_045b9d15-c766-11e1-8775-005056c00008" p="83.987178429923119" q="17.995421100816433"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046f4c23-c766-11e1-8775-005056c00008" name="Barad-dûr" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047dcb11-c766-11e1-8775-005056c00008" name="BAR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0486f2d6-c766-11e1-8775-005056c00008" name="Bellefnt" v="115.83087851917665" angle="-12.571177763728805"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" bus="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus="_0486f2d6-c766-11e1-8775-005056c00008" p="66.001939415039431" q="25.690747351144527"/>
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" bus="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus="_0486f2d6-c766-11e1-8775-005056c00008" q="-9.2441699763632119">
+                <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
+                <iidm:shuntLinearModel bPerSection="0.00013779999999999999" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047a6fb6-c766-11e1-8775-005056c00008" name="Waymoot" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04740714-c766-11e1-8775-005056c00008" name="WAY132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04550d63-c766-11e1-8775-005056c00008" name="Fieldale" v="126.06519478236872" angle="-4.681662705477196"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" bus="_04550d63-c766-11e1-8775-005056c00008" connectableBus="_04550d63-c766-11e1-8775-005056c00008" p="39.000609769860418" q="30.000781760305586"/>
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" bus="_04550d63-c766-11e1-8775-005056c00008" connectableBus="_04550d63-c766-11e1-8775-005056c00008" q="-5.4669970674176991">
+                <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
+                <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0488eea9-c766-11e1-8775-005056c00008" name="Upbourn" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047147f4-c766-11e1-8775-005056c00008" name="UPB132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04862f81-c766-11e1-8775-005056c00008" name="Muskngum1" v="138.59999100975705" angle="-2.2421530570888666"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_047f0391-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="392" targetV="138.59999099999999" targetQ="0" bus="_04862f81-c766-11e1-8775-005056c00008" connectableBus="_04862f81-c766-11e1-8775-005056c00008" p="-400" q="-5.7298284212362205">
+                <iidm:property name="CGMES.GeneratingUnit" value="_d9948603-709f-41dd-a0ff-2ebda091255a"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_23727856-fd9b-4124-a981-4e862148f3bb"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
+            </iidm:generator>
+            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" bus="_04862f81-c766-11e1-8775-005056c00008" connectableBus="_04862f81-c766-11e1-8775-005056c00008" p="39.000000004118249" q="18.000000003167884"/>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_0463da78-c766-11e1-8775-005056c00008" name="UPB220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0458ddf2-c766-11e1-8775-005056c00008" name="Muskngum2" v="221.09999999999997" angle="0"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" bus="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus="_0458ddf2-c766-11e1-8775-005056c00008" p="-400" q="-121.10242882208824">
+                <iidm:property name="CGMES.GeneratingUnit" value="_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_12b01822-ca11-4cf8-a6b4-2f8ff805ca20"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus1="_0458ddf2-c766-11e1-8775-005056c00008" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" bus2="_04862f81-c766-11e1-8775-005056c00008" connectableBus2="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="119.33663009564617" q1="74.573220424092455" p2="-119.33663009564614" q2="-68.231449155583334">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0695187165775399"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.93896713615023475"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.88495575221238942"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.83682008368200833"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.79365079365079361"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.75471698113207553"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.71942446043165464"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.6872852233676976"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.65789473684210531"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.63091482649842268"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.60606060606060608"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.58309037900874627"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_069c77f0-1cf0-491a-ae17-8f71e0c7cc0b" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_a7b7f7b8-4ee3-45f5-ba3e-edb3678e0866" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_85b581c6-1005-4dc0-a758-ad5cfa9b05c4" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_981fee8c-aaa5-4946-b2d2-292bb3a4e7df" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_04773b6b-c766-11e1-8775-005056c00008" name="Fornost Erain" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046b2d70-c766-11e1-8775-005056c00008" name="FOR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0474f17a-c766-11e1-8775-005056c00008" name="Adams" v="97.363615087649436" angle="-80.918091344517151"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" bus="_0474f17a-c766-11e1-8775-005056c00008" connectableBus="_0474f17a-c766-11e1-8775-005056c00008" p="14.550511344560149" q="2.1044123379088395"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04887979-c766-11e1-8775-005056c00008" name="The Wall" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0475b4c0-c766-11e1-8775-005056c00008" name="THE132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04597a36-c766-11e1-8775-005056c00008" name="Claytor" v="133.31999200456107" angle="1.1394031586013413"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" bus="_04597a36-c766-11e1-8775-005056c00008" connectableBus="_04597a36-c766-11e1-8775-005056c00008" p="-52.681968298723781" q="-80.352682780410419">
+                <iidm:property name="CGMES.GeneratingUnit" value="_e56da2eb-bb6a-4133-953c-40073c5bc5f4"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_d41be6b4-155e-4c8f-b46b-16b50c49f0f4"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
+            </iidm:generator>
+            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" bus="_04597a36-c766-11e1-8775-005056c00008" connectableBus="_04597a36-c766-11e1-8775-005056c00008" p="23.00000000118029" q="16.000000001368452"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04795e41-c766-11e1-8775-005056c00008" name="Havens of the Falas" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045d23b4-c766-11e1-8775-005056c00008" name="HAV132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04725962-c766-11e1-8775-005056c00008" name="N.Newark" v="114.67438346518996" angle="-22.969827005101905"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" bus="_04725962-c766-11e1-8775-005056c00008" connectableBus="_04725962-c766-11e1-8775-005056c00008" p="50.782150595801042" q="20.487142108264564"/>
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" bus="_04725962-c766-11e1-8775-005056c00008" connectableBus="_04725962-c766-11e1-8775-005056c00008" q="-7.5482229640717016">
+                <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
+                <iidm:shuntLinearModel bPerSection="0.0001148" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047e404a-c766-11e1-8775-005056c00008" name="Minas Anor" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048433b5-c766-11e1-8775-005056c00008" name="MNA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0472a783-c766-11e1-8775-005056c00008" name="Hillsbro" v="107.68447049732227" angle="-36.359167848577734"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" bus="_0472a783-c766-11e1-8775-005056c00008" connectableBus="_0472a783-c766-11e1-8775-005056c00008" p="11.209422364908352" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0449c2ca-c766-11e1-8775-005056c00008" name="Avallonë" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045e8349-c766-11e1-8775-005056c00008" name="AVA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046bf0cb-c766-11e1-8775-005056c00008" name="S.Kenton" v="86.367016928223151" angle="-59.502882722128362"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" bus="_046bf0cb-c766-11e1-8775-005056c00008" connectableBus="_046bf0cb-c766-11e1-8775-005056c00008" p="12.156403279838496" q="3.6390305085129895"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0468bc71-c766-11e1-8775-005056c00008" name="Vale of Arryn" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0484f70a-c766-11e1-8775-005056c00008" name="VLA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04689561-c766-11e1-8775-005056c00008" name="Hazard" v="129.33589856147555" angle="8.0493631432343999"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" bus="_04689561-c766-11e1-8775-005056c00008" connectableBus="_04689561-c766-11e1-8775-005056c00008" p="20.988093373777509" q="9.9905520826992209"/>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_04555b88-c766-11e1-8775-005056c00008" name="VALE33KV" nominalV="33" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04505279-c766-11e1-8775-005056c00008" name="Pinevlle" v="33.495000001052539" angle="8.6411386085332591"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_047fc6e6-c766-11e1-8775-005056c00008" name="Pinevlle SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="4" targetV="33.494999999999997" targetQ="0" bus="_04505279-c766-11e1-8775-005056c00008" connectableBus="_04505279-c766-11e1-8775-005056c00008" p="-7.1704920746809453" q="-16.265938585708753">
+                <iidm:property name="CGMES.GeneratingUnit" value="_9a6bdb3c-346d-4426-8127-5f6cbf0150b2"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_98f667da-02d1-4a31-b826-44314a1fbbfe"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" bus1="_04689561-c766-11e1-8775-005056c00008" connectableBus1="_04689561-c766-11e1-8775-005056c00008" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" bus2="_04505279-c766-11e1-8775-005056c00008" connectableBus2="_04505279-c766-11e1-8775-005056c00008" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="-7.0837499920026445" q1="-11.357600702897797" p2="7.1704920796898453" q2="16.265938584853217">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="31" loadTapChangingCapabilities="false">
+                <iidm:step r="-78.460970487743992" x="-78.460970487743992" g="364.27347129590328" b="364.27347129590328" rho="0.4641016"/>
+                <iidm:step r="-76.770985444658564" x="-76.770985444658564" g="330.49609255595948" b="330.49609255595948" rho="0.48196488000000004"/>
+                <iidm:step r="-75.017181047101431" x="-75.017181047101431" g="300.27508580410921" b="300.27508580410921" rho="0.49982816000000002"/>
+                <iidm:step r="-73.199557295072623" x="-73.199557295072623" g="273.1281647135425" b="273.1281647135425" rho="0.51769144000000011"/>
+                <iidm:step r="-71.318114188572153" x="-71.318114188572153" g="248.65210975826625" b="248.65210975826625" rho="0.53555472000000004"/>
+                <iidm:step r="-69.372851727600008" x="-69.372851727600008" g="226.50770848984379" b="226.50770848984379" rho="0.55341799999999997"/>
+                <iidm:step r="-67.363769912156158" x="-67.363769912156158" g="206.40793906293555" b="206.40793906293555" rho="0.57128128"/>
+                <iidm:step r="-65.290868742240633" x="-65.290868742240633" g="188.10862264852744" b="188.10862264852744" rho="0.58914456000000004"/>
+                <iidm:step r="-63.154148217853432" x="-63.154148217853432" g="171.40097232995538" b="171.40097232995538" rho="0.60700784000000008"/>
+                <iidm:step r="-60.953608338994556" x="-60.953608338994556" g="156.10561116167679" b="156.10561116167679" rho="0.62487112"/>
+                <iidm:step r="-58.689249105663997" x="-58.689249105663997" g="142.06773741726079" b="142.06773741726079" rho="0.64273440000000004"/>
+                <iidm:step r="-56.361070517861769" x="-56.361070517861769" g="129.15319231405709" b="129.15319231405709" rho="0.66059767999999996"/>
+                <iidm:step r="-53.969072575587838" x="-53.969072575587838" g="117.24524269951107" b="117.24524269951107" rho="0.67846096"/>
+                <iidm:step r="-51.51325527884223" x="-51.51325527884223" g="106.24193390397649" b="106.24193390397649" rho="0.69632424000000004"/>
+                <iidm:step r="-48.993618627624947" x="-48.993618627624947" g="96.053900138385018" b="96.053900138385018" rho="0.71418752000000008"/>
+                <iidm:step r="-46.410162621936003" x="-46.410162621936003" g="86.602544237115268" b="86.602544237115268" rho="0.7320508"/>
+                <iidm:step r="-43.762887261775354" x="-43.762887261775354" g="77.81851722275475" b="77.81851722275475" rho="0.74991407999999993"/>
+                <iidm:step r="-41.051792547143037" x="-41.051792547143037" g="69.640442552852292" b="69.640442552852292" rho="0.76777735999999996"/>
+                <iidm:step r="-38.276878478039045" x="-38.276878478039045" g="62.013841060226049" b="62.013841060226049" rho="0.78564064"/>
+                <iidm:step r="-35.438145054463355" x="-35.438145054463355" g="54.890221299184191" b="54.890221299184191" rho="0.80350392000000004"/>
+                <iidm:step r="-32.53559227641599" x="-32.53559227641599" g="48.2263068397802" b="48.2263068397802" rho="0.82136720000000008"/>
+                <iidm:step r="-29.569220143896956" x="-29.569220143896956" g="41.983377444222199" b="41.983377444222199" rho="0.83923048"/>
+                <iidm:step r="-26.53902865690624" x="-26.53902865690624" g="36.126705339843348" b="36.126705339843348" rho="0.85709376000000004"/>
+                <iidm:step r="-23.445017815443848" x="-23.445017815443848" g="30.625071218648301" b="30.625071218648301" rho="0.87495704000000007"/>
+                <iidm:step r="-20.287187619509762" x="-20.287187619509762" g="25.450347332714429" b="25.450347332714429" rho="0.89282032000000011"/>
+                <iidm:step r="-17.06553806910399" x="-17.06553806910399" g="20.577137262099331" b="20.577137262099331" rho="0.91068360000000004"/>
+                <iidm:step r="-13.780069164226571" x="-13.780069164226571" g="15.982463718828566" b="15.982463718828566" rho="0.92854687999999996"/>
+                <iidm:step r="-10.430780904877434" x="-10.430780904877434" g="11.645497203453271" b="11.645497203453271" rho="0.94641016"/>
+                <iidm:step r="-7.0176732910566368" x="-7.0176732910566368" g="7.5473195169912355" b="7.5473195169912355" rho="0.96427344000000004"/>
+                <iidm:step r="-3.5407463227641656" x="-3.5407463227641656" g="3.6707171036300279" b="3.6707171036300279" rho="0.98213671999999985"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="3.6045656772358381" x="3.6045656772358381" g="-3.4791571719583358" b="-3.4791571719583358" rho="1.01786328"/>
+                <iidm:step r="7.272950708943382" x="7.272950708943382" g="-6.7798551833225922" b="-6.7798551833225922" rho="1.0357265600000001"/>
+                <iidm:step r="11.005155095122543" x="11.005155095122543" g="-9.9140937064517427" b="-9.9140937064517427" rho="1.0535898399999999"/>
+                <iidm:step r="14.801178835773431" x="14.801178835773431" g="-12.892880531259154" b="-12.892880531259154" rho="1.0714531199999999"/>
+                <iidm:step r="18.661021930895984" x="18.661021930895984" g="-15.726328348801433" b="-15.726328348801433" rho="1.0893164"/>
+                <iidm:step r="22.584684380490238" x="22.584684380490238" g="-18.423740693731116" b="-18.423740693731116" rho="1.10717968"/>
+                <iidm:step r="26.572166184556178" x="26.572166184556178" g="-20.993688411566747" b="-20.993688411566747" rho="1.12504296"/>
+                <iidm:step r="30.623467343093779" x="30.623467343093779" g="-23.444077826121855" b="-23.444077826121855" rho="1.1429062400000001"/>
+                <iidm:step r="34.738587856103067" x="34.738587856103067" g="-25.782211620922489" b="-25.782211620922489" rho="1.1607695200000001"/>
+                <iidm:step r="38.917527723583987" x="38.917527723583987" g="-28.014843311220961" b="-28.014843311220961" rho="1.1786327999999999"/>
+                <iidm:step r="43.16028694553664" x="43.16028694553664" g="-30.148226066322692" b="-30.148226066322692" rho="1.19649608"/>
+                <iidm:step r="47.466865521960955" x="47.466865521960955" g="-32.188156542116317" b="-32.188156542116317" rho="1.21435936"/>
+                <iidm:step r="51.837263452856973" x="51.837263452856973" g="-34.140014298236885" b="-34.140014298236885" rho="1.23222264"/>
+                <iidm:step r="56.271480738224653" x="56.271480738224653" g="-36.0087973009527" b="-36.0087973009527" rho="1.2500859200000001"/>
+                <iidm:step r="60.769517378063973" x="60.769517378063973" g="-37.799153949786998" b="-37.799153949786998" rho="1.2679491999999999"/>
+                <iidm:step r="65.331373372375026" x="65.331373372375026" g="-39.515412011505823" b="-39.515412011505823" rho="1.2858124799999999"/>
+                <iidm:step r="69.957048721157761" x="69.957048721157761" g="-41.161604798123854" b="-41.161604798123854" rho="1.30367576"/>
+                <iidm:step r="74.646543424412172" x="74.646543424412172" g="-42.741494884907091" b="-42.741494884907091" rho="1.32153904"/>
+                <iidm:step r="79.399857482138245" x="79.399857482138245" g="-44.258595629064871" b="-44.258595629064871" rho="1.33940232"/>
+                <iidm:step r="84.216990894335964" x="84.216990894335964" g="-45.716190719151165" b="-45.716190719151165" rho="1.3572655999999998"/>
+                <iidm:step r="89.097943661005473" x="89.097943661005473" g="-47.11735195848069" b="-47.11735195848069" rho="1.3751288800000001"/>
+                <iidm:step r="94.04271578214653" x="94.04271578214653" g="-48.464955462553469" b="-48.464955462553469" rho="1.3929921599999999"/>
+                <iidm:step r="99.051307257759348" x="99.051307257759348" g="-49.761696430103783" b="-49.761696430103783" rho="1.41085544"/>
+                <iidm:step r="104.12371808784383" x="104.12371808784383" g="-51.010102629540867" b="-51.010102629540867" rho="1.42871872"/>
+                <iidm:step r="109.25994827240002" x="109.25994827240002" g="-52.212546726893493" b="-52.212546726893493" rho="1.446582"/>
+                <iidm:step r="114.45999781142788" x="114.45999781142788" g="-53.371257567609966" b="-53.371257567609966" rho="1.4644452800000001"/>
+                <iidm:step r="119.72386670492732" x="119.72386670492732" g="-54.488330512455207" b="-54.488330512455207" rho="1.4823085599999999"/>
+                <iidm:step r="125.05155495289854" x="125.05155495289854" g="-55.565736917068101" b="-55.565736917068101" rho="1.5001718399999999"/>
+                <iidm:step r="130.44306255534144" x="130.44306255534144" g="-56.605332835313817" b="-56.605332835313817" rho="1.51803512"/>
+                <iidm:step r="135.89838951225599" x="135.89838951225599" g="-57.608867018227542" b="-57.608867018227542" rho="1.5358984"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="2186">
+                <iidm:temporaryLimit name="_580d3b53-5508-4d8d-97cc-4ea463e0cdb9" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_a867e68a-58d1-49cb-955f-bb8e59cf2a11" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="8747">
+                <iidm:temporaryLimit name="_1a7f23f9-e2c0-46a6-a93c-687f2209e33d" acceptableDuration="900" value="10059"/>
+                <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_045beb3a-c766-11e1-8775-005056c00008" name="Minas Tirith" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048a9c58-c766-11e1-8775-005056c00008" name="MNT132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04555b87-c766-11e1-8775-005056c00008" name="NwCarlsl" v="102.20235174449152" angle="-94.140719154993718"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" bus="_04555b87-c766-11e1-8775-005056c00008" connectableBus="_04555b87-c766-11e1-8775-005056c00008" p="7.8242831402377995" q="0"/>
+            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" bus="_04555b87-c766-11e1-8775-005056c00008" connectableBus="_04555b87-c766-11e1-8775-005056c00008" p="26.08094380079266" q="9.5027942679391355"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047120e4-c766-11e1-8775-005056c00008" name="Bywater" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046c65f4-c766-11e1-8775-005056c00008" name="BYW132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046b7b91-c766-11e1-8775-005056c00008" name="Blaine" v="126.620353935352" angle="-3.6632099004043295"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" bus="_046b7b91-c766-11e1-8775-005056c00008" connectableBus="_046b7b91-c766-11e1-8775-005056c00008" p="2.0000381389275868" q="1.00003178264168"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0467f928-c766-11e1-8775-005056c00008" name="Tirion" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048bd4da-c766-11e1-8775-005056c00008" name="TIR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04667284-c766-11e1-8775-005056c00008" name="Sundial" v="133.10985257516575" angle="1.8537735001136455"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" bus="_04667284-c766-11e1-8775-005056c00008" connectableBus="_04667284-c766-11e1-8775-005056c00008" p="14.990454464482045" q="8.9904564894529884"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_048badc8-c766-11e1-8775-005056c00008" name="White Harbor" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0488c79a-c766-11e1-8775-005056c00008" name="WHI132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044a8618-c766-11e1-8775-005056c00008" name="Riversde" v="98.444179650244863" angle="-98.974523594192831"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" bus="_044a8618-c766-11e1-8775-005056c00008" connectableBus="_044a8618-c766-11e1-8775-005056c00008" p="41.914660918447346" q="19.469586706989912"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045e8345-c766-11e1-8775-005056c00008" name="Nobottle" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04773b6a-c766-11e1-8775-005056c00008" name="NOB132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0461b794-c766-11e1-8775-005056c00008" name="Randolph" v="104.99867022565479" angle="-70.079655414265602"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" bus="_0461b794-c766-11e1-8775-005056c00008" connectableBus="_0461b794-c766-11e1-8775-005056c00008" p="9.0528726904344818" q="4.2359161952663396"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0452c37a-c766-11e1-8775-005056c00008" name="Formenos" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0478c204-c766-11e1-8775-005056c00008" name="FRM132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0467f927-c766-11e1-8775-005056c00008" name="WNwPhil2" v="126.5250874446199" angle="-15.853943493590576"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" bus="_0467f927-c766-11e1-8775-005056c00008" connectableBus="_0467f927-c766-11e1-8775-005056c00008" p="11.992382113337202" q="2.9968265522735038"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046b0666-c766-11e1-8775-005056c00008" name="Vinyamar" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04479fe8-c766-11e1-8775-005056c00008" name="VIN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044ef2e3-c766-11e1-8775-005056c00008" name="Cloverdl" v="126.73410581339147" angle="-2.9542276992874599"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" bus="_044ef2e3-c766-11e1-8775-005056c00008" connectableBus="_044ef2e3-c766-11e1-8775-005056c00008" p="43.001131717670319" q="16.000701846572937"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046dec9b-c766-11e1-8775-005056c00008" name="Aldburg" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0483977a-c766-11e1-8775-005056c00008" name="ALD132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046783f5-c766-11e1-8775-005056c00008" name="Hancock" v="128.11544299721317" angle="-1.5662610563165653"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" bus="_046783f5-c766-11e1-8775-005056c00008" connectableBus="_046783f5-c766-11e1-8775-005056c00008" p="38.000417798574787" q="25.000458114151293"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04865696-c766-11e1-8775-005056c00008" name="Scary" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04544a15-c766-11e1-8775-005056c00008" name="SCA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047c4478-c766-11e1-8775-005056c00008" name="WMVernon" v="103.26745936707131" angle="-31.541818697125105"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" bus="_047c4478-c766-11e1-8775-005056c00008" connectableBus="_047c4478-c766-11e1-8775-005056c00008" p="14.127845469389497" q="6.5015450443602605"/>
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" bus="_047c4478-c766-11e1-8775-005056c00008" connectableBus="_047c4478-c766-11e1-8775-005056c00008" q="-6.121232526210461">
+                <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
+                <iidm:shuntLinearModel bPerSection="0.0001148" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046030f9-c766-11e1-8775-005056c00008" name="Winterfell" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044f4102-c766-11e1-8775-005056c00008" name="WIN220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047ba832-c766-11e1-8775-005056c00008" name="Breed" v="0" angle="0"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" connectableBus="_047ba832-c766-11e1-8775-005056c00008" p="-0" q="-0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_f26d4eb3-ebdb-4025-8080-f856ce656b42"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_7566f2a7-61eb-42fe-a59a-8276257fdbc6"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-225" maxQ="640"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04703680-c766-11e1-8775-005056c00008" name="Brithombar" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04542300-c766-11e1-8775-005056c00008" name="BRI132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046a4314-c766-11e1-8775-005056c00008" name="Newcmrst" v="127.53176286426" angle="-15.574969392542796"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" bus="_046a4314-c766-11e1-8775-005056c00008" connectableBus="_046a4314-c766-11e1-8775-005056c00008" p="16.982910309546686" q="7.9866008131800639"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0480b149-c766-11e1-8775-005056c00008" name="Nindamos" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04728079-c766-11e1-8775-005056c00008" name="NIN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04689567-c766-11e1-8775-005056c00008" name="TannrsCk1" v="138.60009543815451" angle="-58.407916424423711"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" bus="_04689567-c766-11e1-8775-005056c00008" connectableBus="_04689567-c766-11e1-8775-005056c00008" p="-251.70492074680948" q="-282.86952304151271">
+                <iidm:property name="CGMES.GeneratingUnit" value="_56975783-9739-40fc-8ec1-e1de8cb06c9a"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_b8449cd9-5a17-497e-bf04-70f728b0f9f2"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_044f8f2a-c766-11e1-8775-005056c00008" name="NIN220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0455a9a6-c766-11e1-8775-005056c00008" name="TannrsCk2" v="223.30016153524329" angle="-58.471629369224388"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" bus="_0455a9a6-c766-11e1-8775-005056c00008" connectableBus="_0455a9a6-c766-11e1-8775-005056c00008" p="-345.70492074680948" q="-293.10025965712379">
+                <iidm:property name="CGMES.GeneratingUnit" value="_05df66ba-3f64-40cb-8b18-c66d26c4e2c1"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_c1d29442-5f57-41d1-bb60-4b74b4994c20"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_0455a9a6-c766-11e1-8775-005056c00008" connectableBus1="_0455a9a6-c766-11e1-8775-005056c00008" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" bus2="_04689567-c766-11e1-8775-005056c00008" connectableBus2="_04689567-c766-11e1-8775-005056c00008" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-3.2316649223260079" q1="20.183712132423288" p2="3.2316649223261398" q2="-20.040931780275859">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0416666883680561"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.96153844304733771"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.92592589163237438"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.8928570950255128"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_ac81f7ca-04be-4b10-838b-fd5171e1b0f7" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_2a113652-9eee-4aa3-8fc5-b6ebccfafda5" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_f357d7c9-5bbd-4c6b-960a-7384577353db" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_42b6b196-1272-48c6-a627-914c00e3fe3e" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_04553470-c766-11e1-8775-005056c00008" name="Haysend" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0471bd23-c766-11e1-8775-005056c00008" name="HAY132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044a8615-c766-11e1-8775-005056c00008" name="Sporn1" v="136.62000002647142" angle="-0.018523603262438851"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" bus="_044a8615-c766-11e1-8775-005056c00008" connectableBus="_044a8615-c766-11e1-8775-005056c00008" p="-576.847280493619" q="-97.648286329435635">
+                <iidm:property name="CGMES.GeneratingUnit" value="_27799004-aa1e-4889-ba95-ee6fdae64895"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_827a9c80-183d-4e33-9e73-ef0aab3dfb13"/>
+                <iidm:property name="CGMES.normalPF" value="1.0"/>
+                <iidm:minMaxReactiveLimits minQ="-300" maxQ="850"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_0449e9d2-c766-11e1-8775-005056c00008" name="HAY220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044aad28-c766-11e1-8775-005056c00008" name="Sporn2" v="219.59935665110109" angle="-0.58357859157969871"/>
+            </iidm:busBreakerTopology>
+            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" bus="_044aad28-c766-11e1-8775-005056c00008" connectableBus="_044aad28-c766-11e1-8775-005056c00008" p="184.11568261075283" q="-14.962339386187567">
+                <iidm:currentLimits permanentLimit="1000">
+                    <iidm:temporaryLimit name="_7c27ab8a-8043-4a55-851d-72adb14d9f4d" acceptableDuration="900" value="1150"/>
+                    <iidm:temporaryLimit name="_f4458b8d-a0e1-4adc-977f-14a07b3c44e9" acceptableDuration="60" value="1400"/>
+                </iidm:currentLimits>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_044aad28-c766-11e1-8775-005056c00008" connectableBus1="_044aad28-c766-11e1-8775-005056c00008" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" bus2="_044a8615-c766-11e1-8775-005056c00008" connectableBus2="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-29.450755378381288" q1="94.123238104096757" p2="29.450755378381288" q2="-90.965572377205163">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0695187165775399"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.93896713615023475"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.88495575221238942"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.83682008368200833"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.79365079365079361"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.75471698113207553"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_836577b9-5365-40b9-8bb1-0c635896faab" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_4ff8ded8-043c-467c-9730-a5f583b4631d" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_10213be6-3bb3-4f54-9d8e-67a412744ad4" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_5e63ebf0-b379-4249-91a8-f8f8c88302e7" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_046fe861-c766-11e1-8775-005056c00008" name="Bree" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046bf0c5-c766-11e1-8775-005056c00008" name="BRE132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044b9787-c766-11e1-8775-005056c00008" name="Natrium" v="131.72515853602761" angle="-5.1647530413251497"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" bus="_044b9787-c766-11e1-8775-005056c00008" connectableBus="_044b9787-c766-11e1-8775-005056c00008" p="77.003179275354256" q="14.000963430033558"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047fedfa-c766-11e1-8775-005056c00008" name="Mithlond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0485e169-c766-11e1-8775-005056c00008" name="MIT132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0480d858-c766-11e1-8775-005056c00008" name="Sterling" v="88.798347665063943" angle="-79.374426241915373"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" bus="_0480d858-c766-11e1-8775-005056c00008" connectableBus="_0480d858-c766-11e1-8775-005056c00008" p="21.82628065875361" q="9.4728135785496779"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0460f447-c766-11e1-8775-005056c00008" name="Pincup" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045ed163-c766-11e1-8775-005056c00008" name="PIN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045c8773-c766-11e1-8775-005056c00008" name="Switchbk" v="130.22589364298267" angle="4.5755641098754749"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" bus="_045c8773-c766-11e1-8775-005056c00008" connectableBus="_045c8773-c766-11e1-8775-005056c00008" p="29.976725595538078" q="15.979316991042344"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0471e439-c766-11e1-8775-005056c00008" name="Casterly Rock" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04773b62-c766-11e1-8775-005056c00008" name="CAS132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044b7076-c766-11e1-8775-005056c00008" name="Bradley" v="135.07834917916068" angle="1.8051862291160665"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" bus="_044b7076-c766-11e1-8775-005056c00008" connectableBus="_044b7076-c766-11e1-8775-005056c00008" p="33.999302398565007" q="7.9997264326808137"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047cb9a6-c766-11e1-8775-005056c00008" name="Lannisport" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04819ba0-c766-11e1-8775-005056c00008" name="LAN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046c8d0b-c766-11e1-8775-005056c00008" name="Mullin" v="108.95990690495748" angle="-76.94707732702183"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" bus="_046c8d0b-c766-11e1-8775-005056c00008" connectableBus="_046c8d0b-c766-11e1-8775-005056c00008" p="16.157555580826937" q="6.4314554935712058"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0449c2c6-c766-11e1-8775-005056c00008" name="Armenelos" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04765109-c766-11e1-8775-005056c00008" name="ARM132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0468bc75-c766-11e1-8775-005056c00008" name="Glen Lyn" v="134.24398800517878" angle="4.4818342243246905"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" bus="_0468bc75-c766-11e1-8775-005056c00008" connectableBus="_0468bc75-c766-11e1-8775-005056c00008" p="-283.70492074680948" q="-83.357141477545767">
+                <iidm:property name="CGMES.GeneratingUnit" value="_e54b499b-436c-4b89-9803-b1d75e2fa364"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
+            </iidm:generator>
+            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" bus="_0468bc75-c766-11e1-8775-005056c00008" connectableBus="_0468bc75-c766-11e1-8775-005056c00008" p="37.000000002141029" q="18.000000001735973"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0474f171-c766-11e1-8775-005056c00008" name="Erebor" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044f6818-c766-11e1-8775-005056c00008" name="ERB132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046b066a-c766-11e1-8775-005056c00008" name="Kankakee" v="101.78131722944333" angle="-96.126595850561287"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" bus="_046b066a-c766-11e1-8775-005056c00008" connectableBus="_046b066a-c766-11e1-8775-005056c00008" p="44.927904081193141" q="17.242915753174664"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045fe2d2-c766-11e1-8775-005056c00008" name="Ollivanders" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0465611a-c766-11e1-8775-005056c00008" name="OLL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04876809-c766-11e1-8775-005056c00008" name="Roanoke" v="127.42070622521933" angle="-2.6660916513116413"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" bus="_04876809-c766-11e1-8775-005056c00008" connectableBus="_04876809-c766-11e1-8775-005056c00008" p="31.00029128340282" q="26.000407171623319"/>
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" bus="_04876809-c766-11e1-8775-005056c00008" connectableBus="_04876809-c766-11e1-8775-005056c00008" q="-18.638969758423833">
+                <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
+                <iidm:shuntLinearModel bPerSection="0.0002296" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046cdb28-c766-11e1-8775-005056c00008" name="Pelargir" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048719e8-c766-11e1-8775-005056c00008" name="PEL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04577e63-c766-11e1-8775-005056c00008" name="Howard" v="88.186553219242271" angle="-46.09577716199545"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" bus="_04577e63-c766-11e1-8775-005056c00008" connectableBus="_04577e63-c766-11e1-8775-005056c00008" p="25.781963630070887" q="12.596550002041662"/>
+            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" bus="_04577e63-c766-11e1-8775-005056c00008" connectableBus="_04577e63-c766-11e1-8775-005056c00008" p="41.111779842545467" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044e56a1-c766-11e1-8775-005056c00008" name="Crickhollow" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048a272b-c766-11e1-8775-005056c00008" name="CRI220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0453d4e3-c766-11e1-8775-005056c00008" name="Kanawha" v="218.66872287230206" angle="0.46873360841946832"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_046efe09-c766-11e1-8775-005056c00008" name="CRI132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04898ae9-c766-11e1-8775-005056c00008" name="CabinCrk" v="137.28000001115868" angle="2.1527830503608021"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" bus="_04898ae9-c766-11e1-8775-005056c00008" connectableBus="_04898ae9-c766-11e1-8775-005056c00008" p="-524.55738112021413" q="-170.08341605677271">
+                <iidm:property name="CGMES.GeneratingUnit" value="_a6ec9760-88da-48df-a23f-7877e7c85ccd"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_e6131af8-c298-413b-84e3-4e21c3b6b06f"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-225" maxQ="640"/>
+            </iidm:generator>
+            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" bus="_04898ae9-c766-11e1-8775-005056c00008" connectableBus="_04898ae9-c766-11e1-8775-005056c00008" p="130.00000001585042" q="26.000000005283468"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_0453d4e3-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e3-c766-11e1-8775-005056c00008" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" bus2="_04898ae9-c766-11e1-8775-005056c00008" connectableBus2="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-87.811958669691535" q1="67.506279470371794" p2="87.811958669691549" q2="-63.489554669003432">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0695187165775399"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.93896713615023475"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.88495575221238942"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.83682008368200833"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.79365079365079361"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.75471698113207553"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.71942446043165464"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.6872852233676976"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.65789473684210531"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.63091482649842268"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.60606060606060608"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.58309037900874627"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.5617977528089888"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.5420054200542006"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.52356020942408377"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.50632911392405056"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_6ff12a17-7104-4420-bfdb-5621035eb4e5" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_f5010321-8804-4359-911d-7b7843d02753" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_b5d2a008-83c2-47a3-a978-283e6b8b2167" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_1a134158-4b67-4406-be2d-303158bd41c4" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_0478c205-c766-11e1-8775-005056c00008" name="Harlond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044778d3-c766-11e1-8775-005056c00008" name="HRL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044b7072-c766-11e1-8775-005056c00008" name="Zanesvll" v="133.43911937046465" angle="-13.642668568074448"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" bus="_044b7072-c766-11e1-8775-005056c00008" connectableBus="_044b7072-c766-11e1-8775-005056c00008" p="19.908267375749343" q="10.916040387302099"/>
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" bus="_044b7072-c766-11e1-8775-005056c00008" connectableBus="_044b7072-c766-11e1-8775-005056c00008" q="-15.330964775972367">
+                <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
+                <iidm:shuntLinearModel bPerSection="0.00017220000000000001" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04670ec0-c766-11e1-8775-005056c00008" name="Stock" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04789af0-c766-11e1-8775-005056c00008" name="STK132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04667289-c766-11e1-8775-005056c00008" name="Tazewell" v="129.73539392813268" angle="7.33596194872342"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" bus="_04667289-c766-11e1-8775-005056c00008" connectableBus="_04667289-c766-11e1-8775-005056c00008" p="11.991742166488978" q="6.9919733924939402"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04675ce0-c766-11e1-8775-005056c00008" name="Stormlands" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046bf0c7-c766-11e1-8775-005056c00008" name="STO132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04778983-c766-11e1-8775-005056c00008" name="NwLibrty" v="84.125816498731325" angle="-72.383000074618522"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" bus="_04778983-c766-11e1-8775-005056c00008" connectableBus="_04778983-c766-11e1-8775-005056c00008" p="17.529455140740886" q="5.3546831027331532"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044e7db2-c766-11e1-8775-005056c00008" name="Crownlands" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04784cd1-c766-11e1-8775-005056c00008" name="CRO132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0482d420-c766-11e1-8775-005056c00008" name="Danville" v="122.60446090541276" angle="-7.3288947548098733"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" bus="_0482d420-c766-11e1-8775-005056c00008" connectableBus="_0482d420-c766-11e1-8775-005056c00008" p="25.000427752516856" q="13.000370720962282"/>
+            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" bus="_0482d420-c766-11e1-8775-005056c00008" connectableBus="_0482d420-c766-11e1-8775-005056c00008" p="43.000735734328991" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0455a9aa-c766-11e1-8775-005056c00008" name="Hobbiton" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0470f9d2-c766-11e1-8775-005056c00008" name="HOB132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047a96c0-c766-11e1-8775-005056c00008" name="Fremont" v="130.05442464776991" angle="13.067111168106274"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" bus="_047a96c0-c766-11e1-8775-005056c00008" connectableBus="_047a96c0-c766-11e1-8775-005056c00008" p="47.974003016796203" q="9.990974899456182"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0452ea87-c766-11e1-8775-005056c00008" name="Goblin Town" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04703689-c766-11e1-8775-005056c00008" name="GOB132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04719616-c766-11e1-8775-005056c00008" name="Turner" v="130.89091692219799" angle="-0.964324741406835"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" bus="_04719616-c766-11e1-8775-005056c00008" connectableBus="_04719616-c766-11e1-8775-005056c00008" p="60.764829944367285" q="27.820319782296725"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0463da79-c766-11e1-8775-005056c00008" name="Rohan" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04588fd5-c766-11e1-8775-005056c00008" name="ROH132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04885267-c766-11e1-8775-005056c00008" name="Grant" v="107.22827806179237" angle="-79.325254897080228"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" bus="_04885267-c766-11e1-8775-005056c00008" connectableBus="_04885267-c766-11e1-8775-005056c00008" p="22.422599204445014" q="3.5715043112928604"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046eafe6-c766-11e1-8775-005056c00008" name="Andúnië" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047d07c9-c766-11e1-8775-005056c00008" name="AND220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045163e5-c766-11e1-8775-005056c00008" name="Olive1" v="166.93520436313969" angle="-89.208021075787372"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" bus="_045163e5-c766-11e1-8775-005056c00008" connectableBus="_045163e5-c766-11e1-8775-005056c00008" p="23.616608011811405" q="0"/>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_044be5a3-c766-11e1-8775-005056c00008" name="AND132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047147f0-c766-11e1-8775-005056c00008" name="Olive2" v="102.4198897532854" angle="-93.711103752413877"/>
+            </iidm:busBreakerTopology>
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" bus="_047147f0-c766-11e1-8775-005056c00008" connectableBus="_047147f0-c766-11e1-8775-005056c00008" q="-24.084658444004514">
+                <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
+                <iidm:shuntLinearModel bPerSection="0.00045919999999999999" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_045163e5-c766-11e1-8775-005056c00008" connectableBus1="_045163e5-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" bus2="_047147f0-c766-11e1-8775-005056c00008" connectableBus2="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="175.76330971373091" q1="-9.1214900881814174" p2="-175.76330971373088" q2="23.058119687429485">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0152284160890517"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.98522168458346493"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.97087380525968558"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.9569378265149614"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.94339626201495319"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.93023260140616748"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.91743124316135283"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.90497743289449806"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_61e544bc-df04-4b97-8a18-5a8f66ae2ab7" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_4109402d-315d-4c0e-8d0e-a7a277ad5608" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_7d97fc29-56b8-4cd3-924e-aa67d27306c8" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_23406b6a-ccc0-4233-a063-caf8238c5a4e" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_045ab2b7-c766-11e1-8775-005056c00008" name="Michel Delving" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046ed6f7-c766-11e1-8775-005056c00008" name="MIC132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0485ba50-c766-11e1-8775-005056c00008" name="Wythe" v="130.78856636933003" angle="6.3823062045369365"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" bus="_0485ba50-c766-11e1-8775-005056c00008" connectableBus="_0485ba50-c766-11e1-8775-005056c00008" p="21.995131758590507" q="14.994468315553213"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044c0cba-c766-11e1-8775-005056c00008" name="Calembel" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04817490-c766-11e1-8775-005056c00008" name="CAL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045ef874-c766-11e1-8775-005056c00008" name="WestLima" v="88.875379951210547" angle="-79.454377029545697"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" bus="_045ef874-c766-11e1-8775-005056c00008" connectableBus="_045ef874-c766-11e1-8775-005056c00008" p="23.264668043087624" q="5.0259023134861405"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_048481d3-c766-11e1-8775-005056c00008" name="Riverlands" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04664b7a-c766-11e1-8775-005056c00008" name="RVR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045f1f84-c766-11e1-8775-005056c00008" name="BeaverCk" v="129.56825697463975" angle="9.1244000220201009"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" bus="_045f1f84-c766-11e1-8775-005056c00008" connectableBus="_045f1f84-c766-11e1-8775-005056c00008" p="23.976318172351903" q="14.97533954426803"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0466e7ba-c766-11e1-8775-005056c00008" name="Standelf" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047b8123-c766-11e1-8775-005056c00008" name="STA220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046c3ee8-c766-11e1-8775-005056c00008" name="Sorenson2" v="168.52180166674572" angle="-79.149321845104211"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0476c631-c766-11e1-8775-005056c00008" name="Sorenson1" v="101.33741722821284" angle="-83.879892035190167"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" bus="_0476c631-c766-11e1-8775-005056c00008" connectableBus="_0476c631-c766-11e1-8775-005056c00008" p="9.4418728295961589" q="2.3257535399817999"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_046c3ee8-c766-11e1-8775-005056c00008" connectableBus1="_046c3ee8-c766-11e1-8775-005056c00008" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" bus2="_0476c631-c766-11e1-8775-005056c00008" connectableBus2="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="130.20379928196414" q1="67.520680169040801" p2="-130.20379928196417" q2="-54.411074831242857">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0416666883680561"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.96153844304733771"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.92592589163237438"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_d161a693-b7ea-488b-a945-b567ee43f412" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_f7fdb434-5e1f-4292-9849-2542cf0f4c3d" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_c65fcaa8-aacd-4104-90bc-ba8b3185073e" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_f62f2fc6-4b6c-4571-a8c5-40d6a89ac703" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_04642898-c766-11e1-8775-005056c00008" name="Rómenna" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0457f394-c766-11e1-8775-005056c00008" name="RÓM132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0454e653-c766-11e1-8775-005056c00008" name="Philo" v="134.75117874868516" angle="-12.195512695102877"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" bus="_0454e653-c766-11e1-8775-005056c00008" connectableBus="_0454e653-c766-11e1-8775-005056c00008" p="-235.70492074680948" q="-450">
+                <iidm:property name="CGMES.GeneratingUnit" value="_e3753d6d-b894-4cce-b6fa-307c50dc107f"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_dff93c01-9c84-4c1f-8529-66c054ed9e37"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
+            </iidm:generator>
+            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" bus="_0454e653-c766-11e1-8775-005056c00008" connectableBus="_0454e653-c766-11e1-8775-005056c00008" p="86.760725492529517" q="29.862612021296819"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04828600-c766-11e1-8775-005056c00008" name="Ost-in-Edhil" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047b0bf4-c766-11e1-8775-005056c00008" name="OST132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04716f02-c766-11e1-8775-005056c00008" name="BetsyLne" v="128.57869922248423" angle="7.067059271943914"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" bus="_04716f02-c766-11e1-8775-005056c00008" connectableBus="_04716f02-c766-11e1-8775-005056c00008" p="10.983967617573894" q="6.983004220441198"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045fe2d1-c766-11e1-8775-005056c00008" name="Oldtown" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046205b3-c766-11e1-8775-005056c00008" name="OLD132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0483be8a-c766-11e1-8775-005056c00008" name="Reusens" v="124.75974481530244" angle="-5.6512944013421134"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" p="22.000421601653127" q="0"/>
+            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" p="28.000536583922162" q="12.000383276678429"/>
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" q="-5.3543579106745085">
+                <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
+                <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0453fbf4-c766-11e1-8775-005056c00008" name="Grey Havens" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047d07c3-c766-11e1-8775-005056c00008" name="GRE132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_048433b2-c766-11e1-8775-005056c00008" name="Holston" v="126.42569751295336" angle="11.355076842157906"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" bus="_048433b2-c766-11e1-8775-005056c00008" connectableBus="_048433b2-c766-11e1-8775-005056c00008" p="84.989067420410393" q="0"/>
+            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" bus="_048433b2-c766-11e1-8775-005056c00008" connectableBus="_048433b2-c766-11e1-8775-005056c00008" p="77.989967750494245" q="41.990997085164281"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04745531-c766-11e1-8775-005056c00008" name="Edhellond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048740f7-c766-11e1-8775-005056c00008" name="EDH132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04716f04-c766-11e1-8775-005056c00008" name="SthPoint" v="118.88458281909674" angle="-9.8071900515829427"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" bus="_04716f04-c766-11e1-8775-005056c00008" connectableBus="_04716f04-c766-11e1-8775-005056c00008" p="45.906831366905124" q="10.576901283144142"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0476ed45-c766-11e1-8775-005056c00008" name="Forlond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04481510-c766-11e1-8775-005056c00008" name="FRL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0447ee09-c766-11e1-8775-005056c00008" name="CapitlHl" v="131.94170305731112" angle="-0.66714194249739089"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" bus="_0447ee09-c766-11e1-8775-005056c00008" connectableBus="_0447ee09-c766-11e1-8775-005056c00008" p="38.898715406126364" q="31.861611092684878"/>
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" bus="_0447ee09-c766-11e1-8775-005056c00008" connectableBus="_0447ee09-c766-11e1-8775-005056c00008" q="-19.985087730501881">
+                <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
+                <iidm:shuntLinearModel bPerSection="0.0002296" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04825ef5-c766-11e1-8775-005056c00008" name="Osgiliath" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044fb634-c766-11e1-8775-005056c00008" name="OSG132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0482860b-c766-11e1-8775-005056c00008" name="Chemical" v="130.77121210276562" angle="-1.1759634843386289"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" bus="_0482860b-c766-11e1-8775-005056c00008" connectableBus="_0482860b-c766-11e1-8775-005056c00008" p="70.756516032951993" q="25.851564699904124"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0476510a-c766-11e1-8775-005056c00008" name="Ethring" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047eb571-c766-11e1-8775-005056c00008" name="ETH132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04684743-c766-11e1-8775-005056c00008" name="JacksnRd" v="102.51618137089226" angle="-96.234920417081824"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" bus="_04684743-c766-11e1-8775-005056c00008" connectableBus="_04684743-c766-11e1-8775-005056c00008" p="16.594071105761895" q="1.5959853674451348"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047edc88-c766-11e1-8775-005056c00008" name="Minas Ithil" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0468bc77-c766-11e1-8775-005056c00008" name="MNI132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04502b6a-c766-11e1-8775-005056c00008" name="Saltvlle" v="130.60235168245882" angle="11.048174555158438"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" bus="_04502b6a-c766-11e1-8775-005056c00008" connectableBus="_04502b6a-c766-11e1-8775-005056c00008" p="64.975618312136149" q="9.9937490668744662"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0452ea86-c766-11e1-8775-005056c00008" name="Frogmorton" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048c22fa-c766-11e1-8775-005056c00008" name="FRO132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04520021-c766-11e1-8775-005056c00008" name="Trenton" v="113.36100149684867" angle="-52.80618563610922"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" bus="_04520021-c766-11e1-8775-005056c00008" connectableBus="_04520021-c766-11e1-8775-005056c00008" p="12.334770914100494" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045dbff3-c766-11e1-8775-005056c00008" name="Nargothrond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047eb579-c766-11e1-8775-005056c00008" name="NAR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0471bd2a-c766-11e1-8775-005056c00008" name="HickryCk" v="99.667406543494138" angle="-97.996803791122304"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" bus="_0471bd2a-c766-11e1-8775-005056c00008" connectableBus="_0471bd2a-c766-11e1-8775-005056c00008" p="32.651644396192928" q="7.4370508623542273"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045386c0-c766-11e1-8775-005056c00008" name="Kings Landing" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04854527-c766-11e1-8775-005056c00008" name="GOD220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047f2aa7-c766-11e1-8775-005056c00008" name="Tidd2" v="212.92440942026789" angle="-5.6547701458121864"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_0455a9a2-c766-11e1-8775-005056c00008" name="KGL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045645e7-c766-11e1-8775-005056c00008" name="Tidd1" v="130.02000000180939" angle="-9.4741716339726896"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" bus="_045645e7-c766-11e1-8775-005056c00008" connectableBus="_045645e7-c766-11e1-8775-005056c00008" p="-174.02295244808568" q="-75.592673688626093">
+                <iidm:property name="CGMES.GeneratingUnit" value="_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_29df1e0b-36ca-4536-97b4-6f98b84d49d8"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-90" maxQ="255"/>
+            </iidm:generator>
+            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" bus="_045645e7-c766-11e1-8775-005056c00008" connectableBus="_045645e7-c766-11e1-8775-005056c00008" p="277.00000000578223" q="113.00000000393133"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_047f2aa7-c766-11e1-8775-005056c00008" connectableBus1="_047f2aa7-c766-11e1-8775-005056c00008" voltageLevelId1="_04854527-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="171.36866738833999" q1="66.216452351370009" p2="-171.36866738833996" q2="-53.398410408134289">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0416666883680561"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.96153844304733771"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.92592589163237438"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.8928570950255128"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.86206890606421327"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.83333326388889462"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.80645153485952892"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.78124991455079051"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.75757566574840418"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.73529402032873259"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.71428561224491249"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.69444433834878172"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.6756755661066649"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.65789462430749834"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.64102552596977735"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.62499988281252195"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.60975597858419928"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.59523797477326701"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.58139522714983605"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.56818169550622477"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.55555543209879288"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.54347813681477308"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.53191476912633062"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.52083320855037707"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.51020395668474527"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.49999987500003124"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.49019595347946271"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.48076910595417433"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.47169798860807843"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.46296283864886734"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_67e78c48-0ca2-48d3-8a23-d06c0fcd887e" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_5629d2df-9e35-47ae-8a33-c8276f9343d9" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_1afd1e4c-1377-424b-a866-7f6cba69be6c" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_f2daef4d-6f1a-44d1-9c9b-228acff12575" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_0488eea4-c766-11e1-8775-005056c00008" name="Tuckborough" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04876804-c766-11e1-8775-005056c00008" name="TUC132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04494d93-c766-11e1-8775-005056c00008" name="Wooster" v="124.8674017185629" angle="-16.7903476906863"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" bus="_04494d93-c766-11e1-8775-005056c00008" connectableBus="_04494d93-c766-11e1-8775-005056c00008" p="22.993305290586363" q="10.994664155200033"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046eafe3-c766-11e1-8775-005056c00008" name="Alqualondë" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04767817-c766-11e1-8775-005056c00008" name="ALQ132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04769f21-c766-11e1-8775-005056c00008" name="Wagenhls" v="125.55043086688063" angle="-15.611225712833761"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" bus="_04769f21-c766-11e1-8775-005056c00008" connectableBus="_04769f21-c766-11e1-8775-005056c00008" p="62.991958678150738" q="21.995320064717365"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045ab2b4-c766-11e1-8775-005056c00008" name="Menegroth" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04851e1b-c766-11e1-8775-005056c00008" name="MEN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045b4ef9-c766-11e1-8775-005056c00008" name="Concord" v="98.832854616009669" angle="-95.371436525909559"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" bus="_045b4ef9-c766-11e1-8775-005056c00008" connectableBus="_045b4ef9-c766-11e1-8775-005056c00008" p="28.108756980161488" q="11.65175083173764"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0450c7a8-c766-11e1-8775-005056c00008" name="Erech" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047b3309-c766-11e1-8775-005056c00008" name="ERE132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04675ce7-c766-11e1-8775-005056c00008" name="Delaware" v="108.49653411682701" angle="-74.510089804320728"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" bus="_04675ce7-c766-11e1-8775-005056c00008" connectableBus="_04675ce7-c766-11e1-8775-005056c00008" p="55.914947582144478" q="21.030730274054612"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044f19f8-c766-11e1-8775-005056c00008" name="Dunharrow" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0467ab04-c766-11e1-8775-005056c00008" name="DUN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0474071a-c766-11e1-8775-005056c00008" name="FtWayne" v="96.603635403743539" angle="-87.427342023050841"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" bus="_0474071a-c766-11e1-8775-005056c00008" connectableBus="_0474071a-c766-11e1-8775-005056c00008" p="71.902407044109438" q="20.635870216104308"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047ce0b8-c766-11e1-8775-005056c00008" name="Linhir" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0489b1f8-c766-11e1-8775-005056c00008" name="LIN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047c9297-c766-11e1-8775-005056c00008" name="WNwPhil1" v="127.9993667678778" angle="-15.136892908821141"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" bus="_047c9297-c766-11e1-8775-005056c00008" connectableBus="_047c9297-c766-11e1-8775-005056c00008" p="11.98994627168616" q="2.9958121165227629"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045ef876-c766-11e1-8775-005056c00008" name="Nogrod" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046512f8-c766-11e1-8775-005056c00008" name="NOG132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044ea4c4-c766-11e1-8775-005056c00008" name="Logan" v="129.31105907972002" angle="1.6263994987307042"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" bus="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus="_044ea4c4-c766-11e1-8775-005056c00008" p="53.878352363020277" q="26.898703110409887"/>
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" bus="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus="_044ea4c4-c766-11e1-8775-005056c00008" q="-19.196109800366035">
+                <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
+                <iidm:shuntLinearModel bPerSection="0.0002296" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046f7334-c766-11e1-8775-005056c00008" name="Beauxbatons" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048a7544-c766-11e1-8775-005056c00008" name="BEA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0462a1f3-c766-11e1-8775-005056c00008" name="W.Lancst" v="129.07906379362311" angle="-16.860178744337897"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" p="-22.170492074680944" q="-45">
+                <iidm:property name="CGMES.GeneratingUnit" value="_83fae784-1da1-4055-8108-ba978276d1b6"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_5f711f63-f631-45d3-b26c-33821ab2ee56"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
+            </iidm:generator>
+            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" p="27.707366340028234" q="9.8264208249150435"/>
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" q="-9.5636463034471433">
+                <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
+                <iidm:shuntLinearModel bPerSection="0.0001148" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0471e435-c766-11e1-8775-005056c00008" name="Carn Dûm" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045d98e1-c766-11e1-8775-005056c00008" name="CAR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04499bb3-c766-11e1-8775-005056c00008" name="Portsmth" v="113.42766643676676" angle="-15.82354869258914"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" bus="_04499bb3-c766-11e1-8775-005056c00008" connectableBus="_04499bb3-c766-11e1-8775-005056c00008" p="63.128465353616839" q="18.570865990882666"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0474a35b-c766-11e1-8775-005056c00008" name="Ephel Brandir" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04636548-c766-11e1-8775-005056c00008" name="EPH132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04723255-c766-11e1-8775-005056c00008" name="DeerCrk" v="107.06063638703282" angle="-79.546163160735972"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" bus="_04723255-c766-11e1-8775-005056c00008" connectableBus="_04723255-c766-11e1-8775-005056c00008" p="-10.170492074680945" q="-45">
+                <iidm:property name="CGMES.GeneratingUnit" value="_e5a479a8-ab8d-4a54-bb52-376874ae2784"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_b55d80d5-720f-46f9-897f-ff8c5eaf8b44"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
+            </iidm:generator>
+            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" bus="_04723255-c766-11e1-8775-005056c00008" connectableBus="_04723255-c766-11e1-8775-005056c00008" p="40.079648220151476" q="24.013539237383672"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04669999-c766-11e1-8775-005056c00008" name="Staddle" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04555b83-c766-11e1-8775-005056c00008" name="STA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044fdd40-c766-11e1-8775-005056c00008" name="Medford" v="109.33549432678562" angle="-74.941424862443426"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" bus="_044fdd40-c766-11e1-8775-005056c00008" connectableBus="_044fdd40-c766-11e1-8775-005056c00008" p="20.926759261371654" q="6.4401631429811079"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04731cb4-c766-11e1-8775-005056c00008" name="Diagon Alley" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047f9fdb-c766-11e1-8775-005056c00008" name="DIA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0449e9d4-c766-11e1-8775-005056c00008" name="CollCrnr" v="116.99156128289157" angle="-60.456693116881539"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" bus="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus="_0449e9d4-c766-11e1-8775-005056c00008" p="6.7189619780286884" q="2.8019571785059472"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045fe2da-c766-11e1-8775-005056c00008" name="Ondosto" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044f4108-c766-11e1-8775-005056c00008" name="OND132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047e6750-c766-11e1-8775-005056c00008" name="Caldwell" v="128.82214827101822" angle="3.0771932539357993"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" bus="_047e6750-c766-11e1-8775-005056c00008" connectableBus="_047e6750-c766-11e1-8775-005056c00008" p="41.955914399652137" q="30.945786691173925"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04631727-c766-11e1-8775-005056c00008" name="Rivendell" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046b7b99-c766-11e1-8775-005056c00008" name="RIV132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046c17da-c766-11e1-8775-005056c00008" name="Franklin" v="126.3301615896559" angle="-4.0379174281595205"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" bus="_046c17da-c766-11e1-8775-005056c00008" connectableBus="_046c17da-c766-11e1-8775-005056c00008" p="8.0001574775162645" q="3.0000984240934754"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04765106-c766-11e1-8775-005056c00008" name="Esgaroth" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04689563-c766-11e1-8775-005056c00008" name="ESG132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04686e54-c766-11e1-8775-005056c00008" name="McKinley" v="96.804938794366933" angle="-86.024884408732007"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" bus="_04686e54-c766-11e1-8775-005056c00008" connectableBus="_04686e54-c766-11e1-8775-005056c00008" p="48.08484683993774" q="23.509346743821624"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046b2d72-c766-11e1-8775-005056c00008" name="Hogwarts" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04479fe2-c766-11e1-8775-005056c00008" name="HOG132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047566a8-c766-11e1-8775-005056c00008" name="TwinBrch" v="104.02833785347121" angle="-95.911355566925863"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" bus="_047566a8-c766-11e1-8775-005056c00008" connectableBus="_047566a8-c766-11e1-8775-005056c00008" p="-97.681968298723774" q="-170">
+                <iidm:property name="CGMES.GeneratingUnit" value="_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_668eb671-5c36-4351-a95d-53ca850581db"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
+            </iidm:generator>
+            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" bus="_047566a8-c766-11e1-8775-005056c00008" connectableBus="_047566a8-c766-11e1-8775-005056c00008" p="41.960056252786025" q="8.2774583915794029"/>
+            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" bus="_047566a8-c766-11e1-8775-005056c00008" connectableBus="_047566a8-c766-11e1-8775-005056c00008" p="20.261492118613607" q="6.8890330538344982">
+                <iidm:currentLimits permanentLimit="1000">
+                    <iidm:temporaryLimit name="_c42b1a7f-971e-44aa-b615-fb7d49f3256c" acceptableDuration="900" value="1150"/>
+                    <iidm:temporaryLimit name="_543c8189-a696-4529-9d26-f06fd03e57ad" acceptableDuration="60" value="1400"/>
+                </iidm:currentLimits>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04499bb4-c766-11e1-8775-005056c00008" name="Annúminas" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04633e3a-c766-11e1-8775-005056c00008" name="ANN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04670ec8-c766-11e1-8775-005056c00008" name="Lincoln" v="95.520443937464776" angle="-85.995073027658052"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" bus="_04670ec8-c766-11e1-8775-005056c00008" connectableBus="_04670ec8-c766-11e1-8775-005056c00008" p="35.348234439731122" q="16.718553407054358"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046f2515-c766-11e1-8775-005056c00008" name="Azkaban" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04644fa4-c766-11e1-8775-005056c00008" name="AZK132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_048c4a07-c766-11e1-8775-005056c00008" name="Hinton" v="134.63901064972688" angle="2.439744706542065"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" bus="_048c4a07-c766-11e1-8775-005056c00008" connectableBus="_048c4a07-c766-11e1-8775-005056c00008" p="41.99928775430962" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04631725-c766-11e1-8775-005056c00008" name="Qarth" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04878f10-c766-11e1-8775-005056c00008" name="QAR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_048b86b5-c766-11e1-8775-005056c00008" name="EastLima1" v="90.220198162402156" angle="-78.462601171256665"/>
+            </iidm:busBreakerTopology>
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" bus="_048b86b5-c766-11e1-8775-005056c00008" connectableBus="_048b86b5-c766-11e1-8775-005056c00008" q="-11.680446764524564">
+                <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
+                <iidm:shuntLinearModel bPerSection="0.00028699999999999998" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_04742e21-c766-11e1-8775-005056c00008" name="QAR220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0451b206-c766-11e1-8775-005056c00008" name="EastLima2" v="151.80421570964967" angle="-78.545892799807547"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_0451b206-c766-11e1-8775-005056c00008" connectableBus1="_0451b206-c766-11e1-8775-005056c00008" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" bus2="_048b86b5-c766-11e1-8775-005056c00008" connectableBus2="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-1.9553596581182164" q1="107.25978022975666" p2="1.9553596581182109" q2="-99.335673139004683">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0695187165775399"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.93896713615023475"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.88495575221238942"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.83682008368200833"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.79365079365079361"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.75471698113207553"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.71942446043165464"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.6872852233676976"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_fc89899a-e1ba-48c5-aec0-1d321408483c" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_6ee590e8-2483-491d-a919-ffe1e93a41d3" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_f0cc6f7c-99a3-496d-8d13-1ac44171b1b9" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_c97df399-5a91-4c8b-b72c-496cade334b5" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_0486a4b7-c766-11e1-8775-005056c00008" name="St Mungos" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046f7338-c766-11e1-8775-005056c00008" name="STM132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04531195-c766-11e1-8775-005056c00008" name="N. E." v="101.58046321478056" angle="-93.271066868487793"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" bus="_04531195-c766-11e1-8775-005056c00008" connectableBus="_04531195-c766-11e1-8775-005056c00008" p="21.53604780920686" q="7.7990791881457859"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044aad21-c766-11e1-8775-005056c00008" name="Belegost" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04806326-c766-11e1-8775-005056c00008" name="BEL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_048c22f1-c766-11e1-8775-005056c00008" name="SCoshoct" v="126.26565655101835" angle="-16.340439902602416"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" bus="_048c22f1-c766-11e1-8775-005056c00008" connectableBus="_048c22f1-c766-11e1-8775-005056c00008" p="17.986690299026161" q="4.993839620285585"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04784cda-c766-11e1-8775-005056c00008" name="Gulltown" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047a96c5-c766-11e1-8775-005056c00008" name="GUL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0479102a-c766-11e1-8775-005056c00008" name="WHuntngd" v="117.35620641388135" angle="-9.9033277254375278"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" bus="_0479102a-c766-11e1-8775-005056c00008" connectableBus="_0479102a-c766-11e1-8775-005056c00008" p="32.307800681323343" q="14.479281695243168"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0456bb19-c766-11e1-8775-005056c00008" name="Khazad-dûm" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046a1c00-c766-11e1-8775-005056c00008" name="KHA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045fe2d4-c766-11e1-8775-005056c00008" name="DanRiver" v="129.3600000040114" angle="-3.1595737481734374"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" bus="_045fe2d4-c766-11e1-8775-005056c00008" connectableBus="_045fe2d4-c766-11e1-8775-005056c00008" p="-39.170492074680944" q="-20.462333125297295">
+                <iidm:property name="CGMES.GeneratingUnit" value="_fec62959-21c5-4921-90b2-7c85e9f3bfab"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_9db08c95-4586-4a2b-87e3-5a17c944b43a"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045bc420-c766-11e1-8775-005056c00008" name="Minas Morgul" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04664b78-c766-11e1-8775-005056c00008" name="MNM132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04878f11-c766-11e1-8775-005056c00008" name="X5 TRI" v="111.58096168026253" angle="-19.180900707871565"/>
+            </iidm:busBreakerTopology>
+            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" bus="_04878f11-c766-11e1-8775-005056c00008" connectableBus="_04878f11-c766-11e1-8775-005056c00008" p="6.0043690504272895" q="-0.81883314081487113">
+                <iidm:currentLimits permanentLimit="1000">
+                    <iidm:temporaryLimit name="_d8fc27d8-dd8b-4396-ae7f-b877910f9726" acceptableDuration="900" value="1150"/>
+                    <iidm:temporaryLimit name="_1481884d-3134-4896-ae32-b507830cc47a" acceptableDuration="60" value="1400"/>
+                </iidm:currentLimits>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04595327-c766-11e1-8775-005056c00008" name="Lond Daer Enedh" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0456e220-c766-11e1-8775-005056c00008" name="LON132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04812671-c766-11e1-8775-005056c00008" name="Summerfl" v="134.63356163980202" angle="-4.37027045835812"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" bus="_04812671-c766-11e1-8775-005056c00008" connectableBus="_04812671-c766-11e1-8775-005056c00008" p="28.002705582150266" q="7.0011273622059456"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047391e8-c766-11e1-8775-005056c00008" name="Durmstrang" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0448d866-c766-11e1-8775-005056c00008" name="DUR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0453d4e4-c766-11e1-8775-005056c00008" name="ClinchRv" v="132.66000000293289" angle="17.672177555637226"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" bus="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus="_0453d4e4-c766-11e1-8775-005056c00008" p="-670.40984149361896" q="-36.494529890793935">
+                <iidm:property name="CGMES.GeneratingUnit" value="_2621b09a-22e3-4630-b3bd-32c102e36741"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_b0d662e5-64c9-4d59-b8e0-9b1ed175769b"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-300" maxQ="850"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044ca8f4-c766-11e1-8775-005056c00008" name="Combe" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045d4ac5-c766-11e1-8775-005056c00008" name="COM132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045fe2d7-c766-11e1-8775-005056c00008" name="Pokagon" v="101.14155385047411" angle="-97.607645465434331"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" bus="_045fe2d7-c766-11e1-8775-005056c00008" connectableBus="_045fe2d7-c766-11e1-8775-005056c00008" p="17.117295280244033" q="6.9435956244435895"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04500458-c766-11e1-8775-005056c00008" name="Eldalondë" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047b8129-c766-11e1-8775-005056c00008" name="ELD132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047e4045-c766-11e1-8775-005056c00008" name="GoshenJt" v="101.61779912138054" angle="-94.401551633727422"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" bus="_047e4045-c766-11e1-8775-005056c00008" connectableBus="_047e4045-c766-11e1-8775-005056c00008" p="12.066836467867063" q="0.78062475440683998"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047d2ed1-c766-11e1-8775-005056c00008" name="Lorien" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048c4a08-c766-11e1-8775-005056c00008" name="LOR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04544a19-c766-11e1-8775-005056c00008" name="S.Tiffin" v="82.023448661841769" angle="-62.517934649339324"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" bus="_04544a19-c766-11e1-8775-005056c00008" connectableBus="_04544a19-c766-11e1-8775-005056c00008" p="23.127009375242686" q="4.5694393847669508"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0478e914-c766-11e1-8775-005056c00008" name="Harrenhal" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0456bb11-c766-11e1-8775-005056c00008" name="HAR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045e0e10-c766-11e1-8775-005056c00008" name="Haviland" v="92.232088940777487" angle="-84.603494644709627"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" bus="_045e0e10-c766-11e1-8775-005056c00008" connectableBus="_045e0e10-c766-11e1-8775-005056c00008" p="17.142005025839524" q="5.5139837206457294"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046ab849-c766-11e1-8775-005056c00008" name="Valmar" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045cfca4-c766-11e1-8775-005056c00008" name="VAL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047d2ed4-c766-11e1-8775-005056c00008" name="SWKammer" v="131.09093427991863" angle="-5.2493899969162978"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" bus="_047d2ed4-c766-11e1-8775-005056c00008" connectableBus="_047d2ed4-c766-11e1-8775-005056c00008" p="77.999665739503754" q="2.9999785730757198"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047343c0-c766-11e1-8775-005056c00008" name="Dol Amroth" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045a1672-c766-11e1-8775-005056c00008" name="DOL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0479fa80-c766-11e1-8775-005056c00008" name="Baileysv" v="130.2540629927843" angle="2.2537900771746968"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" bus="_0479fa80-c766-11e1-8775-005056c00008" connectableBus="_0479fa80-c766-11e1-8775-005056c00008" p="37.951236947115397" q="14.967932768615325"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0476ed41-c766-11e1-8775-005056c00008" name="Fangorn Forest" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044f8f29-c766-11e1-8775-005056c00008" name="FAN132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04675ce9-c766-11e1-8775-005056c00008" name="HolstonT" v="128.04549672799209" angle="10.900392226190119"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" bus="_04675ce9-c766-11e1-8775-005056c00008" connectableBus="_04675ce9-c766-11e1-8775-005056c00008" p="9.9977077717246008" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046c17d5-c766-11e1-8775-005056c00008" name="Westerlands" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04791027-c766-11e1-8775-005056c00008" name="WES132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046f9a47-c766-11e1-8775-005056c00008" name="WMedford" v="109.15950503990871" angle="-74.932295298694612"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" bus="_046f9a47-c766-11e1-8775-005056c00008" connectableBus="_046f9a47-c766-11e1-8775-005056c00008" p="7.6051733630294276" q="2.7573155735962711"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0467ab01-c766-11e1-8775-005056c00008" name="Tharbad" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0483be8b-c766-11e1-8775-005056c00008" name="THA132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044e56a4-c766-11e1-8775-005056c00008" name="Rockhill" v="89.495769277696724" angle="-78.51492739856927"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" bus="_044e56a4-c766-11e1-8775-005056c00008" connectableBus="_044e56a4-c766-11e1-8775-005056c00008" p="42.030686588382942" q="14.773978725478813"/>
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" bus="_044e56a4-c766-11e1-8775-005056c00008" connectableBus="_044e56a4-c766-11e1-8775-005056c00008" q="-6.4316226530412006">
+                <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
+                <iidm:shuntLinearModel bPerSection="0.0001606" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04719613-c766-11e1-8775-005056c00008" name="Caras Galadhon" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04728074-c766-11e1-8775-005056c00008" name="CAR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046a9133-c766-11e1-8775-005056c00008" name="Sprigg" v="128.80080883107712" angle="3.4805736356950088"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" bus="_046a9133-c766-11e1-8775-005056c00008" connectableBus="_046a9133-c766-11e1-8775-005056c00008" p="19.957583002701522" q="9.9646774970560141"/>
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" bus="_046a9133-c766-11e1-8775-005056c00008" connectableBus="_046a9133-c766-11e1-8775-005056c00008" q="-9.5224581560797734">
+                <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
+                <iidm:shuntLinearModel bPerSection="0.0001148" maximumSectionCount="10"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0488eea8-c766-11e1-8775-005056c00008" name="Umbar" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0479d371-c766-11e1-8775-005056c00008" name="UMB132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045868c7-c766-11e1-8775-005056c00008" name="West End" v="82.513382244092213" angle="-67.178494184132433"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" bus="_045868c7-c766-11e1-8775-005056c00008" connectableBus="_045868c7-c766-11e1-8775-005056c00008" p="29.010494408040184" q="0"/>
+            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" bus="_045868c7-c766-11e1-8775-005056c00008" connectableBus="_045868c7-c766-11e1-8775-005056c00008" p="12.61325843827834" q="10.667353004370408"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047343ca-c766-11e1-8775-005056c00008" name="Dorne" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04662460-c766-11e1-8775-005056c00008" name="DOR132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0453d4eb-c766-11e1-8775-005056c00008" name="Deer Crk" v="102.1097745280742" angle="-82.744117472723545"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" bus="_0453d4eb-c766-11e1-8775-005056c00008" connectableBus="_0453d4eb-c766-11e1-8775-005056c00008" p="5.2091029516307321" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04745536-c766-11e1-8775-005056c00008" name="Eglarest" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0457f396-c766-11e1-8775-005056c00008" name="EGL132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045d23b1-c766-11e1-8775-005056c00008" name="Crooksvl" v="132.61657222439456" angle="-12.598492995180091"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" bus="_045d23b1-c766-11e1-8775-005056c00008" connectableBus="_045d23b1-c766-11e1-8775-005056c00008" p="33.825922578336368" q="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0480b143-c766-11e1-8775-005056c00008" name="Newbury" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044d1e26-c766-11e1-8775-005056c00008" name="NEW132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044a5f04-c766-11e1-8775-005056c00008" name="WCambrdg" v="131.80592719158915" angle="-13.671941916169375"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" bus="_044a5f04-c766-11e1-8775-005056c00008" connectableBus="_044a5f04-c766-11e1-8775-005056c00008" p="16.966355979489027" q="3.9868149721116888"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04640189-c766-11e1-8775-005056c00008" name="Rushey" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04605807-c766-11e1-8775-005056c00008" name="RUS132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0458b6e4-c766-11e1-8775-005056c00008" name="SouthBnd" v="102.08972265160921" angle="-95.785804478048249"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" bus="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus="_0458b6e4-c766-11e1-8775-005056c00008" p="60.75496717800555" q="18.163550830778558"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0453add1-c766-11e1-8775-005056c00008" name="Gondolin" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045c8779-c766-11e1-8775-005056c00008" name="GON220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044e7db1-c766-11e1-8775-005056c00008" name="X9" v="0" angle="0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04745534-c766-11e1-8775-005056c00008" name="Edoras" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04544a18-c766-11e1-8775-005056c00008" name="EDO220KV" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0457f395-c766-11e1-8775-005056c00008" name="Kammer" v="216.27741339544701" angle="-3.6485469522751663"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_0448d867-c766-11e1-8775-005056c00008" name="EDO132KV" nominalV="132" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04814d88-c766-11e1-8775-005056c00008" name="W.Kammer" v="131.3400000016278" angle="-4.2717243008530774"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" bus="_04814d88-c766-11e1-8775-005056c00008" connectableBus="_04814d88-c766-11e1-8775-005056c00008" p="-179.02295244808565" q="42.465877986245374">
+                <iidm:property name="CGMES.GeneratingUnit" value="_17852426-f663-4add-9a2b-0a635d51f101"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd"/>
+                <iidm:property name="CGMES.normalPF" value="0.0"/>
+                <iidm:minMaxReactiveLimits minQ="-90" maxQ="255"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" bus1="_0457f395-c766-11e1-8775-005056c00008" connectableBus1="_0457f395-c766-11e1-8775-005056c00008" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" bus2="_04814d88-c766-11e1-8775-005056c00008" connectableBus2="_04814d88-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="40.301480624903022" q1="11.577166157143145" p2="-40.301480624903022" q2="-11.104114599840546">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0152284160890517"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.98522168458346493"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.97087380525968558"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.9569378265149614"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.94339626201495319"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.93023260140616748"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.91743124316135283"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.90497743289449806"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.89285720663265766"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.88105733858604451"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312">
+                <iidm:temporaryLimit name="_9d8d5d2f-e17b-44ba-8e5c-c743c13b8932" acceptableDuration="900" value="1508"/>
+                <iidm:temporaryLimit name="_dbe87453-c7d1-4a10-8f4e-992b351d4810" acceptableDuration="60" value="1837"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186">
+                <iidm:temporaryLimit name="_c2676f61-6c29-44b7-9841-6209f952b0dd" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_f6b1a81c-eda7-4a08-b290-bd29a5ed9fa4" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" bus1="_04723255-c766-11e1-8775-005056c00008" connectableBus1="_04723255-c766-11e1-8775-005056c00008" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" bus2="_04675ce7-c766-11e1-8775-005056c00008" connectableBus2="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-56.188219970033238" q1="9.8290726954925525" p2="57.669840212272618" q2="-6.6052109154236396">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f69dc237-d327-475e-93f6-25cbffe65d37" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_de6da3cb-8cb5-4900-9c33-8ad45632b535" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" bus1="_045fe2d7-c766-11e1-8775-005056c00008" connectableBus1="_045fe2d7-c766-11e1-8775-005056c00008" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" bus2="_047566a8-c766-11e1-8775-005056c00008" connectableBus2="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-34.011239169627558" q1="-16.909946078982554" p2="34.465861423557691" q2="17.457887473522653">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_09a180b3-124b-4a91-b323-4aad01f45e8a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6bd63dd1-1344-4183-b7bd-af326919f4eb" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" bus1="_04675ce7-c766-11e1-8775-005056c00008" connectableBus1="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" bus2="_046f9a47-c766-11e1-8775-005056c00008" connectableBus2="_046f9a47-c766-11e1-8775-005056c00008" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="6.3918474847883111" q1="-8.6751947121579125" p2="-6.3704910586554222" q2="7.6654075793506333">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_a8e81058-e847-4ff2-adf2-c4129ce23783" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_5f05650a-c63d-46e5-a426-2db4f036929f" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" bus1="_04520021-c766-11e1-8775-005056c00008" connectableBus1="_04520021-c766-11e1-8775-005056c00008" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" bus2="_0472a783-c766-11e1-8775-005056c00008" connectableBus2="_0472a783-c766-11e1-8775-005056c00008" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-87.449623280014777" q1="53.442352946516714" p2="94.528883314647118" q2="-28.432690438151642">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_a65972e6-89bc-4bc2-adaf-0434a8cb1628" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_d2074163-ab09-4251-a1d7-6983091dc4f1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" bus1="_0476c631-c766-11e1-8775-005056c00008" connectableBus1="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" bus2="_04686e54-c766-11e1-8775-005056c00008" connectableBus2="_04686e54-c766-11e1-8775-005056c00008" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="51.572926476910055" q1="40.036852436784635" p2="-50.676893721338658" q2="-37.089577108744145">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f12edde3-3545-483e-8323-461ae7aa0ada" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2b6693c7-4e29-4c2c-91d0-3485bbe8fe87" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" bus1="_0476c631-c766-11e1-8775-005056c00008" connectableBus1="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" bus2="_0453d4eb-c766-11e1-8775-005056c00008" connectableBus2="_0453d4eb-c766-11e1-8775-005056c00008" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="-39.85050542366956" q1="-2.6747503003084208" p2="40.097440583544277" q2="3.0327493413362885">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_83e15527-5937-42e4-964e-4c736913e9b0" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_786432da-fa4d-4751-a275-87d0e20529f1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_044a5f04-c766-11e1-8775-005056c00008" connectableBus2="_044a5f04-c766-11e1-8775-005056c00008" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="40.707927948143137" q1="15.309372448231933" p2="-40.215401469839847" q2="-15.832893957864897">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_5f6ea7e2-f472-4dba-a863-10ce21ee9702" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_1f0844a5-ea5c-42b2-abcb-6fac2c426092" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" bus1="_044a8618-c766-11e1-8775-005056c00008" connectableBus1="_044a8618-c766-11e1-8775-005056c00008" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" bus2="_0471bd2a-c766-11e1-8775-005056c00008" connectableBus2="_0471bd2a-c766-11e1-8775-005056c00008" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-25.227255760608458" q1="-8.7321092677546641" p2="25.391346360838714" q2="8.6621109514898578">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_bd6a7b7b-b30f-440f-bf3e-7d1d8007b0ab" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_4ea43e34-67a3-42b8-9601-2189db7790d4" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" bus1="_04502b6a-c766-11e1-8775-005056c00008" connectableBus1="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" bus2="_04845ac5-c766-11e1-8775-005056c00008" connectableBus2="_04845ac5-c766-11e1-8775-005056c00008" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="48.858219113543591" q1="-8.95950379670297" p2="-48.549747575114353" q2="8.9297088362365269">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_70154a1f-3853-4c24-8c87-aef442bdefdb" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_23cc194e-9273-46e9-a793-84a9c2911737" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" bus1="_04667289-c766-11e1-8775-005056c00008" connectableBus1="_04667289-c766-11e1-8775-005056c00008" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" bus2="_045c8773-c766-11e1-8775-005056c00008" connectableBus2="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.413538089198511" q1="-21.849085986221557" p2="-56.551319319759784" q2="22.860281833941855">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f5c30ce2-41bf-4665-a68c-a4d64962821a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_1a9fe09e-3f63-4904-8e36-aa38c5e16c59" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" bus1="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus1="_0462a1f3-c766-11e1-8775-005056c00008" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" bus2="_044b7072-c766-11e1-8775-005056c00008" connectableBus2="_044b7072-c766-11e1-8775-005056c00008" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-31.357524896445899" q1="-8.5507162924672802" p2="32.000431163725501" q2="5.9040519485233816">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_79d9d9c2-3ecc-40f2-99c0-c26a56c19fe7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_467ba04d-dbad-4fe1-81c8-3bc87b41fcd1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_04862f81-c766-11e1-8775-005056c00008" connectableBus2="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-196.95086671614689" q1="22.449820305223582" p2="203.7481707388026" q2="9.5948644832964689">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_58073794-ab85-4c83-b59e-07d01d71ec5f" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_d0737ab4-5a3a-46c8-8aeb-789313f0f332" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" bus1="_04716f04-c766-11e1-8775-005056c00008" connectableBus1="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" bus2="_0479102a-c766-11e1-8775-005056c00008" connectableBus2="_0479102a-c766-11e1-8775-005056c00008" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="8.5523630098257488" q1="18.618491684285754" p2="-8.4740456874185028" q2="-19.318043332891673">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_4ea8b910-752d-4475-8141-89e03e629b4e" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_173dc7ff-ae18-4410-b2e1-a4c2abac8ff6" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" bus1="_045c8773-c766-11e1-8775-005056c00008" connectableBus1="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" bus2="_0479fa80-c766-11e1-8775-005056c00008" connectableBus2="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="41.606517700068764" q1="-13.321258486354704" p2="-41.08692739177026" q2="12.760712135500293">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_15760a98-ef2d-4bd9-9370-acb8533d07b8" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_efde58bf-c92e-496d-b558-d0095a271083" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" bus1="_044b9787-c766-11e1-8775-005056c00008" connectableBus1="_044b9787-c766-11e1-8775-005056c00008" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" bus2="_04812671-c766-11e1-8775-005056c00008" connectableBus2="_04812671-c766-11e1-8775-005056c00008" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-15.437403527605875" q1="-16.848492452022143" p2="15.55983191599219" q2="14.247673406189133">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_bb70f086-9826-4662-b5f7-d88e35724d27" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_8a81d4ae-2bc8-4038-8650-27a6150946b1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" bus1="_045d23b1-c766-11e1-8775-005056c00008" connectableBus1="_045d23b1-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-17.809792388704203" q1="-21.321125429575183" p2="17.94942666107654" q2="20.132755285331076">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_36231d1d-0ec0-42d3-a72a-d56bd20ed7b0" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_8d6a074c-900d-4a37-830c-5da4c1de1ab5" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" bus1="_0468bc75-c766-11e1-8775-005056c00008" connectableBus1="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" bus2="_044ef2e3-c766-11e1-8775-005056c00008" connectableBus2="_044ef2e3-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="58.707943584760791" q1="10.135966019461074" p2="-56.587736634902377" q2="-8.1746106434548853">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_2da72d83-6a1a-4a6d-a873-847a8741dc7f" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3154dc30-b0e5-4570-8e52-9333bae20ef2" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" bus1="_04719616-c766-11e1-8775-005056c00008" connectableBus1="_04719616-c766-11e1-8775-005056c00008" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" bus2="_0482860b-c766-11e1-8775-005056c00008" connectableBus2="_0482860b-c766-11e1-8775-005056c00008" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="28.828055702741118" q1="-2.0568863420201771" p2="-28.796197402593322" q2="0.920238822597089">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f6dcf23b-e28d-4722-9b81-e4ae2b782a53" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_cce754c5-b9d5-4105-a431-32da96e4a6cf" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" bus1="_046b066a-c766-11e1-8775-005056c00008" connectableBus1="_046b066a-c766-11e1-8775-005056c00008" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" bus2="_04684743-c766-11e1-8775-005056c00008" connectableBus2="_04684743-c766-11e1-8775-005056c00008" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="0.84877657909873883" q1="-20.983483173889375" p2="-0.81525638616647234" q2="20.806010523419015">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ecaca589-8952-4cab-b3dc-f787858d46a9" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_361a9cc3-fb33-4037-9b9a-c20adb90b66b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" bus1="_04719616-c766-11e1-8775-005056c00008" connectableBus1="_04719616-c766-11e1-8775-005056c00008" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" bus2="_04898ae9-c766-11e1-8775-005056c00008" connectableBus2="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-61.0149020242878" q1="-28.293597649845392" p2="62.348807905546799" q2="30.703599536504932">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_fdae333c-349a-484b-9226-2b694611f4fe" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_da00c66f-a882-4938-923b-f2455f7f9a81" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" bus1="_0482860b-c766-11e1-8775-005056c00008" connectableBus1="_0482860b-c766-11e1-8775-005056c00008" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" bus2="_0447ee09-c766-11e1-8775-005056c00008" connectableBus2="_0447ee09-c766-11e1-8775-005056c00008" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-41.960318632979167" q1="-26.771803514219911" p2="42.097196900397051" q2="26.741784174040063">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_1f58489c-4298-48ca-914f-1a86392e8a4d" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ba4abe9d-8490-4c19-b19b-c9d2c3597fc9" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" bus1="_04597a36-c766-11e1-8775-005056c00008" connectableBus1="_04597a36-c766-11e1-8775-005056c00008" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" bus2="_046783f5-c766-11e1-8775-005056c00008" connectableBus2="_046783f5-c766-11e1-8775-005056c00008" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.880314884611614" q1="13.787263920614027" p2="-33.240990846925314" q2="-15.607003537333201">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_e286f134-f966-4dd2-b24b-b8388ca849a5" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2320da74-eda7-4f7f-ade9-1ed0e994f3af" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" bus1="_047e6750-c766-11e1-8775-005056c00008" connectableBus1="_047e6750-c766-11e1-8775-005056c00008" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" bus2="_0479fa80-c766-11e1-8775-005056c00008" connectableBus2="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="17.587726001841993" q1="-25.372396178326976" p2="-17.42291492726962" q2="24.480024391883777">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_489df699-65e3-4b74-b657-04f7e24da3e0" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3bc03415-e95f-47a7-8e92-01089d304a9c" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" bus1="_04719616-c766-11e1-8775-005056c00008" connectableBus1="_04719616-c766-11e1-8775-005056c00008" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" bus2="_04898ae9-c766-11e1-8775-005056c00008" connectableBus2="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-132.88075798841885" q1="-51.557533471981721" p2="136.35272551122944" q2="56.589769726013053">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_bb9699a6-dcec-459a-b50a-7c7ff7419b33" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_f93b6d4c-39fa-4f6f-a42d-c63a4cf21a67" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" bus1="_047147f0-c766-11e1-8775-005056c00008" connectableBus1="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" bus2="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus2="_0458b6e4-c766-11e1-8775-005056c00008" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="30.197837344817575" q1="-6.0891983136733208" p2="-29.879903794797603" q2="6.1143626596427838">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_55d07074-4a4b-419b-819d-8d6048fcfd1c" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3bc4ab96-7a0d-4e18-b9f5-d89f63a82f0a" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" bus1="_04878f11-c766-11e1-8775-005056c00008" connectableBus1="_04878f11-c766-11e1-8775-005056c00008" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" bus2="_0472a783-c766-11e1-8775-005056c00008" connectableBus2="_0472a783-c766-11e1-8775-005056c00008" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="113.83064400937437" q1="1.1604613700612054" p2="-105.73830678816007" q2="28.432691889083095">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7a622384-0095-408a-9cc5-b561a4bec039" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_bcb69c6e-125e-449c-acb3-a4deb151668d" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" bus1="_04862f81-c766-11e1-8775-005056c00008" connectableBus1="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" bus2="_04812671-c766-11e1-8775-005056c00008" connectableBus2="_04812671-c766-11e1-8775-005056c00008" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="44.056027666939194" q1="20.611433183802458" p2="-43.562537498756846" q2="-21.248800768253282">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_fd2f6dbe-d54c-4d17-9492-da52445d0640" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b4b8a31d-dc3c-4b51-88ad-a22e070eb96c" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" bus1="_044e56a4-c766-11e1-8775-005056c00008" connectableBus1="_044e56a4-c766-11e1-8775-005056c00008" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" bus2="_046bf0cb-c766-11e1-8775-005056c00008" connectableBus2="_046bf0cb-c766-11e1-8775-005056c00008" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="-75.524590335273899" q1="41.539679958665218" p2="82.272965359633531" q2="-15.948211685417412">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_498a5fc8-8519-4545-b941-9e3648608651" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_5585c67a-0839-48e6-8847-4393e1e9b9c7" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" bus1="_048c22f1-c766-11e1-8775-005056c00008" connectableBus1="_048c22f1-c766-11e1-8775-005056c00008" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" bus2="_04494d93-c766-11e1-8775-005056c00008" connectableBus2="_04494d93-c766-11e1-8775-005056c00008" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="5.5448780772901243" q1="2.9843674776218987" p2="-5.5208968162457515" q2="-6.5597473357692184">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_005c0497-2c3d-4384-b39b-e1c8e4695081" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_e7c9dfab-fb45-4470-964f-4ba9e391f60b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" bus1="_04876809-c766-11e1-8775-005056c00008" connectableBus1="_04876809-c766-11e1-8775-005056c00008" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" bus2="_0483be8a-c766-11e1-8775-005056c00008" connectableBus2="_0483be8a-c766-11e1-8775-005056c00008" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.976761161479367" q1="1.2980798797189839" p2="-26.555878262825168" q2="-4.1521443808688705">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_78d5285a-1f72-4d4e-a8ce-d760901cdf1e" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_fff133bf-25fd-46b2-b144-a227c31ee882" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" bus1="_0468bc75-c766-11e1-8775-005056c00008" connectableBus1="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" bus2="_0485ba50-c766-11e1-8775-005056c00008" connectableBus2="_0485ba50-c766-11e1-8775-005056c00008" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-20.753376746001766" q1="24.393631643053254" p2="21.051024062343743" q2="-26.343832903834034">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_78f10485-1742-4778-93bc-90854ee15eb6" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_217e3c95-24b5-438f-a721-d2257e1a43b4" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" bus1="_045b9d15-c766-11e1-8775-005056c00008" connectableBus1="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" bus2="_047c9297-c766-11e1-8775-005056c00008" connectableBus2="_047c9297-c766-11e1-8775-005056c00008" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-10.817435553091276" q1="-13.056993901136469" p2="10.915482079444688" q2="11.094885300361616">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_1b2b5b52-3ac1-40eb-af2e-e5a724e34ed4" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_f5547027-3d48-4a53-937b-bd5ba63ef70d" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" bus1="_045d23b1-c766-11e1-8775-005056c00008" connectableBus1="_045d23b1-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" bus2="_044a8615-c766-11e1-8775-005056c00008" connectableBus2="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.187768079513845" q1="17.28154222547354" p2="80.278682753134106" q2="-7.9027214979820144">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_2e74f628-a179-44d3-bd7f-1d262370e8d2" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_e9fec217-cf6f-4d39-9495-26ed10c05100" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" bus1="_04550d63-c766-11e1-8775-005056c00008" connectableBus1="_04550d63-c766-11e1-8775-005056c00008" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" bus2="_045fe2d4-c766-11e1-8775-005056c00008" connectableBus2="_045fe2d4-c766-11e1-8775-005056c00008" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-38.713893360184883" q1="-20.767869554694141" p2="39.170492076569644" q2="20.462333124693455">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_489598c7-fb80-48bb-abdc-7fbc89ff0fd7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ea48fee0-31b6-4990-a332-25d08b7d731f" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" bus1="_04544a19-c766-11e1-8775-005056c00008" connectableBus1="_04544a19-c766-11e1-8775-005056c00008" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" bus2="_04577e63-c766-11e1-8775-005056c00008" connectableBus2="_04577e63-c766-11e1-8775-005056c00008" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-82.082754856887163" q1="15.318678583955132" p2="89.508174405945567" q2="7.6990512915176668">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_91e7cb96-de23-4948-881e-3112959809d0" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_063af52c-fe10-4c1e-85d4-dd80dcc1d2f9" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" bus1="_04898ae9-c766-11e1-8775-005056c00008" connectableBus1="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" bus2="_048c4a07-c766-11e1-8775-005056c00008" connectableBus2="_048c4a07-c766-11e1-8775-005056c00008" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="-0.33524542240201588" q1="7.2284459005771513" p2="0.37880252051653723" q2="-12.823826566662206">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_b3ada113-b597-41a3-b96c-e2d6413ccd2b" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_c05229ce-6abb-4209-ad4f-0dcd4a070f28" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" bus1="_04549837-c766-11e1-8775-005056c00008" connectableBus1="_04549837-c766-11e1-8775-005056c00008" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-43.156772798323864" q1="-3.495952798986131" p2="44.184308768473926" q2="2.5521995643725939">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f947c23d-f412-4092-bee0-955d804a356e" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ac528cbe-6fc1-41dd-ba9d-d8b7a4c77576" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" bus1="_04502b6a-c766-11e1-8775-005056c00008" connectableBus1="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" bus2="_045c8773-c766-11e1-8775-005056c00008" connectableBus2="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="65.330589910018787" q1="-16.152026054641507" p2="-63.134881156688969" q2="19.401503996024751">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_288185b8-2129-4450-a2c7-ad8080ce1f0a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6ac84228-6b04-4b10-b560-29655c8e93b4" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" bus1="_048b86b5-c766-11e1-8775-005056c00008" connectableBus1="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" bus2="_04778983-c766-11e1-8775-005056c00008" connectableBus2="_04778983-c766-11e1-8775-005056c00008" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="-30.967657240136148" q1="40.828592171906386" p2="32.807725985236189" q2="-35.931343354166543">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_dfe3b6e2-9b9f-400e-93a7-90b35c43d3ea" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2ccdc288-c132-40d1-a928-3887bec4ff67" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" bus1="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus1="_0462a1f3-c766-11e1-8775-005056c00008" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" bus2="_045d23b1-c766-11e1-8775-005056c00008" connectableBus2="_045d23b1-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-57.841541650376968" q1="-2.699903908137208" p2="59.171637863288517" q2="4.0395831708824215">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_81e5d0c5-7cb3-42c7-829e-11059f8a64c3" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_06ca3245-2668-448f-a5c6-961924217a5c" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0473e004-c766-11e1-8775-005056c00008" name="30-38" r="2.2457600000000002" x="26.1360016" g1="0" b1="0.00043595040000000003" g2="0" b2="0.00043595040000000003" bus1="_046c3ee8-c766-11e1-8775-005056c00008" connectableBus1="_046c3ee8-c766-11e1-8775-005056c00008" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" bus2="_0451b206-c766-11e1-8775-005056c00008" connectableBus2="_0451b206-c766-11e1-8775-005056c00008" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="-1.03400970513797" q1="95.555304476529955" p2="1.9553596581181665" q2="-107.25978022975642">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_29165bcc-a0d7-4427-a8b8-8393eb928631" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" bus1="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus1="_044ea4c4-c766-11e1-8775-005056c00008" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" bus2="_046a9133-c766-11e1-8775-005056c00008" connectableBus2="_046a9133-c766-11e1-8775-005056c00008" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-73.911537112290688" q1="32.463312693576405" p2="74.68627609849014" q2="-33.556691420589758">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_31992d9c-cc50-4558-b52a-f9a597797818" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_dfbd2f07-76ab-41e3-910f-dc706979ea4b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" bus1="_046b7b91-c766-11e1-8775-005056c00008" connectableBus1="_046b7b91-c766-11e1-8775-005056c00008" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" bus2="_046c17da-c766-11e1-8775-005056c00008" connectableBus2="_046c17da-c766-11e1-8775-005056c00008" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.77914678948391" q1="-0.53489331508107585" p2="-20.729872536532675" q2="-0.027668494390126717">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ce219edd-f122-4f03-ae4f-0dd3493375e7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_11451cec-81c7-4f83-a7db-df7dcaffa94e" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" bus1="_04499bb3-c766-11e1-8775-005056c00008" connectableBus1="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" bus2="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus2="_0486f2d6-c766-11e1-8775-005056c00008" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="-32.642593223921523" q1="-2.2565815956163542" p2="33.221810747658218" q2="1.6273948181463895">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_fa81f928-3439-4353-ac4c-3785ae142ba2" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_37a5cc00-bd7f-4ec7-a77c-e140e23450d2" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" bus1="_04719616-c766-11e1-8775-005056c00008" connectableBus1="_04719616-c766-11e1-8775-005056c00008" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" bus2="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus2="_044ea4c4-c766-11e1-8775-005056c00008" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-41.181770358948455" q1="25.445741804075638" p2="41.958871816943763" q2="-31.16214800640773">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_1f7aa218-1550-426b-9fd1-6361f5c3e363" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_e9798d58-b518-4fab-984c-c72076dfc2ae" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" bus1="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus1="_0449e9d4-c766-11e1-8775-005056c00008" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" bus2="_04520021-c766-11e1-8775-005056c00008" connectableBus2="_04520021-c766-11e1-8775-005056c00008" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="-175.38115445008333" q1="109.4846523958755" p2="182.80161147603815" q2="-86.233620869115342">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_8b924c6b-d010-4981-b109-fc33cd937313" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_e8ec73b8-1ecf-4d18-9ef9-80eabf3a4969" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" bus1="_0474071a-c766-11e1-8775-005056c00008" connectableBus1="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" bus2="_0476c631-c766-11e1-8775-005056c00008" connectableBus2="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-88.842839077944433" q1="-31.947917900874341" p2="91.02128015741539" q2="36.662437809436923">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_0a1e553e-a285-429e-a660-00078dd05878" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2ceac3d1-f73d-43db-8d37-9e329f1787bb" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" bus1="_045163e5-c766-11e1-8775-005056c00008" connectableBus1="_045163e5-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" bus2="_046c3ee8-c766-11e1-8775-005056c00008" connectableBus2="_046c3ee8-c766-11e1-8775-005056c00008" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-199.3799282360018" q1="9.1214964009154134" p2="202.39845753718041" q2="-3.7009053269441483">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_2e5a9b0c-24d7-4bb6-9761-484be58c5bf6" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ca795ad3-97e5-4416-aaba-53cce27f6434" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_044a8615-c766-11e1-8775-005056c00008" connectableBus2="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-62.165508051624244" q1="17.461042880281308" p2="66.266420337737202" q2="-12.720990787083538">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_4f55c6a7-4a84-47ac-84a2-f7da319866f4" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_c42dc3ef-3a2e-4070-8efb-78e5c0cd5554" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" bus1="_045b4ef9-c766-11e1-8775-005056c00008" connectableBus1="_045b4ef9-c766-11e1-8775-005056c00008" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" bus2="_0474071a-c766-11e1-8775-005056c00008" connectableBus2="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="-26.317814079644926" q1="13.580070119514634" p2="27.549205962250749" q2="-12.970506130842018">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_40c3caa3-b6ce-4e62-ada3-2053aaadb18b" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ad988fd9-9270-4230-95a2-1858f32259df" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" bus1="_044a8615-c766-11e1-8775-005056c00008" connectableBus1="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" bus2="_04499bb3-c766-11e1-8775-005056c00008" connectableBus2="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="218.61512838361668" q1="111.48764764414443" p2="-201.32974148229064" q2="-49.351540176864297">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f71ac0ab-1003-49e3-baae-6860eaa27ea1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_519e3ecb-3561-4d11-ac6b-172a0b4b09b2" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" bus1="_04670ec8-c766-11e1-8775-005056c00008" connectableBus1="_04670ec8-c766-11e1-8775-005056c00008" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" bus2="_0474f17a-c766-11e1-8775-005056c00008" connectableBus2="_0474f17a-c766-11e1-8775-005056c00008" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-39.990829235215166" q1="0.98668007906996014" p2="40.76195203518575" q2="1.0026404578567099">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_e0ff2082-d064-46f0-89c2-f6597d7c5acb" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b88528bf-cb1c-4c00-ad79-d5937197d40c" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" bus1="_045c8773-c766-11e1-8775-005056c00008" connectableBus1="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" bus2="_047e6750-c766-11e1-8775-005056c00008" connectableBus2="_047e6750-c766-11e1-8775-005056c00008" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="60.03854080123827" q1="6.1317831483710714" p2="-59.543640402265829" q2="-5.5733905116334315">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_9b58679f-8c7f-489f-884a-30224849053b" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b70e76a1-6e79-4fb6-b487-dffa9bfeab7b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" bus1="_047566a8-c766-11e1-8775-005056c00008" connectableBus1="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" bus2="_04531195-c766-11e1-8775-005056c00008" connectableBus2="_04531195-c766-11e1-8775-005056c00008" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="-27.096728958137597" q1="24.519041104544172" p2="27.563827321874175" q2="-23.979721449130771">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_25cb43d7-517b-4c25-b213-a01c4afe495d" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_af73f526-c58b-40e7-8e1c-14f05a39f6a2" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" bus1="_0468bc75-c766-11e1-8775-005056c00008" connectableBus1="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" bus2="_04597a36-c766-11e1-8775-005056c00008" connectableBus2="_04597a36-c766-11e1-8775-005056c00008" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="109.08625999191217" q1="-19.129090314645016" p2="-107.20402055510479" q2="19.799426255502535">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ce5f31b6-0de2-41fb-8091-c2d5742b1828" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_1631e50b-21a3-470b-803b-f9665b6fcd60" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" bus1="_04483c26-c766-11e1-8775-005056c00008" connectableBus1="_04483c26-c766-11e1-8775-005056c00008" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" bus2="_04675ce7-c766-11e1-8775-005056c00008" connectableBus2="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="18.133629258529986" q1="22.191626038419525" p2="-17.861637622704631" q2="-22.636634028170668">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_cd4a9202-6aaa-4709-8293-bc142c0c9bc0" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_52eb4b09-42bb-4106-ac26-fe1059639d3a" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" bus1="_045645e7-c766-11e1-8775-005056c00008" connectableBus1="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" bus2="_04814d88-c766-11e1-8775-005056c00008" connectableBus2="_04814d88-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-57.35072529899913" q1="6.7833832651849573" p2="58.488046190378853" q2="-5.3851060332791381">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_13d74b35-2eae-4bb7-9968-655ba9ecd015" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b5a7dea0-bfce-4548-a04d-7bb7b6d9f80a" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" bus1="_0468bc75-c766-11e1-8775-005056c00008" connectableBus1="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" bus2="_046783f5-c766-11e1-8775-005056c00008" connectableBus2="_046783f5-c766-11e1-8775-005056c00008" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="54.05156842641167" q1="11.09177106255591" p2="-52.693499607895745" q2="-10.294729663229734">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_80225115-e6ed-47cd-b7d2-04f198d2417f" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_17a10cd0-b653-4dcf-bdc3-4d5005ea9591" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" bus1="_04716f04-c766-11e1-8775-005056c00008" connectableBus1="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" bus2="_04719616-c766-11e1-8775-005056c00008" connectableBus2="_04719616-c766-11e1-8775-005056c00008" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-72.82017801777728" q1="-15.795520804333425" p2="76.889733712896088" q2="24.865053383328618">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f64d2e1f-164f-4cd3-b7bd-9be3300eacb1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6f81df11-7e71-4b6e-a6ee-a8c5f72f4ba5" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" bus1="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus1="_0449e9d4-c766-11e1-8775-005056c00008" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" bus2="_04675ce7-c766-11e1-8775-005056c00008" connectableBus2="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="160.11920619604169" q1="19.751006585869092" p2="-149.53347606075184" q2="10.182208285266503">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ac71ed2f-6a14-4b3d-aa1b-b7a3cd071a96" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_a8f6a7d2-e58d-4671-a776-97be7291355e" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" bus1="_0479fa80-c766-11e1-8775-005056c00008" connectableBus1="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" bus2="_04667284-c766-11e1-8775-005056c00008" connectableBus2="_04667284-c766-11e1-8775-005056c00008" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="3.0241456461995968" q1="-25.854948479829481" p2="-2.9142453746668311" q2="24.028424550062297">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_b6767a5e-0078-4311-b973-464b8f35bbfd" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ea6d39aa-df95-4d3e-b7b6-a800e552e72a" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" bus1="_04689567-c766-11e1-8775-005056c00008" connectableBus1="_04689567-c766-11e1-8775-005056c00008" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" bus2="_04483c26-c766-11e1-8775-005056c00008" connectableBus2="_04483c26-c766-11e1-8775-005056c00008" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="167.90865369471473" q1="107.78269026013405" p2="-155.79404982239816" q2="-61.740095996206691">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_8a1cb557-29ed-49ae-9120-65b4bdb8d2b1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_d9d53af2-5ffa-4f2a-a4e6-ed22371332d6" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" bus1="_04550d63-c766-11e1-8775-005056c00008" connectableBus1="_04550d63-c766-11e1-8775-005056c00008" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" bus2="_0482d420-c766-11e1-8775-005056c00008" connectableBus2="_0482d420-c766-11e1-8775-005056c00008" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.355620989090767" q1="11.00798668794793" p2="-68.001163487957101" q2="-13.000370720753395">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_e55ac0b9-b111-4207-b7ee-59ac708a4e23" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_d50299b9-a055-408a-aa1e-2e93a715120f" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" bus1="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" bus2="_04502b6a-c766-11e1-8775-005056c00008" connectableBus2="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="227.06566548488149" q1="-3.114993122604226" p2="-222.01199375980661" q2="23.444071945931476">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_4f767c6c-7f3a-4cb0-8a7d-04b1b4897817" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_eee9ca2b-764f-4ab8-a745-405338044743" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_04549837-c766-11e1-8775-005056c00008" connectableBus2="_04549837-c766-11e1-8775-005056c00008" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="24.156444687050293" q1="12.633703107866731" p2="-23.444543722110094" q2="-17.382403137303797">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_c1091068-8e12-44e2-bdc4-44450556f80f" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_690202a4-aad2-4ad3-8842-961b39e37709" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" bus1="_045868c7-c766-11e1-8775-005056c00008" connectableBus1="_045868c7-c766-11e1-8775-005056c00008" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" bus2="_04544a19-c766-11e1-8775-005056c00008" connectableBus2="_04544a19-c766-11e1-8775-005056c00008" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="-57.505466818299844" q1="24.284368006052034" p2="58.955743140717452" q2="-19.888112115025645">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_3d919b23-d14b-4639-a104-ce09f5d78235" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_34f2ef7c-32da-4444-b989-d02f5f931c50" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" bus1="_04778983-c766-11e1-8775-005056c00008" connectableBus1="_04778983-c766-11e1-8775-005056c00008" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" bus2="_045868c7-c766-11e1-8775-005056c00008" connectableBus2="_045868c7-c766-11e1-8775-005056c00008" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="-50.337183670706743" q1="30.576667512553474" p2="51.917342974613391" q2="-25.999448072804661">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_d8fb151e-0854-45a9-8df9-177e6bfebf52" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_38d58455-5205-46bb-8e44-c66873f62938" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" bus1="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" bus2="_04502b6a-c766-11e1-8775-005056c00008" connectableBus2="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="71.631320202060891" q1="-5.7891124559647071" p2="-69.629511835893382" q2="9.7250399774716865">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_135d109b-ce06-4ee9-9fdc-bc39b1cd4791" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_0cce41c7-b99f-4fec-93d2-73ea24433fa1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" bus1="_045e0e10-c766-11e1-8775-005056c00008" connectableBus1="_045e0e10-c766-11e1-8775-005056c00008" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" bus2="_048b86b5-c766-11e1-8775-005056c00008" connectableBus2="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-30.607084549326569" q1="17.481235632661711" p2="31.690375938652977" q2="-15.5228869027837">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f5fb6f64-e16e-422b-b721-de1a781e8c01" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_343677c6-7477-4bf6-a12c-2c7e4a684d6f" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" bus1="_04876809-c766-11e1-8775-005056c00008" connectableBus1="_04876809-c766-11e1-8775-005056c00008" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" bus2="_046b7b91-c766-11e1-8775-005056c00008" connectableBus2="_046b7b91-c766-11e1-8775-005056c00008" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.926409600234056" q1="-0.84583091212464367" p2="-22.779184928445993" q2="-0.46513846754417909">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_072c26b8-9b37-418f-b9a6-338f9a198a84" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_74cf84b9-e14f-4f81-9e8b-3a791cd474a0" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" bus1="_044e56a4-c766-11e1-8775-005056c00008" connectableBus1="_044e56a4-c766-11e1-8775-005056c00008" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" bus2="_048b86b5-c766-11e1-8775-005056c00008" connectableBus2="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-14.226856903356239" q1="-35.933824167120406" p2="14.309136552088592" q2="35.779942330733114">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_1ee3b9bf-743b-4bcb-b6a3-faa02fc44cc1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_8e90bf2e-3be4-41be-a84e-c1d4e709f8a1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" bus1="_04814d88-c766-11e1-8775-005056c00008" connectableBus1="_04814d88-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" bus2="_044b9787-c766-11e1-8775-005056c00008" connectableBus2="_044b9787-c766-11e1-8775-005056c00008" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="37.724466056897533" q1="-16.15311893411608" p2="-37.58558625941496" q2="15.813767542283502">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_b653b5eb-5efc-4bcc-9e10-1eb6bfa6f57c" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_39a23399-348e-44d9-8032-8fc62e6c7d63" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" bus1="_0485ba50-c766-11e1-8775-005056c00008" connectableBus1="_0485ba50-c766-11e1-8775-005056c00008" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" bus2="_04845ac5-c766-11e1-8775-005056c00008" connectableBus2="_04845ac5-c766-11e1-8775-005056c00008" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-43.046155821300211" q1="11.349364588557286" p2="43.551476916251268" q2="-11.927979694356329">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_6be4027d-eae3-4d93-8b3a-bd3ecbefb0a1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_0501dacc-29fc-44a2-8cad-31a20b011d25" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" bus1="_0455a9a6-c766-11e1-8775-005056c00008" connectableBus1="_0455a9a6-c766-11e1-8775-005056c00008" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" bus2="_046c3ee8-c766-11e1-8775-005056c00008" connectableBus2="_046c3ee8-c766-11e1-8775-005056c00008" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="348.9375280550276" q1="272.91696885740214" p2="-331.56824711400662" q2="-159.3750793186266">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_0b8a340a-b8d4-4498-8223-9e70f54345ff" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_c95a66fd-913c-48c7-b8ef-cf3007c60af6" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" bus1="_04577e63-c766-11e1-8775-005056c00008" connectableBus1="_04577e63-c766-11e1-8775-005056c00008" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-120.0885460195541" q1="-12.407153914654268" p2="143.36690219067955" q2="111.16639040236207">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_1aa29312-557e-4a5f-965c-219d32569822" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6cd83bc2-204f-44d5-afd4-fbfef8d2146f" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" bus1="_04876809-c766-11e1-8775-005056c00008" connectableBus1="_04876809-c766-11e1-8775-005056c00008" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" bus2="_044ef2e3-c766-11e1-8775-005056c00008" connectableBus2="_044ef2e3-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="10.206857737732827" q1="5.9202365437883389" p2="-10.184683841948173" q2="-7.1626498133881169">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_6a482321-ff03-47e5-8d69-0a211cec9016" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_487e1317-48f9-4747-b931-f3f79e95f55a" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" bus1="_047d2ed4-c766-11e1-8775-005056c00008" connectableBus1="_047d2ed4-c766-11e1-8775-005056c00008" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" bus2="_04814d88-c766-11e1-8775-005056c00008" connectableBus2="_04814d88-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-122.70554657673169" q1="10.462841330322361" p2="123.11192082871804" q2="-9.823538412964437">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_8f379d20-b516-4eec-b535-925586132d69" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3c55a929-a755-409b-af5f-bae188892af1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" bus1="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus1="_0449e9d4-c766-11e1-8775-005056c00008" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" bus2="_04689567-c766-11e1-8775-005056c00008" connectableBus2="_04689567-c766-11e1-8775-005056c00008" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-73.993821836212376" q1="-169.58127829177599" p2="80.565945165762642" q2="195.12818895234824">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_3e4b7d9a-4e85-4b10-9dba-a83fb76bf6b7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_9658628a-596f-41a9-96a7-c5a8aaf5400c" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" bus1="_04670ec8-c766-11e1-8775-005056c00008" connectableBus1="_04670ec8-c766-11e1-8775-005056c00008" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" bus2="_044e56a4-c766-11e1-8775-005056c00008" connectableBus2="_044e56a4-c766-11e1-8775-005056c00008" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="-19.468467788523515" q1="19.334519466432901" p2="20.645421569509416" q2="-18.576069519670195">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7d1b5b44-e965-446d-b0a2-2abd8f995343" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b69ab61b-751d-487a-a538-2d47eea7572e" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" bus1="_045645e7-c766-11e1-8775-005056c00008" connectableBus1="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" bus2="_047d2ed4-c766-11e1-8775-005056c00008" connectableBus2="_047d2ed4-c766-11e1-8775-005056c00008" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-48.200230732950558" q1="5.0353788258093237" p2="48.974679363301405" q2="-5.1711656350002757">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_37b8abba-f482-471a-a82d-65606ca1d4d5" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_a38d4859-b54a-482f-a2ad-0b4ce4c4da2a" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" bus1="_0474071a-c766-11e1-8775-005056c00008" connectableBus1="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" bus2="_04670ec8-c766-11e1-8775-005056c00008" connectableBus2="_04670ec8-c766-11e1-8775-005056c00008" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="-26.379832556146365" q1="23.426383533101234" p2="26.661559459414207" q2="-23.036302551520109">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_beec41ff-5166-438d-8178-950089f889c8" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_15d16bd2-d87c-4584-93d2-b294dc1be116" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" bus1="_048433b2-c766-11e1-8775-005056c00008" connectableBus1="_048433b2-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" bus2="_04675ce9-c766-11e1-8775-005056c00008" connectableBus2="_04675ce9-c766-11e1-8775-005056c00008" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.1731911760359184" q1="-16.273085753016304" p2="-4.1036228215107027" q2="14.513672411923773">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ff16ab37-609f-4d89-97e0-8f4fd8cfa2e3" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_7d2a67fb-9d8c-4745-a67e-ce6ade5e520e" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" bus1="_0461b794-c766-11e1-8775-005056c00008" connectableBus1="_0461b794-c766-11e1-8775-005056c00008" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" bus2="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus2="_0449e9d4-c766-11e1-8775-005056c00008" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-78.904236801445805" q1="-23.520286675741918" p2="82.536806384515231" q2="37.543664649483041">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_55a45a23-6031-4a23-956f-992afb08c743" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6477d99a-dd64-4083-8f56-1396610879f0" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" bus1="_046a9133-c766-11e1-8775-005056c00008" connectableBus1="_046a9133-c766-11e1-8775-005056c00008" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" bus2="_045f1f84-c766-11e1-8775-005056c00008" connectableBus2="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-58.876081081068286" q1="14.753139843399063" p2="60.563209864660095" q2="-12.279438378831914">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ad873b1b-014a-4c65-b7cd-22ebb86236bc" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_38cb3e5b-af1a-4684-aa2f-242826ed460c" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" bus1="_0476c631-c766-11e1-8775-005056c00008" connectableBus1="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" bus2="_04723255-c766-11e1-8775-005056c00008" connectableBus2="_04723255-c766-11e1-8775-005056c00008" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-33.166247468986313" q1="-11.274943950278747" p2="34.132939947035894" q2="11.974413119095791">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_55a3f358-a56b-467d-96f8-1bfbe09799dc" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_9066b19a-f404-42c3-88ce-51d375f6fdb5" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" bus1="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" bus2="_048433b2-c766-11e1-8775-005056c00008" connectableBus2="_048433b2-c766-11e1-8775-005056c00008" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.622521426208777" q1="9.2621258025409752" p2="-57.726413274492302" q2="-7.4686996186219181">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_d228fae3-2cfd-42c2-85bf-6ed2417949ef" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_924b4a0b-bef5-432a-ad87-ab5c10d9c019" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" bus1="_04499bb3-c766-11e1-8775-005056c00008" connectableBus1="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" bus2="_04716f04-c766-11e1-8775-005056c00008" connectableBus2="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-58.837998050478447" q1="-5.639971796964244" p2="60.855409416786557" q2="9.4969242152430056">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_30aabccf-8ec8-46a2-a3a1-ba354c62f10a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_d432d118-553c-4f4c-a734-e98e0762ec40" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" bus1="_044a5f04-c766-11e1-8775-005056c00008" connectableBus1="_044a5f04-c766-11e1-8775-005056c00008" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" bus2="_047c9297-c766-11e1-8775-005056c00008" connectableBus2="_047c9297-c766-11e1-8775-005056c00008" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="23.249045479866087" q1="11.846078979617987" p2="-22.905428353091295" q2="-14.09069741813355">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_aff34ffe-0ef8-42ff-99bd-8e286c8073a8" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2f32bda4-7275-4485-9901-12f8cff9e4a1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" bus1="_047147f0-c766-11e1-8775-005056c00008" connectableBus1="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" bus2="_046b066a-c766-11e1-8775-005056c00008" connectableBus2="_046b066a-c766-11e1-8775-005056c00008" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="46.199587579952784" q1="-2.6747555413081092" p2="-45.776697811902586" q2="3.7405875174325067">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_3678bd5d-c47e-4eb0-8620-7f9e24a10618" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b3b0e81b-a434-4e9c-ad94-1161ff47b077" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" bus1="_04769f21-c766-11e1-8775-005056c00008" connectableBus1="_04769f21-c766-11e1-8775-005056c00008" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-46.882612032053274" q1="-4.694312466028923" p2="48.036400199200266" q2="4.6555027481254108">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_4a915430-984f-4a53-9533-53efa325d9e5" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6db0d250-4a2e-4169-abf0-f842aeca485d" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" bus1="_044a8618-c766-11e1-8775-005056c00008" connectableBus1="_044a8618-c766-11e1-8775-005056c00008" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" bus2="_045fe2d7-c766-11e1-8775-005056c00008" connectableBus2="_045fe2d7-c766-11e1-8775-005056c00008" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-16.687420360144031" q1="-10.73745715319733" p2="16.893937308500316" q2="9.9663582666212953">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ebd82352-16ad-454f-8920-32a110d327d1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_9f39cb45-314c-445e-b177-909854a9ce45" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" bus1="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus1="_0458b6e4-c766-11e1-8775-005056c00008" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" bus2="_047566a8-c766-11e1-8775-005056c00008" connectableBus2="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-9.8666914058362263" q1="-55.099596042954623" p2="10.176725147082042" q2="55.814852368174648">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_c0261082-5d30-4965-882d-3c1719e82054" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_70fad3e1-4529-4a7f-9e6c-8ab249d65460" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" connectableBus1="_045163e5-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" connectableBus2="_044e7db1-c766-11e1-8775-005056c00008" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="0" q1="-0" p2="0" q2="0">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_0ea6e870-9b01-4226-80d3-5ff1a2f88c40" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_205e5d8a-f05a-479d-adaa-3514f48f6857" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" bus1="_0457f395-c766-11e1-8775-005056c00008" connectableBus1="_0457f395-c766-11e1-8775-005056c00008" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" bus2="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus2="_0458ddf2-c766-11e1-8775-005056c00008" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-212.26718194687351" q1="-64.181793617023075" p2="213.5797425005745" q2="41.364679214313391">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_09341906-df9b-4a95-a073-d9e12f3841be" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_8cee2b62-2953-439b-ba4b-4a48d55116c0" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" bus1="_04549837-c766-11e1-8775-005056c00008" connectableBus1="_04549837-c766-11e1-8775-005056c00008" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" bus2="_045b9d15-c766-11e1-8775-005056c00008" connectableBus2="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="9.8605051459339013" q1="10.15384198025364" p2="-9.8542569005833833" q2="-10.798814702410912">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_665fcc7f-38d1-4204-95fa-0c63c2a2ddc5" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_640627c7-0672-413e-8dc8-c9965709a5cb" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" bus1="_04716f02-c766-11e1-8775-005056c00008" connectableBus1="_04716f02-c766-11e1-8775-005056c00008" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" bus2="_045f1f84-c766-11e1-8775-005056c00008" connectableBus2="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-47.843450127452826" q1="11.524871546276422" p2="48.618683656683643" q2="-11.059333216763111">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_eeb51357-560f-40d7-89d7-4fdfd53a167f" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_8b888209-5038-4b98-80fc-062b5ea55747" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" bus1="_044e56a4-c766-11e1-8775-005056c00008" connectableBus1="_044e56a4-c766-11e1-8775-005056c00008" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" bus2="_0480d858-c766-11e1-8775-005056c00008" connectableBus2="_0480d858-c766-11e1-8775-005056c00008" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="27.075330402105951" q1="4.6278786974070742" p2="-26.932138123966265" q2="-4.4463592447666622">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_52f8cd12-1364-4ef3-ae3d-0285817f0354" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_c0a08025-3a61-4d24-9944-f3ef0b079f64" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" bus1="_04520021-c766-11e1-8775-005056c00008" connectableBus1="_04520021-c766-11e1-8775-005056c00008" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" bus2="_04499bb3-c766-11e1-8775-005056c00008" connectableBus2="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="-107.68676225643934" q1="32.791270597968193" p2="108.07428236431775" q2="31.838945483601787">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_66b89c81-20ba-41de-82a2-f999d5085ebd" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_32793450-bbfd-4dcd-a911-89e199600780" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" bus1="_045f1f84-c766-11e1-8775-005056c00008" connectableBus1="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" bus2="_04689561-c766-11e1-8775-005056c00008" connectableBus2="_04689561-c766-11e1-8775-005056c00008" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="13.977467248003371" q1="-3.764551393871387" p2="-13.904343382086163" q2="1.3670486204845851">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_a9a5c23c-642d-4ae6-9eda-818565194dc7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2ec4bef5-7abb-4f52-bb62-49ee474d672b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" bus1="_04531195-c766-11e1-8775-005056c00008" connectableBus1="_04531195-c766-11e1-8775-005056c00008" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" bus2="_0476c631-c766-11e1-8775-005056c00008" connectableBus2="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-49.099883686694909" q1="16.180652559649879" p2="51.184468688692128" q2="-10.664269903525589">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_142dbec6-04c3-4fb9-becf-7e45d36725bc" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_9280074c-8555-49ff-9e62-8ed8f7d95060" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" bus1="_044b9787-c766-11e1-8775-005056c00008" connectableBus1="_044b9787-c766-11e1-8775-005056c00008" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" bus2="_04862f81-c766-11e1-8775-005056c00008" connectableBus2="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-28.258402907130375" q1="-19.845962487264927" p2="28.784259262564088" q2="16.160115424712732">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_c3ef7069-26cb-4184-bb94-4ac49df0603d" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ace48562-0a49-4b76-ae82-c896a00b04f9" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" bus1="_047ba835-c766-11e1-8775-005056c00008" connectableBus1="_047ba835-c766-11e1-8775-005056c00008" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" bus2="_04719616-c766-11e1-8775-005056c00008" connectableBus2="_04719616-c766-11e1-8775-005056c00008" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-90.761162493710074" q1="-29.449258029103042" p2="95.814314348737696" q2="43.025421021896967">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_bc06dfbb-eb99-4db7-8c9d-ec079e03009f" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3f744dba-88dc-4d89-90d4-a6f196054b28" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" bus1="_047d2ed4-c766-11e1-8775-005056c00008" connectableBus1="_047d2ed4-c766-11e1-8775-005056c00008" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" bus2="_044b9787-c766-11e1-8775-005056c00008" connectableBus2="_044b9787-c766-11e1-8775-005056c00008" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-4.2687985266080162" q1="-8.2916542683774352" p2="4.2782134180332516" q2="6.8797239670990828">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7da82087-b318-404c-9514-65732f211e14" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_43f91aaf-c5f4-4995-85a2-37afac616331" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" bus1="_04483c26-c766-11e1-8775-005056c00008" connectableBus1="_04483c26-c766-11e1-8775-005056c00008" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" bus2="_046c8d0b-c766-11e1-8775-005056c00008" connectableBus2="_046c8d0b-c766-11e1-8775-005056c00008" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="47.408437592906488" q1="11.36455835916356" p2="-46.770087120935486" q2="-10.02251332899583">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_611015af-1467-451a-a0ba-6c093df0fde0" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2c20e8bd-84e6-4a1e-b88e-071f631327cb" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" bus1="_04725962-c766-11e1-8775-005056c00008" connectableBus1="_04725962-c766-11e1-8775-005056c00008" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" bus2="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus2="_0462a1f3-c766-11e1-8775-005056c00008" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-79.347651262100442" q1="-44.201733804721414" p2="83.662191548677271" q2="55.987845362395952">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7a4b30c3-e92f-4a39-aeff-e9554d8ce96e" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6ad31f7e-233f-4801-898f-9ffc883ec724" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" bus1="_04686e54-c766-11e1-8775-005056c00008" connectableBus1="_04686e54-c766-11e1-8775-005056c00008" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" bus2="_04670ec8-c766-11e1-8775-005056c00008" connectableBus2="_04670ec8-c766-11e1-8775-005056c00008" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="2.592031358218104" q1="13.580260736829356" p2="-2.5505078007040916" q2="-14.003428942485552">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_917c1ba3-4b76-4e83-a631-84a088996b57" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_a025c9d8-58f9-4320-a1fe-73ecc68d4147" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" bus1="_044e7db1-c766-11e1-8775-005056c00008" connectableBus1="_044e7db1-c766-11e1-8775-005056c00008" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" bus2="_047ba832-c766-11e1-8775-005056c00008" connectableBus2="_047ba832-c766-11e1-8775-005056c00008" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="0" q1="0" p2="0" q2="0">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_a0202601-e216-4568-ab78-b4fe21fd1fba" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b7fac0a3-c5af-48b9-af49-261fd8d46e00" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" bus1="_045f1f84-c766-11e1-8775-005056c00008" connectableBus1="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" bus2="_047a96c0-c766-11e1-8775-005056c00008" connectableBus2="_047a96c0-c766-11e1-8775-005056c00008" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-63.025490486434478" q1="9.7279461136169303" p2="63.875413563274307" q2="-8.062580751633023">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_1662e4d0-c8bc-4830-a853-01d4c6f3c737" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_51646744-d343-42b5-8ba7-fcedc7cc3a98" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" bus1="_044a8615-c766-11e1-8775-005056c00008" connectableBus1="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" bus2="_04719616-c766-11e1-8775-005056c00008" connectableBus2="_04719616-c766-11e1-8775-005056c00008" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="27.818734177729954" q1="30.544360088579392" p2="-27.219503338883875" q2="-39.248518518932435">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_2dd1be0d-4305-4e5a-af1e-424eda4251b7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_76311a15-b79a-4439-a7ce-47afa8fa6fe2" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" bus1="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus1="_0458b6e4-c766-11e1-8775-005056c00008" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" bus2="_045b4ef9-c766-11e1-8775-005056c00008" connectableBus2="_045b4ef9-c766-11e1-8775-005056c00008" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="2.0344846300293993" q1="24.944986042809589" p2="-1.7909532397774861" q2="-25.231807233463122">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7bf0d6eb-6015-4b67-b5f5-7e9417da9602" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_efbf8de7-4b84-4834-bb7c-6250b6072211" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" bus1="_04597a36-c766-11e1-8775-005056c00008" connectableBus1="_04597a36-c766-11e1-8775-005056c00008" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" bus2="_04876809-c766-11e1-8775-005056c00008" connectableBus2="_04876809-c766-11e1-8775-005056c00008" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="44.569869763743171" q1="12.345627591330903" p2="-43.418892732737078" q2="-12.831586766323774">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_77f8dc85-1e26-4f69-8f9d-2e85760a932b" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_22b6919a-a7a0-49fc-9e90-329069c55055" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" bus1="_04725962-c766-11e1-8775-005056c00008" connectableBus1="_04725962-c766-11e1-8775-005056c00008" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-98.805169294149906" q1="-27.974715258264283" p2="108.27971249007081" q2="49.749844688414974">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_3ad3799b-5f8c-4ba0-9e85-81d48157adf6" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_8b91f4fd-4038-45b7-870c-fbc08592b95a" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" bus1="_047a96c0-c766-11e1-8775-005056c00008" connectableBus1="_047a96c0-c766-11e1-8775-005056c00008" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" bus2="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus2="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.84941658067697" q1="-1.9283941475318893" p2="113.64090434413899" q2="9.1895373297858853">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_6dd129f4-2730-4d27-b5dd-b91c16fc6588" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_970bc323-73bf-440d-a3c5-00aebc3a1992" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" bus1="_04898ae9-c766-11e1-8775-005056c00008" connectableBus1="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" bus2="_044b7076-c766-11e1-8775-005056c00008" connectableBus2="_044b7076-c766-11e1-8775-005056c00008" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="9.0806920711596728" q1="12.531756598333171" p2="-9.0189340710227128" q2="-15.29567323588798">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_70ad4f3f-a659-48e9-8383-8ac70b8bce31" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_cb084dc7-1b26-415f-9495-4695df661912" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" bus1="_04675ce9-c766-11e1-8775-005056c00008" connectableBus1="_04675ce9-c766-11e1-8775-005056c00008" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" bus2="_04502b6a-c766-11e1-8775-005056c00008" connectableBus2="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.8940849503419894" q1="-14.513672411915774" p2="5.9776225847516411" q2="11.651102203523523">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_a688473b-de97-456e-afb7-e65c079e3b34" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3a165a76-f6ba-461b-84d6-159a5e0b5077" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" bus1="_04684743-c766-11e1-8775-005056c00008" connectableBus1="_04684743-c766-11e1-8775-005056c00008" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" bus2="_047566a8-c766-11e1-8775-005056c00008" connectableBus2="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-15.778822180816466" q1="-22.401990875417528" p2="15.88444602601535" q2="22.283604048508224">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_bed061b3-3663-40ad-956f-90cda64cbaab" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b19bc945-cc51-4d77-8eaa-3f6afe2d9316" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" bus1="_048c4a07-c766-11e1-8775-005056c00008" connectableBus1="_048c4a07-c766-11e1-8775-005056c00008" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" bus2="_0468bc75-c766-11e1-8775-005056c00008" connectableBus2="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-42.378090275860295" q1="12.823826566668615" p2="42.722461027086851" q2="-13.509067192434404">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_1bb497d6-1d54-49c9-bdd5-c8634a07cfb5" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_a9e283ed-fcad-4f4c-ab57-8531875bb098" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" bus1="_046f9a47-c766-11e1-8775-005056c00008" connectableBus1="_046f9a47-c766-11e1-8775-005056c00008" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" bus2="_044fdd40-c766-11e1-8775-005056c00008" connectableBus2="_044fdd40-c766-11e1-8775-005056c00008" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-1.2346854839958776" q1="-10.422717430408092" p2="1.2383244358624066" q2="10.250118655396292">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_683d7e84-46ea-46ad-9327-754235536ac4" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_c59e4022-b1c0-4811-a32e-f54656bff32d" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" bus1="_046a9133-c766-11e1-8775-005056c00008" connectableBus1="_046a9133-c766-11e1-8775-005056c00008" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" bus2="_04716f02-c766-11e1-8775-005056c00008" connectableBus2="_04716f02-c766-11e1-8775-005056c00008" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-35.767778020462806" q1="18.361332237053478" p2="36.859482509741127" q2="-18.507875766407818">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_204653d4-8c5b-43bc-9283-a2a842f366a9" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_1268eb09-e233-44ce-b8af-22dc30eb16ad" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" bus1="_047e4045-c766-11e1-8775-005056c00008" connectableBus1="_047e4045-c766-11e1-8775-005056c00008" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" bus2="_0474071a-c766-11e1-8775-005056c00008" connectableBus2="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="-27.310832421527859" q1="23.979896177232877" p2="28.710854376298556" q2="-22.223469701819667">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ff77fc37-c585-41b5-90d2-a44430227501" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_9c0c454b-ecc3-40f6-b505-f32fec412522" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" bus1="_04898ae9-c766-11e1-8775-005056c00008" connectableBus1="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" bus2="_0479fa80-c766-11e1-8775-005056c00008" connectableBus2="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="4.7728751675809002" q1="26.811040502729" p2="-4.47927930661234" q2="-30.386716865128328">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_d63c0548-9f5e-4d60-bae2-0566a6473e46" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_1432f4d6-9299-4b0d-bd7f-16e059f9de66" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" bus1="_045b9d15-c766-11e1-8775-005056c00008" connectableBus1="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-40.372384277905994" q1="0.81812245195630739" p2="41.820839834615228" q2="-1.5446427735188979">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_08a97648-23dd-422a-a403-bdb89143a421" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_193f6952-4267-4cc8-a541-726c095028ba" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" bus1="_04502b6a-c766-11e1-8775-005056c00008" connectableBus1="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" bus2="_0468bc75-c766-11e1-8775-005056c00008" connectableBus2="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="35.739991658224803" q1="-17.176320660023869" p2="-34.748171379800716" q2="16.94034248198377">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_07757788-2dda-494c-9038-c1d010214558" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_579249ce-1c81-4d29-8d3f-5fc627a18f99" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" bus1="_046bf0cb-c766-11e1-8775-005056c00008" connectableBus1="_046bf0cb-c766-11e1-8775-005056c00008" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" bus2="_047c4478-c766-11e1-8775-005056c00008" connectableBus2="_047c4478-c766-11e1-8775-005056c00008" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-94.429369701484205" q1="12.30918485443998" p2="107.35633199923554" q2="36.710625170599862">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f1be8c91-71cf-4d95-bcee-a6e3c19c9a0a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3d2cb4b5-ee82-4866-9855-4a5f4803cd3b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" bus1="_046c17da-c766-11e1-8775-005056c00008" connectableBus1="_046c17da-c766-11e1-8775-005056c00008" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" bus2="_04550d63-c766-11e1-8775-005056c00008" connectableBus2="_04550d63-c766-11e1-8775-005056c00008" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.729715058881366" q1="-2.972429929653047" p2="-12.67925975657937" q2="1.2644101399565191">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_4895e133-ecd4-4a69-b358-c2d8d11bd39d" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6fc48d8d-05f8-4104-a6a2-3686d430a091" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" bus1="_044aad28-c766-11e1-8775-005056c00008" connectableBus1="_044aad28-c766-11e1-8775-005056c00008" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" bus2="_0453d4e3-c766-11e1-8775-005056c00008" connectableBus2="_0453d4e3-c766-11e1-8775-005056c00008" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-87.661881649960321" q1="-10.926932767771524" p2="87.811958669691649" q2="-67.506279470371084">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_4428a1f2-00f5-474c-b891-600c8f530e1f" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_191836a1-39cd-402b-8dcf-4f3867c45bd0" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" bus1="_045f1f84-c766-11e1-8775-005056c00008" connectableBus1="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" bus2="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus2="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-84.110188455565321" q1="2.4000373320749335" p2="85.870458160039988" q2="5.7038914080981717">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_4d831a76-7147-4776-a08a-9b166d2dcc7d" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_66cbdeeb-a4e4-4bfc-aec1-9fb7a2d2b6bc" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" bus1="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" bus2="_048433b2-c766-11e1-8775-005056c00008" connectableBus2="_048433b2-c766-11e1-8775-005056c00008" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.57897192782956" q1="21.24308089899672" p2="-109.42581307435573" q2="-18.249211712974816">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_2eff6ba2-5d90-4d71-bcc6-a0c31c1d028d" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_8489e809-6588-4ed2-a9a4-43c44a0d47da" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" bus1="_044b7076-c766-11e1-8775-005056c00008" connectableBus1="_044b7076-c766-11e1-8775-005056c00008" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" bus2="_0468bc75-c766-11e1-8775-005056c00008" connectableBus2="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-24.98036832862201" q1="7.2959468034686852" p2="25.253263581879494" q2="-11.019420979932042">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_a27844ae-f43e-4dea-82b7-bbfa8265a2d2" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_620beaaf-63c8-4020-bea5-c3609c0eaadf" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" bus1="_046c8d0b-c766-11e1-8775-005056c00008" connectableBus1="_046c8d0b-c766-11e1-8775-005056c00008" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" bus2="_04885267-c766-11e1-8775-005056c00008" connectableBus2="_04885267-c766-11e1-8775-005056c00008" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="30.612523411608876" q1="3.591075847142299" p2="-30.279826105910036" q2="-3.8634083689820935">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" bus1="_0471bd2a-c766-11e1-8775-005056c00008" connectableBus1="_0471bd2a-c766-11e1-8775-005056c00008" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" bus2="_047147f0-c766-11e1-8775-005056c00008" connectableBus2="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-41.391333507197572" q1="-4.6346226614500399" p2="42.121749990237433" q2="6.2434145098925464">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_751f81c5-bc0f-47d9-8bf1-215d33c20a33" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_828ca44c-560b-4f94-b825-21e237285fae" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" bus1="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus1="_044ea4c4-c766-11e1-8775-005056c00008" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" bus2="_0479fa80-c766-11e1-8775-005056c00008" connectableBus2="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-21.925687068734373" q1="-9.0037579942709058" p2="22.013739031404878" q2="4.0329960499890811">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_c0d073c0-9e3c-443a-898c-1b775bffd91a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_233b7735-85f4-4a6f-9d87-15129fe42ef5" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" connectableBus1="_0451b206-c766-11e1-8775-005056c00008" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" connectableBus2="_0458ddf2-c766-11e1-8775-005056c00008" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="0" q1="-0" p2="0" q2="0">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_bbea6b5b-db2c-40f6-afef-3da510b3b212" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_990ce3c5-c90c-41b9-abee-fb803d9df3a5" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" bus1="_044ef2e3-c766-11e1-8775-005056c00008" connectableBus1="_044ef2e3-c766-11e1-8775-005056c00008" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" bus2="_0483be8a-c766-11e1-8775-005056c00008" connectableBus2="_0483be8a-c766-11e1-8775-005056c00008" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.771288758409938" q1="-0.66344138944687603" p2="-23.44507992363755" q2="-2.4938809849248131">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_9bb71092-9fe9-497f-9296-4a8b4d9b2bf6" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_1372c3b0-62d7-47d7-a8c0-ed8e10bc1f1a" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" bus1="_04483c26-c766-11e1-8775-005056c00008" connectableBus1="_04483c26-c766-11e1-8775-005056c00008" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" bus2="_044fdd40-c766-11e1-8775-005056c00008" connectableBus2="_044fdd40-c766-11e1-8775-005056c00008" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="22.343830586985273" q1="16.113719585806496" p2="-22.165093013688931" q2="-16.69026697276264">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_e8ff318f-6a55-4c01-9fcf-9cfe688188ce" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_64cfd0fb-1d8e-45d2-a52f-469238dfc0c6" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" bus1="_047566a8-c766-11e1-8775-005056c00008" connectableBus1="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" bus2="_047e4045-c766-11e1-8775-005056c00008" connectableBus2="_047e4045-c766-11e1-8775-005056c00008" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="-14.946833519038961" q1="24.635609977510608" p2="15.243990352002376" q2="-24.760517174982507">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_cd9654e8-0619-442a-898e-2fc144b2abec" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_efe2501d-bcee-42ff-a037-3d8a280487b0" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" bus1="_047ba835-c766-11e1-8775-005056c00008" connectableBus1="_047ba835-c766-11e1-8775-005056c00008" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" bus2="_0479102a-c766-11e1-8775-005056c00008" connectableBus2="_0479102a-c766-11e1-8775-005056c00008" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="23.957608040613806" q1="-5.5012582970765109" p2="-23.833755011924726" q2="4.8387617266960756">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_9c2c041c-d52f-4062-836d-c76e124232b0" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2ae204bf-78cc-49cb-b886-a933b33057e4" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" bus1="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus1="_0486f2d6-c766-11e1-8775-005056c00008" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" bus2="_04716f04-c766-11e1-8775-005056c00008" connectableBus2="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-99.223750269258858" q1="-18.073971765941906" p2="100.84632035408885" q2="22.612306890490398">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_340906fe-83b3-451f-8724-1708b8dc630b" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_e822432e-79af-4bba-8f40-5250468f81a0" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" bus1="_0471bd2a-c766-11e1-8775-005056c00008" connectableBus1="_0471bd2a-c766-11e1-8775-005056c00008" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" bus2="_047566a8-c766-11e1-8775-005056c00008" connectableBus2="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-16.651670880892048" q1="-11.464527287553775" p2="16.977260904632587" q2="10.122720171004133">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_00e770fb-802e-479b-ae76-a52f5614bc15" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_c437e52c-43d7-4ae9-87ad-dc19396dc6ff" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_046a4314-c766-11e1-8775-005056c00008" connectableBus2="_046a4314-c766-11e1-8775-005056c00008" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="50.930018573639167" q1="22.156370011959726" p2="-49.453104654499988" q2="-21.371268244371198">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_3904e93a-ed7a-4222-9cbc-575270ef2037" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_90dcdbe1-437b-443f-b0b5-c2353f7c6954" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" bus1="_045868c7-c766-11e1-8775-005056c00008" connectableBus1="_045868c7-c766-11e1-8775-005056c00008" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" bus2="_04577e63-c766-11e1-8775-005056c00008" connectableBus2="_04577e63-c766-11e1-8775-005056c00008" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-75.009712907826099" q1="22.43320493592795" p2="83.775171344261139" q2="4.518712131538793">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_b9ea0da8-57a8-46d3-bfa0-dc21a2f40ee7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_9b8510fa-bd0e-4e63-8f4c-0e5443a3eb63" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" bus1="_04675ce7-c766-11e1-8775-005056c00008" connectableBus1="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" bus2="_0453d4eb-c766-11e1-8775-005056c00008" connectableBus2="_0453d4eb-c766-11e1-8775-005056c00008" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="47.418455583029925" q1="6.7041453868887091" p2="-45.30654627646954" q2="-3.0327473202024109">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7a4d98b5-2e0c-4af5-b1d0-c41bea482943" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_336bfd86-a922-4154-9e06-cd87382cdc5f" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" bus1="_046a4314-c766-11e1-8775-005056c00008" connectableBus1="_046a4314-c766-11e1-8775-005056c00008" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" bus2="_0467f927-c766-11e1-8775-005056c00008" connectableBus2="_0467f927-c766-11e1-8775-005056c00008" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="8.8038247872624744" q1="6.3062192156142203" p2="-8.7687217254280281" q2="-7.8631205219216547">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_9c6f5c6b-1c48-486d-817d-544297fbef05" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2be10dec-f0ac-470d-83f7-a2a4e70f3491" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" bus1="_04885267-c766-11e1-8775-005056c00008" connectableBus1="_04885267-c766-11e1-8775-005056c00008" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" bus2="_04723255-c766-11e1-8775-005056c00008" connectableBus2="_04723255-c766-11e1-8775-005056c00008" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="7.8595887782855378" q1="0.29333016392114641" p2="-7.8494260943500063" q2="-0.80903503639199958">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_ee57814f-f263-4a45-87db-86c93966cf99" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_f0e21213-6535-44a7-89b6-3063f8738d6b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" bus1="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus1="_0458ddf2-c766-11e1-8775-005056c00008" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" bus2="_044aad28-c766-11e1-8775-005056c00008" connectableBus2="_044aad28-c766-11e1-8775-005056c00008" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="67.08362740377936" q1="5.1645291836827143" p2="-67.003045582411985" q2="-68.233965950135101">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_be72c97f-9801-4b6e-acc0-fd79b256c7ab" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ab31cd46-6d0c-4d9c-95f1-396a45a237e1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_04549837-c766-11e1-8775-005056c00008" connectableBus2="_04549837-c766-11e1-8775-005056c00008" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="23.873304655983013" q1="13.939142760851677" p2="-23.252507496618531" q2="-18.692257007770756">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_c929168a-b558-48fa-aa86-314a35dd7d82" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_1bf78539-b6fa-4d8b-ba8e-9b5970019be6" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" bus1="_04499bb3-c766-11e1-8775-005056c00008" connectableBus1="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" bus2="_04878f11-c766-11e1-8775-005056c00008" connectableBus2="_04878f11-c766-11e1-8775-005056c00008" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="121.60758464225192" q1="6.8382833251391713" p2="-119.83501305980138" q2="-0.34162822924624914">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_173c0b25-4aa7-4c49-a38e-daf8ddd9b8b7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_08ff3ae4-d1dd-49f7-9eda-32ffc8eb0010" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" bus1="_04769f21-c766-11e1-8775-005056c00008" connectableBus1="_04769f21-c766-11e1-8775-005056c00008" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" bus2="_045b9d15-c766-11e1-8775-005056c00008" connectableBus2="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-12.345992724225191" q1="-12.096369431616447" p2="12.361888588264739" q2="11.806310405480598">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f19aeba4-5612-451d-a2d5-8f8415f42907" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_94316214-afd8-4c0d-bca4-916acb92af85" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" bus1="_045ef874-c766-11e1-8775-005056c00008" connectableBus1="_045ef874-c766-11e1-8775-005056c00008" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" bus2="_048b86b5-c766-11e1-8775-005056c00008" connectableBus2="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-18.161331492984605" q1="-9.942380962789116" p2="18.263931449609839" q2="9.7993470424711955">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_a9ea718f-3a70-4590-bdc8-a638045c7097" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_4ea6b532-d914-4b0c-97ee-9f02a14a40b3" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" bus1="_04555b87-c766-11e1-8775-005056c00008" connectableBus1="_04555b87-c766-11e1-8775-005056c00008" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" bus2="_047147f0-c766-11e1-8775-005056c00008" connectableBus2="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-57.147956436798573" q1="-3.2371545405317033" p2="57.244134798722889" q2="3.5470781016636241">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7ecdb83b-300c-47f9-a746-141b4e88f5d1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_2a95fb2b-6661-46e7-a9f6-fe63c1b7433c" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" bus1="_0474f17a-c766-11e1-8775-005056c00008" connectableBus1="_0474f17a-c766-11e1-8775-005056c00008" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" bus2="_045a1670-c766-11e1-8775-005056c00008" connectableBus2="_045a1670-c766-11e1-8775-005056c00008" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-55.312469055910441" q1="-3.1070471291066064" p2="56.343690151742656" q2="6.6849951691447584">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_9c62dbd2-5c0b-4651-9a3e-60685bcfdf52" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_4b67f5f5-f0e1-4bfb-9d57-4d3474720a45" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" bus1="_046783f5-c766-11e1-8775-005056c00008" connectableBus1="_046783f5-c766-11e1-8775-005056c00008" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" bus2="_04876809-c766-11e1-8775-005056c00008" connectableBus2="_04876809-c766-11e1-8775-005056c00008" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="47.934072655571512" q1="0.90127508685375801" p2="-47.691427050658142" q2="-0.90233615780203957">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_d4cfc077-4796-4a02-b938-a43c0f88d615" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_1ca40dc7-6736-4fa8-b4cb-ca696949e421" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" bus1="_047c4478-c766-11e1-8775-005056c00008" connectableBus1="_047c4478-c766-11e1-8775-005056c00008" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" bus2="_04725962-c766-11e1-8775-005056c00008" connectableBus2="_04725962-c766-11e1-8775-005056c00008" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-121.48417771682804" q1="-37.090937265767892" p2="127.37066956615996" q2="59.23753010625434">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_9ba5e8b2-6a11-456a-aac4-3a733a324ddf" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ba738481-ddba-4ebe-a218-8aad0b537f5b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" bus1="_04555b87-c766-11e1-8775-005056c00008" connectableBus1="_04555b87-c766-11e1-8775-005056c00008" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" bus2="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus2="_0458b6e4-c766-11e1-8775-005056c00008" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="23.242716058573237" q1="-6.265626223805711" p2="-23.042881061284774" q2="5.8767212749649023">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_16d1fe69-1ba4-46ed-870c-952d884df26b" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_b1d87c24-e527-4174-aa04-cd0b9de271ea" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" bus1="_04502b6a-c766-11e1-8775-005056c00008" connectableBus1="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" bus2="_04667289-c766-11e1-8775-005056c00008" connectableBus2="_04667289-c766-11e1-8775-005056c00008" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.759464016102044" q1="-12.526112682187174" p2="-69.405280255877628" q2="14.857112593903016">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_341ddbb0-3a2a-4eb9-bc29-2e0f7900c00a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_4e1daf8e-7708-4b96-8d3f-67f58f2505f9" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" bus1="_04577e63-c766-11e1-8775-005056c00008" connectableBus1="_04577e63-c766-11e1-8775-005056c00008" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-120.0885460195541" q1="-12.407153914654268" p2="143.36690219067955" q2="111.16639040236207">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_9f7663d9-452e-4006-88ac-295dc5108fe7" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_c58940cb-bd36-4dfc-9615-11716dd652a7" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" bus1="_044a8615-c766-11e1-8775-005056c00008" connectableBus1="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" bus2="_04716f04-c766-11e1-8775-005056c00008" connectableBus2="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="154.41756560727939" q1="67.205563203295085" p2="-143.34074618729642" q2="-45.509103132563432">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_f2cd1019-50d4-4961-a413-a74f33221b99" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3c9a454c-10ee-4c72-a059-77f723f5b7c7" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" bus1="_0447ee09-c766-11e1-8775-005056c00008" connectableBus1="_0447ee09-c766-11e1-8775-005056c00008" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" bus2="_04898ae9-c766-11e1-8775-005056c00008" connectableBus2="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-80.995912306866543" q1="-38.618307531661202" p2="82.241960031221012" q2="42.296027401305359">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7452c739-95b4-4967-9703-6790355cb281" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_270a7d04-9ff9-4178-8b72-b610735a72ac" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" bus1="_046a4314-c766-11e1-8775-005056c00008" connectableBus1="_046a4314-c766-11e1-8775-005056c00008" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" bus2="_048c22f1-c766-11e1-8775-005056c00008" connectableBus2="_048c22f1-c766-11e1-8775-005056c00008" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="23.666369552292178" q1="7.0784482147316252" p2="-23.531568379730007" q2="-7.9782070996890244">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_701af727-7df8-4c87-9615-f7ade9c35e3a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_9d1eb182-ceb5-426e-9440-5f4d426a31cb" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" bus1="_04494d93-c766-11e1-8775-005056c00008" connectableBus1="_04494d93-c766-11e1-8775-005056c00008" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" bus2="_04549837-c766-11e1-8775-005056c00008" connectableBus2="_04549837-c766-11e1-8775-005056c00008" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-17.472408475841274" q1="-4.4349168198990219" p2="17.564863245055783" q2="2.06313835942843">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7f361a6a-3949-46c7-a8dd-e212dd07dfcc" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_735ac8df-6a6a-43f0-86f2-49d3280c9a3b" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" bus1="_04549837-c766-11e1-8775-005056c00008" connectableBus1="_04549837-c766-11e1-8775-005056c00008" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" bus2="_04769f21-c766-11e1-8775-005056c00008" connectableBus2="_04769f21-c766-11e1-8775-005056c00008" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="3.7694392072534879" q1="3.3952377875399691" p2="-3.763353922891012" q2="-5.2046381672754816">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_83d1a365-5ebd-48e1-b477-f4bdcb1c880b" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_52aadf8d-53f2-4827-8c70-421bdf1ba822" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" bus1="_04898ae9-c766-11e1-8775-005056c00008" connectableBus1="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" bus2="_04667284-c766-11e1-8775-005056c00008" connectableBus2="_04667284-c766-11e1-8775-005056c00008" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.28360791212228" q1="31.412331038367235" p2="-12.076209090269602" q2="-33.018881039078011">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_77813798-83ae-4088-a129-0c46810ef5f1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_fece5807-6af8-4161-8de8-8f8473d92f11" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" bus1="_04597a36-c766-11e1-8775-005056c00008" connectableBus1="_04597a36-c766-11e1-8775-005056c00008" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" bus2="_04550d63-c766-11e1-8775-005056c00008" connectableBus2="_04550d63-c766-11e1-8775-005056c00008" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="58.435804204506169" q1="18.420365009494592" p2="-56.963077642825596" q2="-16.038311965610376">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_07a99745-5437-4372-a0a7-3b4704c6e20c" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_3eacc034-737e-41de-a7b6-b610d3bd0921" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" bus1="_045b9d15-c766-11e1-8775-005056c00008" connectableBus1="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" bus2="_0467f927-c766-11e1-8775-005056c00008" connectableBus2="_0467f927-c766-11e1-8775-005056c00008" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="3.2408813745786342" q1="-7.0299753522890889" p2="-3.2236603893306528" q2="4.8662939687240083">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_5e786d5a-d8b0-4e68-8b0e-80418c4a25da" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_0d0c3ec5-798a-48a4-9bc8-d19c57128a13" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" bus1="_0474071a-c766-11e1-8775-005056c00008" connectableBus1="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" bus2="_045e0e10-c766-11e1-8775-005056c00008" connectableBus2="_045e0e10-c766-11e1-8775-005056c00008" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="-12.939823597916009" q1="23.079676317390831" p2="13.465074325503506" q2="-22.995210376543753">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_92371c95-ca5e-4604-96b0-3ee21aa98f9b" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_5b0395f4-534d-4975-a1af-e0b6ef439193" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" bus1="_045ef874-c766-11e1-8775-005056c00008" connectableBus1="_045ef874-c766-11e1-8775-005056c00008" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" bus2="_0480d858-c766-11e1-8775-005056c00008" connectableBus2="_0480d858-c766-11e1-8775-005056c00008" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-5.1033425380019963" q1="4.9164889610487021" p2="5.105853511956405" q2="-5.0264425586650709">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7100ff8d-0038-4fea-b382-1114fdbbbb80" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_74c4b341-7b99-4a81-b88a-2ed3b0c4b1de" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0475dbd8-c766-11e1-8775-005056c00008" name="63-64" r="0.83248" x="9.6799990000000005" g1="0" b1="0.00022314049999999999" g2="0" b2="0.00022314049999999999" bus1="_047f2aa7-c766-11e1-8775-005056c00008" connectableBus1="_047f2aa7-c766-11e1-8775-005056c00008" voltageLevelId1="_04854527-c766-11e1-8775-005056c00008" bus2="_0457f395-c766-11e1-8775-005056c00008" connectableBus2="_0457f395-c766-11e1-8775-005056c00008" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-171.3686673883399" q1="-66.216452351369824" p2="171.96570132197039" q2="52.604627459878358">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_eb59d486-fc89-4f4e-9fa7-ec08a3c9cf64" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_ae4eadea-f3fc-4ac6-8899-c1698ece7a89" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" bus1="_048b86b5-c766-11e1-8775-005056c00008" connectableBus1="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" bus2="_045868c7-c766-11e1-8775-005056c00008" connectableBus2="_045868c7-c766-11e1-8775-005056c00008" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="-35.251146358333443" q1="40.131125261203117" p2="38.97407901581218" q2="-31.385464081442116">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_7c0938b3-2f8c-437c-8ed9-3d743f305160" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_e98d56fe-a54b-45e4-acff-0ac310beb3dd" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" bus1="_044b7072-c766-11e1-8775-005056c00008" connectableBus1="_044b7072-c766-11e1-8775-005056c00008" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-51.908698572062804" q1="-1.4891275587484709" p2="52.380794521374732" q2="1.5227349298576665">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_472d8096-6f57-454e-a3d8-3f306b4f4f27" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_f2e58700-2366-46e0-8408-9472d85acd23" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" bus1="_045b9d15-c766-11e1-8775-005056c00008" connectableBus1="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-38.545871662621131" q1="0.26592999695380232" p2="39.90102704884729" q2="-1.4907375267322984">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_3b9aa0d5-4cdd-4527-91e2-89d797598afe" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_89654167-95a6-4c76-aad7-63a881116e17" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" bus1="_045c8773-c766-11e1-8775-005056c00008" connectableBus1="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" bus2="_0468bc75-c766-11e1-8775-005056c00008" connectableBus2="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-11.93558362095764" q1="-51.051627482491" p2="12.384972298050032" q2="46.453008741690525">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_45d8a8d9-59e4-412f-8e4e-ac26b87c52b6" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_216c0f3b-03e8-4b7d-96fc-a5f891331f7f" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_04862f81-c766-11e1-8775-005056c00008" connectableBus2="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-196.95086671614689" q1="22.449820305223582" p2="203.7481707388026" q2="9.5948644832964689">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_1451f44e-543d-4c6f-b201-d7a52943238a" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_32655e4f-e7da-46b0-a908-b601224ddb73" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" bus1="_045a1670-c766-11e1-8775-005056c00008" connectableBus1="_045a1670-c766-11e1-8775-005056c00008" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" bus2="_0461b794-c766-11e1-8775-005056c00008" connectableBus2="_0461b794-c766-11e1-8775-005056c00008" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-68.106736724351407" q1="-12.670153584605822" p2="69.851361736439941" q2="19.284374677698729">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_a4ca519a-5dee-49fc-9d34-d25e4d3e0430" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_bafaeace-e459-4dc2-87a0-467a9ea25f8d" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+</iidm:network>

--- a/dynaflow/src/test/resources/SmallBusBranch/powsybl-inputs/SmallBusBranch.xiidm
+++ b/dynaflow/src/test/resources/SmallBusBranch/powsybl-inputs/SmallBusBranch.xiidm
@@ -1,0 +1,2372 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_2" id="urn:uuid:2399cbd2-9a39-11e0-aa80-0800200c9a66_EU" caseDate="2030-01-02T09:00:00.000Z" forecastDistance="7993438" sourceFormat="CGMES">
+    <iidm:property name="CGMESModelDetail" value="bus-branch"/>
+    <iidm:substation id="_047c929a-c766-11e1-8775-005056c00008" name="Godrics Hollow" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0460f448-c766-11e1-8775-005056c00008" name="GOD132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045a1670-c766-11e1-8775-005056c00008" name="Jay" v="126.706635" angle="-16.31623"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14.0" q0="8.0" bus="_045a1670-c766-11e1-8775-005056c00008" connectableBus="_045a1670-c766-11e1-8775-005056c00008" p="14.0" q="8.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04819ba1-c766-11e1-8775-005056c00008" name="Nurmengard" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0476c639-c766-11e1-8775-005056c00008" name="NUR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04483c26-c766-11e1-8775-005056c00008" name="Madison" v="128.132538" angle="-14.5066376"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62.0" q0="13.0" bus="_04483c26-c766-11e1-8775-005056c00008" connectableBus="_04483c26-c766-11e1-8775-005056c00008" p="62.0" q="13.0"></iidm:load>
+            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9.0" q0="0.0" bus="_04483c26-c766-11e1-8775-005056c00008" connectableBus="_04483c26-c766-11e1-8775-005056c00008" p="9.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04542302-c766-11e1-8775-005056c00008" name="Gringotts" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0450eeb4-c766-11e1-8775-005056c00008" name="GRI132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04549837-c766-11e1-8775-005056c00008" name="Torrey" v="126.06" angle="-14.6406355"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20.0" maxP="80.0" ratedS="100.0" voltageRegulatorOn="true" targetP="48.0" targetV="126.06" targetQ="0.0" bus="_04549837-c766-11e1-8775-005056c00008" connectableBus="_04549837-c766-11e1-8775-005056c00008" p="-48.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_b97aee41-3115-4cfd-9071-b52fb44d0b66"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_5005c073-28d1-4a7d-b257-649dec43ec73"/>
+                <iidm:minMaxReactiveLimits minQ="-30.0" maxQ="85.0"/>
+            </iidm:generator>
+            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113.0" q0="32.0" bus="_04549837-c766-11e1-8775-005056c00008" connectableBus="_04549837-c766-11e1-8775-005056c00008" p="113.0" q="32.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045de701-c766-11e1-8775-005056c00008" name="Needlehole" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04808a33-c766-11e1-8775-005056c00008" name="NEE132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047ba835-c766-11e1-8775-005056c00008" name="Darrah" v="123.719063" angle="-8.168152"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68.0" q0="36.0" bus="_047ba835-c766-11e1-8775-005056c00008" connectableBus="_047ba835-c766-11e1-8775-005056c00008" p="68.0" q="36.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0472f5a8-c766-11e1-8775-005056c00008" name="Dale" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0467d214-c766-11e1-8775-005056c00008" name="DAL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04845ac5-c766-11e1-8775-005056c00008" name="Smythe" v="130.725067" angle="2.296253"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5.0" q0="3.0" bus="_04845ac5-c766-11e1-8775-005056c00008" connectableBus="_04845ac5-c766-11e1-8775-005056c00008" p="5.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047a48a3-c766-11e1-8775-005056c00008" name="Hogsmeade" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047e675c-c766-11e1-8775-005056c00008" name="HOG132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045b9d15-c766-11e1-8775-005056c00008" name="Sunnysde" v="125.9138" angle="-14.74322"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84.0" q0="18.0" bus="_045b9d15-c766-11e1-8775-005056c00008" connectableBus="_045b9d15-c766-11e1-8775-005056c00008" p="84.0" q="18.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046f4c23-c766-11e1-8775-005056c00008" name="Barad-dûr" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047dcb11-c766-11e1-8775-005056c00008" name="BAR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0486f2d6-c766-11e1-8775-005056c00008" name="Bellefnt" v="126.403" angle="-8.388306"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68.0" q0="27.0" bus="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus="_0486f2d6-c766-11e1-8775-005056c00008" p="68.0" q="27.0"></iidm:load>
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" bPerSection="1.378E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="126.403" targetDeadband="1.0" bus="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus="_0486f2d6-c766-11e1-8775-005056c00008" q="-11.0086479">
+                <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047a6fb6-c766-11e1-8775-005056c00008" name="Waymoot" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04740714-c766-11e1-8775-005056c00008" name="WAY132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04550d63-c766-11e1-8775-005056c00008" name="Fieldale" v="126.066" angle="-11.6781759"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39.0" q0="30.0" bus="_04550d63-c766-11e1-8775-005056c00008" connectableBus="_04550d63-c766-11e1-8775-005056c00008" p="39.0" q="30.0"></iidm:load>
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" bPerSection="6.88E-5" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1.0" bus="_04550d63-c766-11e1-8775-005056c00008" connectableBus="_04550d63-c766-11e1-8775-005056c00008" q="-5.46706724">
+                <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0488eea9-c766-11e1-8775-005056c00008" name="Upbourn" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047147f4-c766-11e1-8775-005056c00008" name="UPB132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04862f81-c766-11e1-8775-005056c00008" name="Muskngum1" v="138.599991" angle="-2.44860148"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_047f0391-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200.0" maxP="400.0" ratedS="500.0" voltageRegulatorOn="true" targetP="392.0" targetV="138.599991" targetQ="0.0" bus="_04862f81-c766-11e1-8775-005056c00008" connectableBus="_04862f81-c766-11e1-8775-005056c00008" p="-392.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_d9948603-709f-41dd-a0ff-2ebda091255a"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_23727856-fd9b-4124-a981-4e862148f3bb"/>
+                <iidm:minMaxReactiveLimits minQ="-150.0" maxQ="450.0"/>
+            </iidm:generator>
+            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39.0" q0="18.0" bus="_04862f81-c766-11e1-8775-005056c00008" connectableBus="_04862f81-c766-11e1-8775-005056c00008" p="39.0" q="18.0"></iidm:load>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_0463da78-c766-11e1-8775-005056c00008" name="UPB220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0458ddf2-c766-11e1-8775-005056c00008" name="Muskngum2" v="221.1" angle="-2.31989479"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200.0" maxP="400.0" ratedS="500.0" voltageRegulatorOn="true" targetP="391.0" targetV="221.1" targetQ="0.0" bus="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus="_0458ddf2-c766-11e1-8775-005056c00008" p="-391.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_12b01822-ca11-4cf8-a6b4-2f8ff805ca20"/>
+                <iidm:minMaxReactiveLimits minQ="-150.0" maxQ="450.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0.0" x="6.44688" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus1="_0458ddf2-c766-11e1-8775-005056c00008" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" bus2="_04862f81-c766-11e1-8775-005056c00008" connectableBus2="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.06951871657754"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9389671361502347"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8849557522123894"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8368200836820083"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7936507936507936"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7547169811320755"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7194244604316546"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6872852233676976"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6578947368421053"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6309148264984227"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6060606060606061"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5830903790087463"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_069c77f0-1cf0-491a-ae17-8f71e0c7cc0b" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_a7b7f7b8-4ee3-45f5-ba3e-edb3678e0866" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_85b581c6-1005-4dc0-a758-ad5cfa9b05c4" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_981fee8c-aaa5-4946-b2d2-292bb3a4e7df" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_04773b6b-c766-11e1-8775-005056c00008" name="Fornost Erain" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046b2d70-c766-11e1-8775-005056c00008" name="FOR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0474f17a-c766-11e1-8775-005056c00008" name="Adams" v="126.359306" angle="-17.8946"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18.0" q0="3.0" bus="_0474f17a-c766-11e1-8775-005056c00008" connectableBus="_0474f17a-c766-11e1-8775-005056c00008" p="18.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04887979-c766-11e1-8775-005056c00008" name="The Wall" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0475b4c0-c766-11e1-8775-005056c00008" name="THE132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04597a36-c766-11e1-8775-005056c00008" name="Claytor" v="133.319992" angle="-5.7111764"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0.0" maxP="160.0" ratedS="200.0" voltageRegulatorOn="true" targetP="40.0" targetV="133.319992" targetQ="0.0" bus="_04597a36-c766-11e1-8775-005056c00008" connectableBus="_04597a36-c766-11e1-8775-005056c00008" p="-40.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_e56da2eb-bb6a-4133-953c-40073c5bc5f4"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_d41be6b4-155e-4c8f-b46b-16b50c49f0f4"/>
+                <iidm:minMaxReactiveLimits minQ="-60.0" maxQ="170.0"/>
+            </iidm:generator>
+            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23.0" q0="16.0" bus="_04597a36-c766-11e1-8775-005056c00008" connectableBus="_04597a36-c766-11e1-8775-005056c00008" p="23.0" q="16.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04795e41-c766-11e1-8775-005056c00008" name="Havens of the Falas" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045d23b4-c766-11e1-8775-005056c00008" name="HAV132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04725962-c766-11e1-8775-005056c00008" name="N.Newark" v="130.323" angle="-14.23693"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53.0" q0="22.0" bus="_04725962-c766-11e1-8775-005056c00008" connectableBus="_04725962-c766-11e1-8775-005056c00008" p="53.0" q="22.0"></iidm:load>
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.323" targetDeadband="1.0" bus="_04725962-c766-11e1-8775-005056c00008" connectableBus="_04725962-c766-11e1-8775-005056c00008" q="-9.748864">
+                <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047e404a-c766-11e1-8775-005056c00008" name="Minas Anor" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048433b5-c766-11e1-8775-005056c00008" name="MNA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0472a783-c766-11e1-8775-005056c00008" name="Hillsbro" v="131.421951" angle="-9.167447"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12.0" q0="0.0" bus="_0472a783-c766-11e1-8775-005056c00008" connectableBus="_0472a783-c766-11e1-8775-005056c00008" p="12.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0449c2ca-c766-11e1-8775-005056c00008" name="Avallonë" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045e8349-c766-11e1-8775-005056c00008" name="AVA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046bf0cb-c766-11e1-8775-005056c00008" name="S.Kenton" v="129.64537" angle="-18.6851273"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18.0" q0="7.0" bus="_046bf0cb-c766-11e1-8775-005056c00008" connectableBus="_046bf0cb-c766-11e1-8775-005056c00008" p="18.0" q="7.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0468bc71-c766-11e1-8775-005056c00008" name="Vale of Arryn" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0484f70a-c766-11e1-8775-005056c00008" name="VLA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04689561-c766-11e1-8775-005056c00008" name="Hazard" v="129.887009" angle="1.19663978"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21.0" q0="10.0" bus="_04689561-c766-11e1-8775-005056c00008" connectableBus="_04689561-c766-11e1-8775-005056c00008" p="21.0" q="10.0"></iidm:load>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_04555b88-c766-11e1-8775-005056c00008" name="VALE33KV" nominalV="33.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04505279-c766-11e1-8775-005056c00008" name="Pinevlle" v="33.495" angle="1.43515372"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_047fc6e6-c766-11e1-8775-005056c00008" name="Pinevlle SM" energySource="THERMAL" minP="0.0" maxP="40.0" ratedS="50.0" voltageRegulatorOn="true" targetP="4.0" targetV="33.495" targetQ="0.0" bus="_04505279-c766-11e1-8775-005056c00008" connectableBus="_04505279-c766-11e1-8775-005056c00008" p="-4.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_9a6bdb3c-346d-4426-8127-5f6cbf0150b2"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_98f667da-02d1-4a31-b826-44314a1fbbfe"/>
+                <iidm:minMaxReactiveLimits minQ="-15.0" maxQ="45.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.3079691875" x="2.25858593125" g="0.0" b="-0.0040863184" ratedU1="132.0" ratedU2="33.0" bus1="_04689561-c766-11e1-8775-005056c00008" connectableBus1="_04689561-c766-11e1-8775-005056c00008" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" bus2="_04505279-c766-11e1-8775-005056c00008" connectableBus2="_04505279-c766-11e1-8775-005056c00008" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="31" loadTapChangingCapabilities="false">
+                <iidm:step r="-78.46097048774399" x="-78.46097048774399" g="364.2734712959033" b="364.2734712959033" rho="0.4641016"/>
+                <iidm:step r="-76.77098544465856" x="-76.77098544465856" g="330.4960925559595" b="330.4960925559595" rho="0.48196488000000004"/>
+                <iidm:step r="-75.01718104710143" x="-75.01718104710143" g="300.2750858041092" b="300.2750858041092" rho="0.49982816"/>
+                <iidm:step r="-73.19955729507262" x="-73.19955729507262" g="273.1281647135425" b="273.1281647135425" rho="0.5176914400000001"/>
+                <iidm:step r="-71.31811418857215" x="-71.31811418857215" g="248.65210975826625" b="248.65210975826625" rho="0.53555472"/>
+                <iidm:step r="-69.37285172760001" x="-69.37285172760001" g="226.5077084898438" b="226.5077084898438" rho="0.553418"/>
+                <iidm:step r="-67.36376991215616" x="-67.36376991215616" g="206.40793906293555" b="206.40793906293555" rho="0.57128128"/>
+                <iidm:step r="-65.29086874224063" x="-65.29086874224063" g="188.10862264852744" b="188.10862264852744" rho="0.58914456"/>
+                <iidm:step r="-63.15414821785343" x="-63.15414821785343" g="171.40097232995538" b="171.40097232995538" rho="0.6070078400000001"/>
+                <iidm:step r="-60.953608338994556" x="-60.953608338994556" g="156.1056111616768" b="156.1056111616768" rho="0.62487112"/>
+                <iidm:step r="-58.689249105664" x="-58.689249105664" g="142.0677374172608" b="142.0677374172608" rho="0.6427344"/>
+                <iidm:step r="-56.36107051786177" x="-56.36107051786177" g="129.1531923140571" b="129.1531923140571" rho="0.66059768"/>
+                <iidm:step r="-53.96907257558784" x="-53.96907257558784" g="117.24524269951107" b="117.24524269951107" rho="0.67846096"/>
+                <iidm:step r="-51.51325527884223" x="-51.51325527884223" g="106.24193390397649" b="106.24193390397649" rho="0.69632424"/>
+                <iidm:step r="-48.99361862762495" x="-48.99361862762495" g="96.05390013838502" b="96.05390013838502" rho="0.7141875200000001"/>
+                <iidm:step r="-46.410162621936" x="-46.410162621936" g="86.60254423711527" b="86.60254423711527" rho="0.7320508"/>
+                <iidm:step r="-43.762887261775354" x="-43.762887261775354" g="77.81851722275475" b="77.81851722275475" rho="0.7499140799999999"/>
+                <iidm:step r="-41.05179254714304" x="-41.05179254714304" g="69.64044255285229" b="69.64044255285229" rho="0.76777736"/>
+                <iidm:step r="-38.276878478039045" x="-38.276878478039045" g="62.01384106022605" b="62.01384106022605" rho="0.78564064"/>
+                <iidm:step r="-35.438145054463355" x="-35.438145054463355" g="54.89022129918419" b="54.89022129918419" rho="0.80350392"/>
+                <iidm:step r="-32.53559227641599" x="-32.53559227641599" g="48.2263068397802" b="48.2263068397802" rho="0.8213672000000001"/>
+                <iidm:step r="-29.569220143896956" x="-29.569220143896956" g="41.9833774442222" b="41.9833774442222" rho="0.83923048"/>
+                <iidm:step r="-26.53902865690624" x="-26.53902865690624" g="36.12670533984335" b="36.12670533984335" rho="0.85709376"/>
+                <iidm:step r="-23.445017815443848" x="-23.445017815443848" g="30.6250712186483" b="30.6250712186483" rho="0.8749570400000001"/>
+                <iidm:step r="-20.287187619509762" x="-20.287187619509762" g="25.45034733271443" b="25.45034733271443" rho="0.8928203200000001"/>
+                <iidm:step r="-17.06553806910399" x="-17.06553806910399" g="20.57713726209933" b="20.57713726209933" rho="0.9106836"/>
+                <iidm:step r="-13.780069164226571" x="-13.780069164226571" g="15.982463718828566" b="15.982463718828566" rho="0.92854688"/>
+                <iidm:step r="-10.430780904877434" x="-10.430780904877434" g="11.64549720345327" b="11.64549720345327" rho="0.94641016"/>
+                <iidm:step r="-7.017673291056637" x="-7.017673291056637" g="7.5473195169912355" b="7.5473195169912355" rho="0.96427344"/>
+                <iidm:step r="-3.5407463227641656" x="-3.5407463227641656" g="3.670717103630028" b="3.670717103630028" rho="0.9821367199999999"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="3.604565677235838" x="3.604565677235838" g="-3.479157171958336" b="-3.479157171958336" rho="1.01786328"/>
+                <iidm:step r="7.272950708943382" x="7.272950708943382" g="-6.779855183322592" b="-6.779855183322592" rho="1.03572656"/>
+                <iidm:step r="11.005155095122543" x="11.005155095122543" g="-9.914093706451743" b="-9.914093706451743" rho="1.0535898399999999"/>
+                <iidm:step r="14.801178835773431" x="14.801178835773431" g="-12.892880531259154" b="-12.892880531259154" rho="1.07145312"/>
+                <iidm:step r="18.661021930895984" x="18.661021930895984" g="-15.726328348801433" b="-15.726328348801433" rho="1.0893164"/>
+                <iidm:step r="22.584684380490238" x="22.584684380490238" g="-18.423740693731116" b="-18.423740693731116" rho="1.10717968"/>
+                <iidm:step r="26.572166184556178" x="26.572166184556178" g="-20.993688411566747" b="-20.993688411566747" rho="1.12504296"/>
+                <iidm:step r="30.62346734309378" x="30.62346734309378" g="-23.444077826121855" b="-23.444077826121855" rho="1.14290624"/>
+                <iidm:step r="34.73858785610307" x="34.73858785610307" g="-25.78221162092249" b="-25.78221162092249" rho="1.16076952"/>
+                <iidm:step r="38.91752772358399" x="38.91752772358399" g="-28.01484331122096" b="-28.01484331122096" rho="1.1786328"/>
+                <iidm:step r="43.16028694553664" x="43.16028694553664" g="-30.148226066322692" b="-30.148226066322692" rho="1.19649608"/>
+                <iidm:step r="47.466865521960955" x="47.466865521960955" g="-32.18815654211632" b="-32.18815654211632" rho="1.21435936"/>
+                <iidm:step r="51.83726345285697" x="51.83726345285697" g="-34.140014298236885" b="-34.140014298236885" rho="1.23222264"/>
+                <iidm:step r="56.27148073822465" x="56.27148073822465" g="-36.0087973009527" b="-36.0087973009527" rho="1.25008592"/>
+                <iidm:step r="60.76951737806397" x="60.76951737806397" g="-37.799153949787" b="-37.799153949787" rho="1.2679491999999999"/>
+                <iidm:step r="65.33137337237503" x="65.33137337237503" g="-39.51541201150582" b="-39.51541201150582" rho="1.28581248"/>
+                <iidm:step r="69.95704872115776" x="69.95704872115776" g="-41.161604798123854" b="-41.161604798123854" rho="1.30367576"/>
+                <iidm:step r="74.64654342441217" x="74.64654342441217" g="-42.74149488490709" b="-42.74149488490709" rho="1.32153904"/>
+                <iidm:step r="79.39985748213824" x="79.39985748213824" g="-44.25859562906487" b="-44.25859562906487" rho="1.33940232"/>
+                <iidm:step r="84.21699089433596" x="84.21699089433596" g="-45.716190719151165" b="-45.716190719151165" rho="1.3572655999999998"/>
+                <iidm:step r="89.09794366100547" x="89.09794366100547" g="-47.11735195848069" b="-47.11735195848069" rho="1.37512888"/>
+                <iidm:step r="94.04271578214653" x="94.04271578214653" g="-48.46495546255347" b="-48.46495546255347" rho="1.39299216"/>
+                <iidm:step r="99.05130725775935" x="99.05130725775935" g="-49.76169643010378" b="-49.76169643010378" rho="1.41085544"/>
+                <iidm:step r="104.12371808784383" x="104.12371808784383" g="-51.01010262954087" b="-51.01010262954087" rho="1.42871872"/>
+                <iidm:step r="109.25994827240002" x="109.25994827240002" g="-52.21254672689349" b="-52.21254672689349" rho="1.446582"/>
+                <iidm:step r="114.45999781142788" x="114.45999781142788" g="-53.371257567609966" b="-53.371257567609966" rho="1.46444528"/>
+                <iidm:step r="119.72386670492732" x="119.72386670492732" g="-54.48833051245521" b="-54.48833051245521" rho="1.4823085599999999"/>
+                <iidm:step r="125.05155495289854" x="125.05155495289854" g="-55.5657369170681" b="-55.5657369170681" rho="1.50017184"/>
+                <iidm:step r="130.44306255534144" x="130.44306255534144" g="-56.60533283531382" b="-56.60533283531382" rho="1.51803512"/>
+                <iidm:step r="135.898389512256" x="135.898389512256" g="-57.60886701822754" b="-57.60886701822754" rho="1.5358984"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_580d3b53-5508-4d8d-97cc-4ea463e0cdb9" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_a867e68a-58d1-49cb-955f-bb8e59cf2a11" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="8747.0">
+                <iidm:temporaryLimit name="_1a7f23f9-e2c0-46a6-a93c-687f2209e33d" acceptableDuration="900" value="10059.0"/>
+                <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_045beb3a-c766-11e1-8775-005056c00008" name="Minas Tirith" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048a9c58-c766-11e1-8775-005056c00008" name="MNT132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04555b87-c766-11e1-8775-005056c00008" name="NwCarlsl" v="133.2002" angle="-14.585494"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9.0" q0="0.0" bus="_04555b87-c766-11e1-8775-005056c00008" connectableBus="_04555b87-c766-11e1-8775-005056c00008" p="9.0" q="0.0"></iidm:load>
+            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30.0" q0="12.0" bus="_04555b87-c766-11e1-8775-005056c00008" connectableBus="_04555b87-c766-11e1-8775-005056c00008" p="30.0" q="12.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047120e4-c766-11e1-8775-005056c00008" name="Bywater" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046c65f4-c766-11e1-8775-005056c00008" name="BYW132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046b7b91-c766-11e1-8775-005056c00008" name="Blaine" v="126.616516" angle="-10.5192728"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2.0" q0="1.0" bus="_046b7b91-c766-11e1-8775-005056c00008" connectableBus="_046b7b91-c766-11e1-8775-005056c00008" p="2.0" q="1.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0467f928-c766-11e1-8775-005056c00008" name="Tirion" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048bd4da-c766-11e1-8775-005056c00008" name="TIR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04667284-c766-11e1-8775-005056c00008" name="Sundial" v="133.4717" angle="-2.1101048"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15.0" q0="9.0" bus="_04667284-c766-11e1-8775-005056c00008" connectableBus="_04667284-c766-11e1-8775-005056c00008" p="15.0" q="9.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_048badc8-c766-11e1-8775-005056c00008" name="White Harbor" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0488c79a-c766-11e1-8775-005056c00008" name="WHI132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044a8618-c766-11e1-8775-005056c00008" name="Riversde" v="126.882912" angle="-19.081995"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51.0" q0="27.0" bus="_044a8618-c766-11e1-8775-005056c00008" connectableBus="_044a8618-c766-11e1-8775-005056c00008" p="51.0" q="27.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045e8345-c766-11e1-8775-005056c00008" name="Nobottle" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04773b6a-c766-11e1-8775-005056c00008" name="NOB132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0461b794-c766-11e1-8775-005056c00008" name="Randolph" v="128.468643" angle="-13.7844219"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10.0" q0="5.0" bus="_0461b794-c766-11e1-8775-005056c00008" connectableBus="_0461b794-c766-11e1-8775-005056c00008" p="10.0" q="5.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0452c37a-c766-11e1-8775-005056c00008" name="Formenos" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0478c204-c766-11e1-8775-005056c00008" name="FRM132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0467f927-c766-11e1-8775-005056c00008" name="WNwPhil2" v="126.58252" angle="-14.3884716"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12.0" q0="3.0" bus="_0467f927-c766-11e1-8775-005056c00008" connectableBus="_0467f927-c766-11e1-8775-005056c00008" p="12.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046b0666-c766-11e1-8775-005056c00008" name="Vinyamar" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04479fe8-c766-11e1-8775-005056c00008" name="VIN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044ef2e3-c766-11e1-8775-005056c00008" name="Cloverdl" v="126.723633" angle="-9.66302"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43.0" q0="16.0" bus="_044ef2e3-c766-11e1-8775-005056c00008" connectableBus="_044ef2e3-c766-11e1-8775-005056c00008" p="43.0" q="16.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046dec9b-c766-11e1-8775-005056c00008" name="Aldburg" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0483977a-c766-11e1-8775-005056c00008" name="ALD132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046783f5-c766-11e1-8775-005056c00008" name="Hancock" v="128.113724" angle="-8.302711"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38.0" q0="25.0" bus="_046783f5-c766-11e1-8775-005056c00008" connectableBus="_046783f5-c766-11e1-8775-005056c00008" p="38.0" q="25.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04865696-c766-11e1-8775-005056c00008" name="Scary" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04544a15-c766-11e1-8775-005056c00008" name="SCA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047c4478-c766-11e1-8775-005056c00008" name="WMVernon" v="130.212" angle="-16.10395"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16.0" q0="8.0" bus="_047c4478-c766-11e1-8775-005056c00008" connectableBus="_047c4478-c766-11e1-8775-005056c00008" p="16.0" q="8.0"></iidm:load>
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.212" targetDeadband="1.0" bus="_047c4478-c766-11e1-8775-005056c00008" connectableBus="_047c4478-c766-11e1-8775-005056c00008" q="-9.732265">
+                <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046030f9-c766-11e1-8775-005056c00008" name="Winterfell" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044f4102-c766-11e1-8775-005056c00008" name="WIN220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047ba832-c766-11e1-8775-005056c00008" name="Breed" v="230.999985" angle="5.752662"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300.0" maxP="600.0" ratedS="750.0" voltageRegulatorOn="true" targetP="450.0" targetV="230.999985" targetQ="0.0" bus="_047ba832-c766-11e1-8775-005056c00008" connectableBus="_047ba832-c766-11e1-8775-005056c00008" p="-450.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_f26d4eb3-ebdb-4025-8080-f856ce656b42"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_7566f2a7-61eb-42fe-a59a-8276257fdbc6"/>
+                <iidm:minMaxReactiveLimits minQ="-225.0" maxQ="640.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04703680-c766-11e1-8775-005056c00008" name="Brithombar" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04542300-c766-11e1-8775-005056c00008" name="BRI132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046a4314-c766-11e1-8775-005056c00008" name="Newcmrst" v="127.620132" angle="-13.6114807"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17.0" q0="8.0" bus="_046a4314-c766-11e1-8775-005056c00008" connectableBus="_046a4314-c766-11e1-8775-005056c00008" p="17.0" q="8.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0480b149-c766-11e1-8775-005056c00008" name="Nindamos" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04728079-c766-11e1-8775-005056c00008" name="NIN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04689567-c766-11e1-8775-005056c00008" name="TannrsCk1" v="138.599991" angle="-1.946908"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100.0" maxP="400.0" ratedS="500.0" voltageRegulatorOn="true" targetP="220.0" targetV="138.599991" targetQ="0.0" bus="_04689567-c766-11e1-8775-005056c00008" connectableBus="_04689567-c766-11e1-8775-005056c00008" p="-220.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_56975783-9739-40fc-8ec1-e1de8cb06c9a"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_b8449cd9-5a17-497e-bf04-70f728b0f9f2"/>
+                <iidm:minMaxReactiveLimits minQ="-150.0" maxQ="450.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_044f8f2a-c766-11e1-8775-005056c00008" name="NIN220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0455a9a6-c766-11e1-8775-005056c00008" name="TannrsCk2" v="223.3" angle="-0.158602178"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100.0" maxP="400.0" ratedS="500.0" voltageRegulatorOn="true" targetP="314.0" targetV="223.3" targetQ="0.0" bus="_0455a9a6-c766-11e1-8775-005056c00008" connectableBus="_0455a9a6-c766-11e1-8775-005056c00008" p="-314.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_05df66ba-3f64-40cb-8b18-c66d26c4e2c1"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_c1d29442-5f57-41d1-bb60-4b74b4994c20"/>
+                <iidm:minMaxReactiveLimits minQ="-150.0" maxQ="450.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0.0" x="6.6559680000000006" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_0455a9a6-c766-11e1-8775-005056c00008" connectableBus1="_0455a9a6-c766-11e1-8775-005056c00008" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" bus2="_04689567-c766-11e1-8775-005056c00008" connectableBus2="_04689567-c766-11e1-8775-005056c00008" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.041666688368056"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9615384430473377"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9259258916323744"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8928570950255128"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_ac81f7ca-04be-4b10-838b-fd5171e1b0f7" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_2a113652-9eee-4aa3-8fc5-b6ebccfafda5" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_f357d7c9-5bbd-4c6b-960a-7384577353db" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_42b6b196-1272-48c6-a627-914c00e3fe3e" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_04553470-c766-11e1-8775-005056c00008" name="Haysend" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0471bd23-c766-11e1-8775-005056c00008" name="HAY132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044a8615-c766-11e1-8775-005056c00008" name="Sporn1" v="136.62" angle="-0.0"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400.0" maxP="800.0" ratedS="1000.0" voltageRegulatorOn="true" targetP="513.437439" targetV="136.62" targetQ="-62.1325531" bus="_044a8615-c766-11e1-8775-005056c00008" connectableBus="_044a8615-c766-11e1-8775-005056c00008" p="-513.437439" q="62.1325531">
+                <iidm:property name="CGMES.GeneratingUnit" value="_27799004-aa1e-4889-ba95-ee6fdae64895"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_827a9c80-183d-4e33-9e73-ef0aab3dfb13"/>
+                <iidm:minMaxReactiveLimits minQ="-300.0" maxQ="850.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_0449e9d2-c766-11e1-8775-005056c00008" name="HAY220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044aad28-c766-11e1-8775-005056c00008" name="Sporn2" v="219.706345" angle="-2.41812253"/>
+            </iidm:busBreakerTopology>
+            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184.0" q0="0.0" r="0.16456" x="1.9602" g="0.0" b="3.38843E-4" ucteXnodeCode="XWE_BR21" bus="_044aad28-c766-11e1-8775-005056c00008" connectableBus="_044aad28-c766-11e1-8775-005056c00008" p="184.11572091711315" q="-14.972515845786626">
+                <iidm:currentLimits permanentLimit="1000.0">
+                    <iidm:temporaryLimit name="_7c27ab8a-8043-4a55-851d-72adb14d9f4d" acceptableDuration="900" value="1150.0"/>
+                    <iidm:temporaryLimit name="_f4458b8d-a0e1-4adc-977f-14a07b3c44e9" acceptableDuration="60" value="1400.0"/>
+                </iidm:currentLimits>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0.0" x="6.44688" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_044aad28-c766-11e1-8775-005056c00008" connectableBus1="_044aad28-c766-11e1-8775-005056c00008" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" bus2="_044a8615-c766-11e1-8775-005056c00008" connectableBus2="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.06951871657754"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9389671361502347"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8849557522123894"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8368200836820083"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7936507936507936"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7547169811320755"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_836577b9-5365-40b9-8bb1-0c635896faab" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_4ff8ded8-043c-467c-9730-a5f583b4631d" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_10213be6-3bb3-4f54-9d8e-67a412744ad4" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_5e63ebf0-b379-4249-91a8-f8f8c88302e7" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_046fe861-c766-11e1-8775-005056c00008" name="Bree" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046bf0c5-c766-11e1-8775-005056c00008" name="BRE132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044b9787-c766-11e1-8775-005056c00008" name="Natrium" v="131.702545" angle="-6.50974226"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77.0" q0="14.0" bus="_044b9787-c766-11e1-8775-005056c00008" connectableBus="_044b9787-c766-11e1-8775-005056c00008" p="77.0" q="14.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047fedfa-c766-11e1-8775-005056c00008" name="Mithlond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0485e169-c766-11e1-8775-005056c00008" name="MIT132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0480d858-c766-11e1-8775-005056c00008" name="Sterling" v="130.059479" angle="-19.1328583"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31.0" q0="17.0" bus="_0480d858-c766-11e1-8775-005056c00008" connectableBus="_0480d858-c766-11e1-8775-005056c00008" p="31.0" q="17.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0460f447-c766-11e1-8775-005056c00008" name="Pincup" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045ed163-c766-11e1-8775-005056c00008" name="PIN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045c8773-c766-11e1-8775-005056c00008" name="Switchbk" v="130.706055" angle="-1.35899651"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30.0" q0="16.0" bus="_045c8773-c766-11e1-8775-005056c00008" connectableBus="_045c8773-c766-11e1-8775-005056c00008" p="30.0" q="16.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0471e439-c766-11e1-8775-005056c00008" name="Casterly Rock" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04773b62-c766-11e1-8775-005056c00008" name="CAS132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044b7076-c766-11e1-8775-005056c00008" name="Bradley" v="135.103149" angle="-2.59428334"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34.0" q0="8.0" bus="_044b7076-c766-11e1-8775-005056c00008" connectableBus="_044b7076-c766-11e1-8775-005056c00008" p="34.0" q="8.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047cb9a6-c766-11e1-8775-005056c00008" name="Lannisport" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04819ba0-c766-11e1-8775-005056c00008" name="LAN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046c8d0b-c766-11e1-8775-005056c00008" name="Mullin" v="127.143242" angle="-16.2140541"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17.0" q0="7.0" bus="_046c8d0b-c766-11e1-8775-005056c00008" connectableBus="_046c8d0b-c766-11e1-8775-005056c00008" p="17.0" q="7.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0449c2c6-c766-11e1-8775-005056c00008" name="Armenelos" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04765109-c766-11e1-8775-005056c00008" name="ARM132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0468bc75-c766-11e1-8775-005056c00008" name="Glen Lyn" v="134.243988" angle="-1.97640443"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200.0" maxP="400.0" ratedS="500.0" voltageRegulatorOn="true" targetP="252.0" targetV="134.243988" targetQ="0.0" bus="_0468bc75-c766-11e1-8775-005056c00008" connectableBus="_0468bc75-c766-11e1-8775-005056c00008" p="-252.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_e54b499b-436c-4b89-9803-b1d75e2fa364"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5"/>
+                <iidm:minMaxReactiveLimits minQ="-150.0" maxQ="450.0"/>
+            </iidm:generator>
+            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37.0" q0="18.0" bus="_0468bc75-c766-11e1-8775-005056c00008" connectableBus="_0468bc75-c766-11e1-8775-005056c00008" p="37.0" q="18.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0474f171-c766-11e1-8775-005056c00008" name="Erebor" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044f6818-c766-11e1-8775-005056c00008" name="ERB132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046b066a-c766-11e1-8775-005056c00008" name="Kankakee" v="130.82402" angle="-16.7107086"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52.0" q0="22.0" bus="_046b066a-c766-11e1-8775-005056c00008" connectableBus="_046b066a-c766-11e1-8775-005056c00008" p="52.0" q="22.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045fe2d2-c766-11e1-8775-005056c00008" name="Ollivanders" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0465611a-c766-11e1-8775-005056c00008" name="OLL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04876809-c766-11e1-8775-005056c00008" name="Roanoke" v="127.423" angle="-9.429042"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31.0" q0="26.0" bus="_04876809-c766-11e1-8775-005056c00008" connectableBus="_04876809-c766-11e1-8775-005056c00008" p="31.0" q="26.0"></iidm:load>
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" bPerSection="2.296E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1.0" bus="_04876809-c766-11e1-8775-005056c00008" connectableBus="_04876809-c766-11e1-8775-005056c00008" q="-18.63964">
+                <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046cdb28-c766-11e1-8775-005056c00008" name="Pelargir" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048719e8-c766-11e1-8775-005056c00008" name="PEL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04577e63-c766-11e1-8775-005056c00008" name="Howard" v="123.81781" angle="-20.9805279"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37.0" q0="23.0" bus="_04577e63-c766-11e1-8775-005056c00008" connectableBus="_04577e63-c766-11e1-8775-005056c00008" p="37.0" q="23.0"></iidm:load>
+            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59.0" q0="0.0" bus="_04577e63-c766-11e1-8775-005056c00008" connectableBus="_04577e63-c766-11e1-8775-005056c00008" p="59.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044e56a1-c766-11e1-8775-005056c00008" name="Crickhollow" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048a272b-c766-11e1-8775-005056c00008" name="CRI220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0453d4e3-c766-11e1-8775-005056c00008" name="Kanawha" v="218.673645" angle="-1.87761688"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_046efe09-c766-11e1-8775-005056c00008" name="CRI132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04898ae9-c766-11e1-8775-005056c00008" name="CabinCrk" v="137.28" angle="-1.03307128"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300.0" maxP="600.0" ratedS="750.0" voltageRegulatorOn="true" targetP="477.0" targetV="137.28" targetQ="0.0" bus="_04898ae9-c766-11e1-8775-005056c00008" connectableBus="_04898ae9-c766-11e1-8775-005056c00008" p="-477.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_a6ec9760-88da-48df-a23f-7877e7c85ccd"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_e6131af8-c298-413b-84e3-4e21c3b6b06f"/>
+                <iidm:minMaxReactiveLimits minQ="-225.0" maxQ="640.0"/>
+            </iidm:generator>
+            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130.0" q0="26.0" bus="_04898ae9-c766-11e1-8775-005056c00008" connectableBus="_04898ae9-c766-11e1-8775-005056c00008" p="130.0" q="26.0"></iidm:load>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0.0" x="6.44688" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_0453d4e3-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e3-c766-11e1-8775-005056c00008" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" bus2="_04898ae9-c766-11e1-8775-005056c00008" connectableBus2="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.06951871657754"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9389671361502347"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8849557522123894"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8368200836820083"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7936507936507936"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7547169811320755"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7194244604316546"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6872852233676976"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6578947368421053"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6309148264984227"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6060606060606061"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5830903790087463"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5617977528089888"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5420054200542006"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5235602094240838"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5063291139240506"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_6ff12a17-7104-4420-bfdb-5621035eb4e5" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_f5010321-8804-4359-911d-7b7843d02753" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_b5d2a008-83c2-47a3-a978-283e6b8b2167" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_1a134158-4b67-4406-be2d-303158bd41c4" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_0478c205-c766-11e1-8775-005056c00008" name="Harlond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044778d3-c766-11e1-8775-005056c00008" name="HRL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044b7072-c766-11e1-8775-005056c00008" name="Zanesvll" v="134.723" angle="-9.946326"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20.0" q0="11.0" bus="_044b7072-c766-11e1-8775-005056c00008" connectableBus="_044b7072-c766-11e1-8775-005056c00008" p="20.0" q="11.0"></iidm:load>
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" bPerSection="1.722E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="134.723" targetDeadband="1.0" bus="_044b7072-c766-11e1-8775-005056c00008" connectableBus="_044b7072-c766-11e1-8775-005056c00008" q="-15.6273985">
+                <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04670ec0-c766-11e1-8775-005056c00008" name="Stock" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04789af0-c766-11e1-8775-005056c00008" name="STK132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04667289-c766-11e1-8775-005056c00008" name="Tazewell" v="130.195465" angle="0.792081952"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12.0" q0="7.0" bus="_04667289-c766-11e1-8775-005056c00008" connectableBus="_04667289-c766-11e1-8775-005056c00008" p="12.0" q="7.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04675ce0-c766-11e1-8775-005056c00008" name="Stormlands" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046bf0c7-c766-11e1-8775-005056c00008" name="STO132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04778983-c766-11e1-8775-005056c00008" name="NwLibrty" v="125.535988" angle="-21.3517132"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27.0" q0="11.0" bus="_04778983-c766-11e1-8775-005056c00008" connectableBus="_04778983-c766-11e1-8775-005056c00008" p="27.0" q="11.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044e7db2-c766-11e1-8775-005056c00008" name="Crownlands" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04784cd1-c766-11e1-8775-005056c00008" name="CRO132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0482d420-c766-11e1-8775-005056c00008" name="Danville" v="122.605453" angle="-14.3253107"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25.0" q0="13.0" bus="_0482d420-c766-11e1-8775-005056c00008" connectableBus="_0482d420-c766-11e1-8775-005056c00008" p="25.0" q="13.0"></iidm:load>
+            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43.0" q0="0.0" bus="_0482d420-c766-11e1-8775-005056c00008" connectableBus="_0482d420-c766-11e1-8775-005056c00008" p="43.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0455a9aa-c766-11e1-8775-005056c00008" name="Hobbiton" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0470f9d2-c766-11e1-8775-005056c00008" name="HOB132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047a96c0-c766-11e1-8775-005056c00008" name="Fremont" v="130.405121" angle="5.64272642"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48.0" q0="10.0" bus="_047a96c0-c766-11e1-8775-005056c00008" connectableBus="_047a96c0-c766-11e1-8775-005056c00008" p="48.0" q="10.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0452ea87-c766-11e1-8775-005056c00008" name="Goblin Town" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04703689-c766-11e1-8775-005056c00008" name="GOB132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04719616-c766-11e1-8775-005056c00008" name="Turner" v="132.47049" angle="-3.2331"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61.0" q0="28.0" bus="_04719616-c766-11e1-8775-005056c00008" connectableBus="_04719616-c766-11e1-8775-005056c00008" p="61.0" q="28.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0463da79-c766-11e1-8775-005056c00008" name="Rohan" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04588fd5-c766-11e1-8775-005056c00008" name="ROH132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04885267-c766-11e1-8775-005056c00008" name="Grant" v="127.201248" angle="-17.1918983"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24.0" q0="4.0" bus="_04885267-c766-11e1-8775-005056c00008" connectableBus="_04885267-c766-11e1-8775-005056c00008" p="24.0" q="4.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046eafe6-c766-11e1-8775-005056c00008" name="Andúnië" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047d07c9-c766-11e1-8775-005056c00008" name="AND220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045163e5-c766-11e1-8775-005056c00008" name="Olive1" v="222.522873" angle="-9.119988"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28.0" q0="0.0" bus="_045163e5-c766-11e1-8775-005056c00008" connectableBus="_045163e5-c766-11e1-8775-005056c00008" p="28.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_044be5a3-c766-11e1-8775-005056c00008" name="AND132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047147f0-c766-11e1-8775-005056c00008" name="Olive2" v="133.676" angle="-14.1409559"/>
+            </iidm:busBreakerTopology>
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" bPerSection="4.592E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="133.676" targetDeadband="1.0" bus="_047147f0-c766-11e1-8775-005056c00008" connectableBus="_047147f0-c766-11e1-8775-005056c00008" q="-41.0278473">
+                <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0.0" x="4.652208" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_045163e5-c766-11e1-8775-005056c00008" connectableBus1="_045163e5-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" bus2="_047147f0-c766-11e1-8775-005056c00008" connectableBus2="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0152284160890517"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9852216845834649"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9708738052596856"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9569378265149614"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9433962620149532"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9302326014061675"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9174312431613528"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9049774328944981"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_61e544bc-df04-4b97-8a18-5a8f66ae2ab7" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_4109402d-315d-4c0e-8d0e-a7a277ad5608" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_7d97fc29-56b8-4cd3-924e-aa67d27306c8" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_23406b6a-ccc0-4233-a063-caf8238c5a4e" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_045ab2b7-c766-11e1-8775-005056c00008" name="Michel Delving" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046ed6f7-c766-11e1-8775-005056c00008" name="MIC132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0485ba50-c766-11e1-8775-005056c00008" name="Wythe" v="130.954666" angle="-0.4037235"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22.0" q0="15.0" bus="_0485ba50-c766-11e1-8775-005056c00008" connectableBus="_0485ba50-c766-11e1-8775-005056c00008" p="22.0" q="15.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044c0cba-c766-11e1-8775-005056c00008" name="Calembel" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04817490-c766-11e1-8775-005056c00008" name="CAL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045ef874-c766-11e1-8775-005056c00008" name="WestLima" v="130.137146" angle="-19.1362"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33.0" q0="9.0" bus="_045ef874-c766-11e1-8775-005056c00008" connectableBus="_045ef874-c766-11e1-8775-005056c00008" p="33.0" q="9.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_048481d3-c766-11e1-8775-005056c00008" name="Riverlands" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04664b7a-c766-11e1-8775-005056c00008" name="RVR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045f1f84-c766-11e1-8775-005056c00008" name="BeaverCk" v="130.168991" angle="2.505279"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24.0" q0="15.0" bus="_045f1f84-c766-11e1-8775-005056c00008" connectableBus="_045f1f84-c766-11e1-8775-005056c00008" p="24.0" q="15.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0466e7ba-c766-11e1-8775-005056c00008" name="Standelf" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047b8123-c766-11e1-8775-005056c00008" name="STA220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046c3ee8-c766-11e1-8775-005056c00008" name="Sorenson2" v="216.352249" angle="-11.0758839"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0476c631-c766-11e1-8775-005056c00008" name="Sorenson1" v="130.74118" angle="-16.0552044"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11.0" q0="3.0" bus="_0476c631-c766-11e1-8775-005056c00008" connectableBus="_0476c631-c766-11e1-8775-005056c00008" p="11.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0.0" x="6.76051254" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_046c3ee8-c766-11e1-8775-005056c00008" connectableBus1="_046c3ee8-c766-11e1-8775-005056c00008" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" bus2="_0476c631-c766-11e1-8775-005056c00008" connectableBus2="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.041666688368056"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9615384430473377"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9259258916323744"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_d161a693-b7ea-488b-a945-b567ee43f412" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_f7fdb434-5e1f-4292-9849-2542cf0f4c3d" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_c65fcaa8-aacd-4104-90bc-ba8b3185073e" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_f62f2fc6-4b6c-4571-a8c5-40d6a89ac703" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_04642898-c766-11e1-8775-005056c00008" name="Rómenna" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0457f394-c766-11e1-8775-005056c00008" name="RÓM132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0454e653-c766-11e1-8775-005056c00008" name="Philo" v="135.3" angle="-8.939582"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100.0" maxP="400.0" ratedS="500.0" voltageRegulatorOn="true" targetP="204.0" targetV="135.3" targetQ="0.0" bus="_0454e653-c766-11e1-8775-005056c00008" connectableBus="_0454e653-c766-11e1-8775-005056c00008" p="-204.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_e3753d6d-b894-4cce-b6fa-307c50dc107f"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_dff93c01-9c84-4c1f-8529-66c054ed9e37"/>
+                <iidm:minMaxReactiveLimits minQ="-150.0" maxQ="450.0"/>
+            </iidm:generator>
+            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87.0" q0="30.0" bus="_0454e653-c766-11e1-8775-005056c00008" connectableBus="_0454e653-c766-11e1-8775-005056c00008" p="87.0" q="30.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04828600-c766-11e1-8775-005056c00008" name="Ost-in-Edhil" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047b0bf4-c766-11e1-8775-005056c00008" name="OST132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04716f02-c766-11e1-8775-005056c00008" name="BetsyLne" v="129.421829" angle="0.9595726"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11.0" q0="7.0" bus="_04716f02-c766-11e1-8775-005056c00008" connectableBus="_04716f02-c766-11e1-8775-005056c00008" p="11.0" q="7.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045fe2d1-c766-11e1-8775-005056c00008" name="Oldtown" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046205b3-c766-11e1-8775-005056c00008" name="OLD132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0483be8a-c766-11e1-8775-005056c00008" name="Reusens" v="124.763" angle="-12.388133"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22.0" q0="0.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" p="22.0" q="0.0"></iidm:load>
+            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28.0" q0="12.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" p="28.0" q="12.0"></iidm:load>
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" bPerSection="6.88E-5" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="124.763" targetDeadband="1.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" q="-5.354637">
+                <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0453fbf4-c766-11e1-8775-005056c00008" name="Grey Havens" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047d07c3-c766-11e1-8775-005056c00008" name="GRE132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_048433b2-c766-11e1-8775-005056c00008" name="Holston" v="126.513268" angle="3.558016"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85.0" q0="0.0" bus="_048433b2-c766-11e1-8775-005056c00008" connectableBus="_048433b2-c766-11e1-8775-005056c00008" p="85.0" q="0.0"></iidm:load>
+            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78.0" q0="42.0" bus="_048433b2-c766-11e1-8775-005056c00008" connectableBus="_048433b2-c766-11e1-8775-005056c00008" p="78.0" q="42.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04745531-c766-11e1-8775-005056c00008" name="Edhellond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048740f7-c766-11e1-8775-005056c00008" name="EDH132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04716f04-c766-11e1-8775-005056c00008" name="SthPoint" v="127.438782" angle="-7.091006"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47.0" q0="11.0" bus="_04716f04-c766-11e1-8775-005056c00008" connectableBus="_04716f04-c766-11e1-8775-005056c00008" p="47.0" q="11.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0476ed45-c766-11e1-8775-005056c00008" name="Forlond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04481510-c766-11e1-8775-005056c00008" name="FRL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0447ee09-c766-11e1-8775-005056c00008" name="CapitlHl" v="133.002" angle="-3.25421"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39.0" q0="32.0" bus="_0447ee09-c766-11e1-8775-005056c00008" connectableBus="_0447ee09-c766-11e1-8775-005056c00008" p="39.0" q="32.0"></iidm:load>
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" bPerSection="2.296E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="133.002" targetDeadband="1.0" bus="_0447ee09-c766-11e1-8775-005056c00008" connectableBus="_0447ee09-c766-11e1-8775-005056c00008" q="-20.3075829">
+                <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04825ef5-c766-11e1-8775-005056c00008" name="Osgiliath" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044fb634-c766-11e1-8775-005056c00008" name="OSG132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0482860b-c766-11e1-8775-005056c00008" name="Chemical" v="132.164886" angle="-3.54462719"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71.0" q0="26.0" bus="_0482860b-c766-11e1-8775-005056c00008" connectableBus="_0482860b-c766-11e1-8775-005056c00008" p="71.0" q="26.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0476510a-c766-11e1-8775-005056c00008" name="Ethring" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047eb571-c766-11e1-8775-005056c00008" name="ETH132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04684743-c766-11e1-8775-005056c00008" name="JacksnRd" v="130.680786" angle="-17.1475945"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19.0" q0="2.0" bus="_04684743-c766-11e1-8775-005056c00008" connectableBus="_04684743-c766-11e1-8775-005056c00008" p="19.0" q="2.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047edc88-c766-11e1-8775-005056c00008" name="Minas Ithil" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0468bc77-c766-11e1-8775-005056c00008" name="MNI132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04502b6a-c766-11e1-8775-005056c00008" name="Saltvlle" v="130.873917" angle="3.80151629"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65.0" q0="10.0" bus="_04502b6a-c766-11e1-8775-005056c00008" connectableBus="_04502b6a-c766-11e1-8775-005056c00008" p="65.0" q="10.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0452ea86-c766-11e1-8775-005056c00008" name="Frogmorton" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048c22fa-c766-11e1-8775-005056c00008" name="FRO132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04520021-c766-11e1-8775-005056c00008" name="Trenton" v="132.730774" angle="-9.129811"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13.0" q0="0.0" bus="_04520021-c766-11e1-8775-005056c00008" connectableBus="_04520021-c766-11e1-8775-005056c00008" p="13.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045dbff3-c766-11e1-8775-005056c00008" name="Nargothrond" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047eb579-c766-11e1-8775-005056c00008" name="NAR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0471bd2a-c766-11e1-8775-005056c00008" name="HickryCk" v="128.575378" angle="-18.20656"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39.0" q0="10.0" bus="_0471bd2a-c766-11e1-8775-005056c00008" connectableBus="_0471bd2a-c766-11e1-8775-005056c00008" p="39.0" q="10.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045386c0-c766-11e1-8775-005056c00008" name="Kings Landing" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04854527-c766-11e1-8775-005056c00008" name="GOD220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047f2aa7-c766-11e1-8775-005056c00008" name="Tidd2" v="213.126556" angle="-7.192931"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_0455a9a2-c766-11e1-8775-005056c00008" name="KGL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045645e7-c766-11e1-8775-005056c00008" name="Tidd1" v="130.02" angle="-10.5625124"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120.0" maxP="240.0" ratedS="300.0" voltageRegulatorOn="true" targetP="155.0" targetV="130.02" targetQ="0.0" bus="_045645e7-c766-11e1-8775-005056c00008" connectableBus="_045645e7-c766-11e1-8775-005056c00008" p="-155.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_29df1e0b-36ca-4536-97b4-6f98b84d49d8"/>
+                <iidm:minMaxReactiveLimits minQ="-90.0" maxQ="255.0"/>
+            </iidm:generator>
+            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277.0" q0="113.0" bus="_045645e7-c766-11e1-8775-005056c00008" connectableBus="_045645e7-c766-11e1-8775-005056c00008" p="277.0" q="113.0"></iidm:load>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0.0" x="6.725664612" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_047f2aa7-c766-11e1-8775-005056c00008" connectableBus1="_047f2aa7-c766-11e1-8775-005056c00008" voltageLevelId1="_04854527-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.041666688368056"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9615384430473377"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9259258916323744"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8928570950255128"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8620689060642133"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8333332638888946"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8064515348595289"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7812499145507905"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7575756657484042"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7352940203287326"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7142856122449125"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6944443383487817"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6756755661066649"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6578946243074983"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6410255259697774"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.624999882812522"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6097559785841993"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.595237974773267"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.581395227149836"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5681816955062248"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5555554320987929"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5434781368147731"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5319147691263306"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5208332085503771"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.5102039566847453"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.49999987500003124"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.4901959534794627"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.4807691059541743"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.47169798860807843"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.46296283864886734"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_67e78c48-0ca2-48d3-8a23-d06c0fcd887e" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_5629d2df-9e35-47ae-8a33-c8276f9343d9" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_1afd1e4c-1377-424b-a866-7f6cba69be6c" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_f2daef4d-6f1a-44d1-9c9b-228acff12575" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_0488eea4-c766-11e1-8775-005056c00008" name="Tuckborough" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04876804-c766-11e1-8775-005056c00008" name="TUC132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04494d93-c766-11e1-8775-005056c00008" name="Wooster" v="124.866585" angle="-15.5480585"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23.0" q0="11.0" bus="_04494d93-c766-11e1-8775-005056c00008" connectableBus="_04494d93-c766-11e1-8775-005056c00008" p="23.0" q="11.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046eafe3-c766-11e1-8775-005056c00008" name="Alqualondë" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04767817-c766-11e1-8775-005056c00008" name="ALQ132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04769f21-c766-11e1-8775-005056c00008" name="Wagenhls" v="125.576439" angle="-14.9212084"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63.0" q0="22.0" bus="_04769f21-c766-11e1-8775-005056c00008" connectableBus="_04769f21-c766-11e1-8775-005056c00008" p="63.0" q="22.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045ab2b4-c766-11e1-8775-005056c00008" name="Menegroth" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04851e1b-c766-11e1-8775-005056c00008" name="MEN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045b4ef9-c766-11e1-8775-005056c00008" name="Concord" v="128.097244" angle="-18.40343"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34.0" q0="16.0" bus="_045b4ef9-c766-11e1-8775-005056c00008" connectableBus="_045b4ef9-c766-11e1-8775-005056c00008" p="34.0" q="16.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0450c7a8-c766-11e1-8775-005056c00008" name="Erech" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047b3309-c766-11e1-8775-005056c00008" name="ERE132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04675ce7-c766-11e1-8775-005056c00008" name="Delaware" v="127.922295" angle="-15.096735"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59.0" q0="23.0" bus="_04675ce7-c766-11e1-8775-005056c00008" connectableBus="_04675ce7-c766-11e1-8775-005056c00008" p="59.0" q="23.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044f19f8-c766-11e1-8775-005056c00008" name="Dunharrow" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0467ab04-c766-11e1-8775-005056c00008" name="DUN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0474071a-c766-11e1-8775-005056c00008" name="FtWayne" v="127.583809" angle="-18.5791779"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90.0" q0="30.0" bus="_0474071a-c766-11e1-8775-005056c00008" connectableBus="_0474071a-c766-11e1-8775-005056c00008" p="90.0" q="30.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047ce0b8-c766-11e1-8775-005056c00008" name="Linhir" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0489b1f8-c766-11e1-8775-005056c00008" name="LIN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047c9297-c766-11e1-8775-005056c00008" name="WNwPhil1" v="128.105865" angle="-13.52993"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12.0" q0="3.0" bus="_047c9297-c766-11e1-8775-005056c00008" connectableBus="_047c9297-c766-11e1-8775-005056c00008" p="12.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045ef876-c766-11e1-8775-005056c00008" name="Nogrod" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046512f8-c766-11e1-8775-005056c00008" name="NOG132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044ea4c4-c766-11e1-8775-005056c00008" name="Logan" v="130.419" angle="-2.74680519"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54.0" q0="27.0" bus="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus="_044ea4c4-c766-11e1-8775-005056c00008" p="54.0" q="27.0"></iidm:load>
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" bPerSection="2.296E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.419" targetDeadband="1.0" bus="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus="_044ea4c4-c766-11e1-8775-005056c00008" q="-19.5264664">
+                <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046f7334-c766-11e1-8775-005056c00008" name="Beauxbatons" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048a7544-c766-11e1-8775-005056c00008" name="BEA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0462a1f3-c766-11e1-8775-005056c00008" name="W.Lancst" v="132.66" angle="-11.4028854"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0.0" maxP="40.0" ratedS="50.0" voltageRegulatorOn="true" targetP="19.0" targetV="132.66" targetQ="0.0" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" p="-19.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_83fae784-1da1-4055-8108-ba978276d1b6"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_5f711f63-f631-45d3-b26c-33821ab2ee56"/>
+                <iidm:minMaxReactiveLimits minQ="-15.0" maxQ="45.0"/>
+            </iidm:generator>
+            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28.0" q0="10.0" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" p="28.0" q="10.0"></iidm:load>
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1.0" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" q="-10.1016407">
+                <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0471e435-c766-11e1-8775-005056c00008" name="Carn Dûm" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045d98e1-c766-11e1-8775-005056c00008" name="CAR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04499bb3-c766-11e1-8775-005056c00008" name="Portsmth" v="129.4594" angle="-7.402933"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66.0" q0="20.0" bus="_04499bb3-c766-11e1-8775-005056c00008" connectableBus="_04499bb3-c766-11e1-8775-005056c00008" p="66.0" q="20.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0474a35b-c766-11e1-8775-005056c00008" name="Ephel Brandir" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04636548-c766-11e1-8775-005056c00008" name="EPH132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04723255-c766-11e1-8775-005056c00008" name="DeerCrk" v="127.644" angle="-17.0689125"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0.0" maxP="40.0" ratedS="50.0" voltageRegulatorOn="true" targetP="7.0" targetV="127.644" targetQ="0.0" bus="_04723255-c766-11e1-8775-005056c00008" connectableBus="_04723255-c766-11e1-8775-005056c00008" p="-7.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_e5a479a8-ab8d-4a54-bb52-376874ae2784"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_b55d80d5-720f-46f9-897f-ff8c5eaf8b44"/>
+                <iidm:minMaxReactiveLimits minQ="-15.0" maxQ="45.0"/>
+            </iidm:generator>
+            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43.0" q0="27.0" bus="_04723255-c766-11e1-8775-005056c00008" connectableBus="_04723255-c766-11e1-8775-005056c00008" p="43.0" q="27.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04669999-c766-11e1-8775-005056c00008" name="Staddle" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04555b83-c766-11e1-8775-005056c00008" name="STA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044fdd40-c766-11e1-8775-005056c00008" name="Medford" v="127.312294" angle="-15.4113827"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22.0" q0="7.0" bus="_044fdd40-c766-11e1-8775-005056c00008" connectableBus="_044fdd40-c766-11e1-8775-005056c00008" p="22.0" q="7.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04731cb4-c766-11e1-8775-005056c00008" name="Diagon Alley" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047f9fdb-c766-11e1-8775-005056c00008" name="DIA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0449e9d4-c766-11e1-8775-005056c00008" name="CollCrnr" v="132.910187" angle="-8.931758"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7.0" q0="3.0" bus="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus="_0449e9d4-c766-11e1-8775-005056c00008" p="7.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045fe2da-c766-11e1-8775-005056c00008" name="Ondosto" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044f4108-c766-11e1-8775-005056c00008" name="OND132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047e6750-c766-11e1-8775-005056c00008" name="Caldwell" v="129.429367" angle="-2.32587671"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42.0" q0="31.0" bus="_047e6750-c766-11e1-8775-005056c00008" connectableBus="_047e6750-c766-11e1-8775-005056c00008" p="42.0" q="31.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04631727-c766-11e1-8775-005056c00008" name="Rivendell" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046b7b99-c766-11e1-8775-005056c00008" name="RIV132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046c17da-c766-11e1-8775-005056c00008" name="Franklin" v="126.326439" angle="-10.9323874"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8.0" q0="3.0" bus="_046c17da-c766-11e1-8775-005056c00008" connectableBus="_046c17da-c766-11e1-8775-005056c00008" p="8.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04765106-c766-11e1-8775-005056c00008" name="Esgaroth" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04689563-c766-11e1-8775-005056c00008" name="ESG132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04686e54-c766-11e1-8775-005056c00008" name="McKinley" v="127.008171" angle="-18.19826"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60.0" q0="34.0" bus="_04686e54-c766-11e1-8775-005056c00008" connectableBus="_04686e54-c766-11e1-8775-005056c00008" p="60.0" q="34.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046b2d72-c766-11e1-8775-005056c00008" name="Hogwarts" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04479fe2-c766-11e1-8775-005056c00008" name="HOG132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047566a8-c766-11e1-8775-005056c00008" name="TwinBrch" v="130.680008" angle="-17.4932461"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50.0" maxP="160.0" ratedS="200.0" voltageRegulatorOn="true" targetP="85.0" targetV="130.680008" targetQ="0.0" bus="_047566a8-c766-11e1-8775-005056c00008" connectableBus="_047566a8-c766-11e1-8775-005056c00008" p="-85.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_668eb671-5c36-4351-a95d-53ca850581db"/>
+                <iidm:minMaxReactiveLimits minQ="-60.0" maxQ="170.0"/>
+            </iidm:generator>
+            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47.0" q0="10.0" bus="_047566a8-c766-11e1-8775-005056c00008" connectableBus="_047566a8-c766-11e1-8775-005056c00008" p="47.0" q="10.0"></iidm:load>
+            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20.0" q0="8.0" r="5.732496" x="24.3936" g="0.0" b="2.054637E-4" ucteXnodeCode="XMO_TE32" bus="_047566a8-c766-11e1-8775-005056c00008" connectableBus="_047566a8-c766-11e1-8775-005056c00008" p="20.152549931578697" q="5.197252003124272">
+                <iidm:currentLimits permanentLimit="1000.0">
+                    <iidm:temporaryLimit name="_c42b1a7f-971e-44aa-b615-fb7d49f3256c" acceptableDuration="900" value="1150.0"/>
+                    <iidm:temporaryLimit name="_543c8189-a696-4529-9d26-f06fd03e57ad" acceptableDuration="60" value="1400.0"/>
+                </iidm:currentLimits>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04499bb4-c766-11e1-8775-005056c00008" name="Annúminas" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04633e3a-c766-11e1-8775-005056c00008" name="ANN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04670ec8-c766-11e1-8775-005056c00008" name="Lincoln" v="126.691772" angle="-18.766777"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45.0" q0="25.0" bus="_04670ec8-c766-11e1-8775-005056c00008" connectableBus="_04670ec8-c766-11e1-8775-005056c00008" p="45.0" q="25.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046f2515-c766-11e1-8775-005056c00008" name="Azkaban" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04644fa4-c766-11e1-8775-005056c00008" name="AZK132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_048c4a07-c766-11e1-8775-005056c00008" name="Hinton" v="134.659927" angle="-3.0770843"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42.0" q0="0.0" bus="_048c4a07-c766-11e1-8775-005056c00008" connectableBus="_048c4a07-c766-11e1-8775-005056c00008" p="42.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04631725-c766-11e1-8775-005056c00008" name="Qarth" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04878f10-c766-11e1-8775-005056c00008" name="QAR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_048b86b5-c766-11e1-8775-005056c00008" name="EastLima1" v="131.565" angle="-18.24901"/>
+            </iidm:busBreakerTopology>
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" bPerSection="2.87E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1.0" bus="_048b86b5-c766-11e1-8775-005056c00008" connectableBus="_048b86b5-c766-11e1-8775-005056c00008" q="-24.8389168">
+                <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_04742e21-c766-11e1-8775-005056c00008" name="QAR220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0451b206-c766-11e1-8775-005056c00008" name="EastLima2" v="211.959686" angle="-13.0689487"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0.0" x="6.534000539999999" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_0451b206-c766-11e1-8775-005056c00008" connectableBus1="_0451b206-c766-11e1-8775-005056c00008" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" bus2="_048b86b5-c766-11e1-8775-005056c00008" connectableBus2="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.06951871657754"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9389671361502347"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8849557522123894"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8368200836820083"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7936507936507936"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7547169811320755"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.7194244604316546"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6872852233676976"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_fc89899a-e1ba-48c5-aec0-1d321408483c" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_6ee590e8-2483-491d-a919-ffe1e93a41d3" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_f0cc6f7c-99a3-496d-8d13-1ac44171b1b9" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_c97df399-5a91-4c8b-b72c-496cade334b5" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="_0486a4b7-c766-11e1-8775-005056c00008" name="St Mungos" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046f7338-c766-11e1-8775-005056c00008" name="STM132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04531195-c766-11e1-8775-005056c00008" name="N. E." v="129.679718" angle="-17.8200111"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25.0" q0="10.0" bus="_04531195-c766-11e1-8775-005056c00008" connectableBus="_04531195-c766-11e1-8775-005056c00008" p="25.0" q="10.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044aad21-c766-11e1-8775-005056c00008" name="Belegost" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04806326-c766-11e1-8775-005056c00008" name="BEL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_048c22f1-c766-11e1-8775-005056c00008" name="SCoshoct" v="126.293083" angle="-14.5671663"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18.0" q0="5.0" bus="_048c22f1-c766-11e1-8775-005056c00008" connectableBus="_048c22f1-c766-11e1-8775-005056c00008" p="18.0" q="5.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04784cda-c766-11e1-8775-005056c00008" name="Gulltown" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047a96c5-c766-11e1-8775-005056c00008" name="GUL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0479102a-c766-11e1-8775-005056c00008" name="WHuntngd" v="124.835312" angle="-8.056691"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33.0" q0="15.0" bus="_0479102a-c766-11e1-8775-005056c00008" connectableBus="_0479102a-c766-11e1-8775-005056c00008" p="33.0" q="15.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0456bb19-c766-11e1-8775-005056c00008" name="Khazad-dûm" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_046a1c00-c766-11e1-8775-005056c00008" name="KHA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045fe2d4-c766-11e1-8775-005056c00008" name="DanRiver" v="129.36" angle="-10.3138609"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20.0" maxP="40.0" ratedS="50.0" voltageRegulatorOn="true" targetP="36.0" targetV="129.36" targetQ="0.0" bus="_045fe2d4-c766-11e1-8775-005056c00008" connectableBus="_045fe2d4-c766-11e1-8775-005056c00008" p="-36.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_fec62959-21c5-4921-90b2-7c85e9f3bfab"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_9db08c95-4586-4a2b-87e3-5a17c944b43a"/>
+                <iidm:minMaxReactiveLimits minQ="-15.0" maxQ="45.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_045bc420-c766-11e1-8775-005056c00008" name="Minas Morgul" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04664b78-c766-11e1-8775-005056c00008" name="MNM132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04878f11-c766-11e1-8775-005056c00008" name="X5 TRI" v="129.8615" angle="-7.8189826"/>
+            </iidm:busBreakerTopology>
+            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6.0" q0="0.0" r="1.508918" x="7.910496" g="0.0" b="6.76079E-5" ucteXnodeCode="XMO_TE31" bus="_04878f11-c766-11e1-8775-005056c00008" connectableBus="_04878f11-c766-11e1-8775-005056c00008" p="6.0032519495334284" q="-1.1227797436619282">
+                <iidm:currentLimits permanentLimit="1000.0">
+                    <iidm:temporaryLimit name="_d8fc27d8-dd8b-4396-ae7f-b877910f9726" acceptableDuration="900" value="1150.0"/>
+                    <iidm:temporaryLimit name="_1481884d-3134-4896-ae32-b507830cc47a" acceptableDuration="60" value="1400.0"/>
+                </iidm:currentLimits>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04595327-c766-11e1-8775-005056c00008" name="Lond Daer Enedh" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0456e220-c766-11e1-8775-005056c00008" name="LON132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04812671-c766-11e1-8775-005056c00008" name="Summerfl" v="134.582016" angle="-5.09154034"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28.0" q0="7.0" bus="_04812671-c766-11e1-8775-005056c00008" connectableBus="_04812671-c766-11e1-8775-005056c00008" p="28.0" q="7.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047391e8-c766-11e1-8775-005056c00008" name="Durmstrang" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0448d866-c766-11e1-8775-005056c00008" name="DUR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0453d4e4-c766-11e1-8775-005056c00008" name="ClinchRv" v="132.66" angle="9.704128"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400.0" maxP="800.0" ratedS="1000.0" voltageRegulatorOn="true" targetP="607.0" targetV="132.66" targetQ="0.0" bus="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus="_0453d4e4-c766-11e1-8775-005056c00008" p="-607.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_2621b09a-22e3-4630-b3bd-32c102e36741"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_b0d662e5-64c9-4d59-b8e0-9b1ed175769b"/>
+                <iidm:minMaxReactiveLimits minQ="-300.0" maxQ="850.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_044ca8f4-c766-11e1-8775-005056c00008" name="Combe" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045d4ac5-c766-11e1-8775-005056c00008" name="COM132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045fe2d7-c766-11e1-8775-005056c00008" name="Pokagon" v="128.538834" angle="-18.4971886"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20.0" q0="9.0" bus="_045fe2d7-c766-11e1-8775-005056c00008" connectableBus="_045fe2d7-c766-11e1-8775-005056c00008" p="20.0" q="9.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04500458-c766-11e1-8775-005056c00008" name="Eldalondë" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_047b8129-c766-11e1-8775-005056c00008" name="ELD132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047e4045-c766-11e1-8775-005056c00008" name="GoshenJt" v="129.711578" angle="-18.22939"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14.0" q0="1.0" bus="_047e4045-c766-11e1-8775-005056c00008" connectableBus="_047e4045-c766-11e1-8775-005056c00008" p="14.0" q="1.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047d2ed1-c766-11e1-8775-005056c00008" name="Lorien" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_048c4a08-c766-11e1-8775-005056c00008" name="LOR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04544a19-c766-11e1-8775-005056c00008" name="S.Tiffin" v="122.716858" angle="-22.757822"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37.0" q0="10.0" bus="_04544a19-c766-11e1-8775-005056c00008" connectableBus="_04544a19-c766-11e1-8775-005056c00008" p="37.0" q="10.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0478e914-c766-11e1-8775-005056c00008" name="Harrenhal" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0456bb11-c766-11e1-8775-005056c00008" name="HAR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045e0e10-c766-11e1-8775-005056c00008" name="Haviland" v="128.295212" angle="-19.275671"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23.0" q0="9.0" bus="_045e0e10-c766-11e1-8775-005056c00008" connectableBus="_045e0e10-c766-11e1-8775-005056c00008" p="23.0" q="9.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046ab849-c766-11e1-8775-005056c00008" name="Valmar" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045cfca4-c766-11e1-8775-005056c00008" name="VAL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_047d2ed4-c766-11e1-8775-005056c00008" name="SWKammer" v="131.090652" angle="-6.788445"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78.0" q0="3.0" bus="_047d2ed4-c766-11e1-8775-005056c00008" connectableBus="_047d2ed4-c766-11e1-8775-005056c00008" p="78.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047343c0-c766-11e1-8775-005056c00008" name="Dol Amroth" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045a1672-c766-11e1-8775-005056c00008" name="DOL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0479fa80-c766-11e1-8775-005056c00008" name="Baileysv" v="130.977081" angle="-2.48613644"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38.0" q0="15.0" bus="_0479fa80-c766-11e1-8775-005056c00008" connectableBus="_0479fa80-c766-11e1-8775-005056c00008" p="38.0" q="15.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0476ed41-c766-11e1-8775-005056c00008" name="Fangorn Forest" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044f8f29-c766-11e1-8775-005056c00008" name="FAN132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04675ce9-c766-11e1-8775-005056c00008" name="HolstonT" v="128.206528" angle="3.32668257"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10.0" q0="0.0" bus="_04675ce9-c766-11e1-8775-005056c00008" connectableBus="_04675ce9-c766-11e1-8775-005056c00008" p="10.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_046c17d5-c766-11e1-8775-005056c00008" name="Westerlands" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04791027-c766-11e1-8775-005056c00008" name="WES132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046f9a47-c766-11e1-8775-005056c00008" name="WMedford" v="127.35347" angle="-15.4067049"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8.0" q0="3.0" bus="_046f9a47-c766-11e1-8775-005056c00008" connectableBus="_046f9a47-c766-11e1-8775-005056c00008" p="8.0" q="3.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0467ab01-c766-11e1-8775-005056c00008" name="Tharbad" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0483be8b-c766-11e1-8775-005056c00008" name="THA132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044e56a4-c766-11e1-8775-005056c00008" name="Rockhill" v="130.814" angle="-18.7122536"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59.0" q0="26.0" bus="_044e56a4-c766-11e1-8775-005056c00008" connectableBus="_044e56a4-c766-11e1-8775-005056c00008" p="59.0" q="26.0"></iidm:load>
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" bPerSection="1.606E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.814" targetDeadband="1.0" bus="_044e56a4-c766-11e1-8775-005056c00008" connectableBus="_044e56a4-c766-11e1-8775-005056c00008" q="-13.7411785">
+                <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04719613-c766-11e1-8775-005056c00008" name="Caras Galadhon" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04728074-c766-11e1-8775-005056c00008" name="CAR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_046a9133-c766-11e1-8775-005056c00008" name="Sprigg" v="129.935" angle="-1.56099224"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20.0" q0="10.0" bus="_046a9133-c766-11e1-8775-005056c00008" connectableBus="_046a9133-c766-11e1-8775-005056c00008" p="20.0" q="10.0"></iidm:load>
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1.0" bus="_046a9133-c766-11e1-8775-005056c00008" connectableBus="_046a9133-c766-11e1-8775-005056c00008" q="-9.690902">
+                <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0488eea8-c766-11e1-8775-005056c00008" name="Umbar" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0479d371-c766-11e1-8775-005056c00008" name="UMB132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045868c7-c766-11e1-8775-005056c00008" name="West End" v="123.667236" angle="-22.2906227"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46.0" q0="0.0" bus="_045868c7-c766-11e1-8775-005056c00008" connectableBus="_045868c7-c766-11e1-8775-005056c00008" p="46.0" q="0.0"></iidm:load>
+            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20.0" q0="23.0" bus="_045868c7-c766-11e1-8775-005056c00008" connectableBus="_045868c7-c766-11e1-8775-005056c00008" p="20.0" q="23.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_047343ca-c766-11e1-8775-005056c00008" name="Dorne" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04662460-c766-11e1-8775-005056c00008" name="DOR132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0453d4eb-c766-11e1-8775-005056c00008" name="Deer Crk" v="130.412933" angle="-16.0396042"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6.0" q0="0.0" bus="_0453d4eb-c766-11e1-8775-005056c00008" connectableBus="_0453d4eb-c766-11e1-8775-005056c00008" p="6.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04745536-c766-11e1-8775-005056c00008" name="Eglarest" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_0457f396-c766-11e1-8775-005056c00008" name="EGL132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_045d23b1-c766-11e1-8775-005056c00008" name="Crooksvl" v="134.25235" angle="-9.172073"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34.0" q0="0.0" bus="_045d23b1-c766-11e1-8775-005056c00008" connectableBus="_045d23b1-c766-11e1-8775-005056c00008" p="34.0" q="0.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0480b143-c766-11e1-8775-005056c00008" name="Newbury" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_044d1e26-c766-11e1-8775-005056c00008" name="NEW132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044a5f04-c766-11e1-8775-005056c00008" name="WCambrdg" v="132.138168" angle="-10.9845123"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17.0" q0="4.0" bus="_044a5f04-c766-11e1-8775-005056c00008" connectableBus="_044a5f04-c766-11e1-8775-005056c00008" p="17.0" q="4.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04640189-c766-11e1-8775-005056c00008" name="Rushey" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04605807-c766-11e1-8775-005056c00008" name="RUS132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0458b6e4-c766-11e1-8775-005056c00008" name="SouthBnd" v="130.527084" angle="-17.0296078"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70.0" q0="23.0" bus="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus="_0458b6e4-c766-11e1-8775-005056c00008" p="70.0" q="23.0"></iidm:load>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_0453add1-c766-11e1-8775-005056c00008" name="Gondolin" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_045c8779-c766-11e1-8775-005056c00008" name="GON220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_044e7db1-c766-11e1-8775-005056c00008" name="X9" v="229.031372" angle="-1.83390415"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="_04745534-c766-11e1-8775-005056c00008" name="Edoras" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
+        <iidm:voltageLevel id="_04544a18-c766-11e1-8775-005056c00008" name="EDO220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_0457f395-c766-11e1-8775-005056c00008" name="Kammer" v="216.42598" angle="-5.43209553"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="_0448d867-c766-11e1-8775-005056c00008" name="EDO132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="_04814d88-c766-11e1-8775-005056c00008" name="W.Kammer" v="131.34" angle="-5.89862871"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120.0" maxP="240.0" ratedS="300.0" voltageRegulatorOn="true" targetP="160.0" targetV="131.34" targetQ="0.0" bus="_04814d88-c766-11e1-8775-005056c00008" connectableBus="_04814d88-c766-11e1-8775-005056c00008" p="-160.0" q="-0.0">
+                <iidm:property name="CGMES.GeneratingUnit" value="_17852426-f663-4add-9a2b-0a635d51f101"/>
+                <iidm:property name="CGMES.RegulatingControl" value="_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd"/>
+                <iidm:minMaxReactiveLimits minQ="-90.0" maxQ="255.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0.0" x="4.669632" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_0457f395-c766-11e1-8775-005056c00008" connectableBus1="_0457f395-c766-11e1-8775-005056c00008" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" bus2="_04814d88-c766-11e1-8775-005056c00008" connectableBus2="_04814d88-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008">
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="1" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0152284160890517"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9852216845834649"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9708738052596856"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9569378265149614"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9433962620149532"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9302326014061675"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9174312431613528"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9049774328944981"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8928572066326577"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8810573385860445"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="1312.0">
+                <iidm:temporaryLimit name="_9d8d5d2f-e17b-44ba-8e5c-c743c13b8932" acceptableDuration="900" value="1508.0"/>
+                <iidm:temporaryLimit name="_dbe87453-c7d1-4a10-8f4e-992b351d4810" acceptableDuration="60" value="1837.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_c2676f61-6c29-44b7-9841-6209f952b0dd" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_f6b1a81c-eda7-4a08-b290-bd29a5ed9fa4" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.192352" x="17.16264" g1="0.0" b1="7.20271E-5" g2="0.0" b2="7.20271E-5" bus1="_04723255-c766-11e1-8775-005056c00008" connectableBus1="_04723255-c766-11e1-8775-005056c00008" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" bus2="_04675ce7-c766-11e1-8775-005056c00008" connectableBus2="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f69dc237-d327-475e-93f6-25cbffe65d37" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_de6da3cb-8cb5-4900-9c33-8ad45632b535" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.258288" x="10.7331839" g1="0.0" b1="4.51102E-5" g2="0.0" b2="4.51102E-5" bus1="_045fe2d7-c766-11e1-8775-005056c00008" connectableBus1="_045fe2d7-c766-11e1-8775-005056c00008" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" bus2="_047566a8-c766-11e1-8775-005056c00008" connectableBus2="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_09a180b3-124b-4a91-b323-4aad01f45e8a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6bd63dd1-1344-4183-b7bd-af326919f4eb" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.35224" x="10.6634884" g1="0.0" b1="4.671715E-5" g2="0.0" b2="4.671715E-5" bus1="_04675ce7-c766-11e1-8775-005056c00008" connectableBus1="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" bus2="_046f9a47-c766-11e1-8775-005056c00008" connectableBus2="_046f9a47-c766-11e1-8775-005056c00008" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_a8e81058-e847-4ff2-adf2-c4129ce23783" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_5f05650a-c63d-46e5-a426-2db4f036929f" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.502912" x="34.15104" g1="0.0" b1="1.4003675E-4" g2="0.0" b2="1.4003675E-4" bus1="_04520021-c766-11e1-8775-005056c00008" connectableBus1="_04520021-c766-11e1-8775-005056c00008" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" bus2="_0472a783-c766-11e1-8775-005056c00008" connectableBus2="_0472a783-c766-11e1-8775-005056c00008" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_a65972e6-89bc-4bc2-adaf-0434a8cb1628" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_d2074163-ab09-4251-a1d7-6983091dc4f1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.143152" x="8.79912" g1="0.0" b1="3.72475E-5" g2="0.0" b2="3.72475E-5" bus1="_0476c631-c766-11e1-8775-005056c00008" connectableBus1="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" bus2="_04686e54-c766-11e1-8775-005056c00008" connectableBus2="_04686e54-c766-11e1-8775-005056c00008" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f12edde3-3545-483e-8323-461ae7aa0ada" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2b6693c7-4e29-4c2c-91d0-3485bbe8fe87" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0.0" b1="2.203855E-5" g2="0.0" b2="2.203855E-5" bus1="_0476c631-c766-11e1-8775-005056c00008" connectableBus1="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" bus2="_0453d4eb-c766-11e1-8775-005056c00008" connectableBus2="_0453d4eb-c766-11e1-8775-005056c00008" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_83e15527-5937-42e4-964e-4c736913e9b0" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_786432da-fa4d-4751-a275-87d0e20529f1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.652208" x="13.1028481" g1="0.0" b1="5.37764E-5" g2="0.0" b2="5.37764E-5" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_044a5f04-c766-11e1-8775-005056c00008" connectableBus2="_044a5f04-c766-11e1-8775-005056c00008" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_5f6ea7e2-f472-4dba-a863-10ce21ee9702" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_1f0844a5-ea5c-42b2-abcb-6fac2c426092" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.247696" x="7.387776" g1="0.0" b1="3.104915E-5" g2="0.0" b2="3.104915E-5" bus1="_044a8618-c766-11e1-8775-005056c00008" connectableBus1="_044a8618-c766-11e1-8775-005056c00008" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" bus2="_0471bd2a-c766-11e1-8775-005056c00008" connectableBus2="_0471bd2a-c766-11e1-8775-005056c00008" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_bd6a7b7b-b30f-440f-bf3e-7d1d8007b0ab" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_4ea43e34-67a3-42b8-9601-2189db7790d4" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.143152" x="9.740016" g1="0.0" b1="4.2011E-5" g2="0.0" b2="4.2011E-5" bus1="_04502b6a-c766-11e1-8775-005056c00008" connectableBus1="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" bus2="_04845ac5-c766-11e1-8775-005056c00008" connectableBus2="_04845ac5-c766-11e1-8775-005056c00008" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_70154a1f-3853-4c24-8c87-aef442bdefdb" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_23cc194e-9273-46e9-a793-84a9c2911737" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.885552" x="12.7543688" g1="0.0" b1="5.38338E-5" g2="0.0" b2="5.38338E-5" bus1="_04667289-c766-11e1-8775-005056c00008" connectableBus1="_04667289-c766-11e1-8775-005056c00008" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" bus2="_045c8773-c766-11e1-8775-005056c00008" connectableBus2="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f5c30ce2-41bf-4665-a68c-a4d64962821a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_1a9fe09e-3f63-4904-8e36-aa38c5e16c59" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.93136" g1="0.0" b1="1.3544535E-4" g2="0.0" b2="1.3544535E-4" bus1="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus1="_0462a1f3-c766-11e1-8775-005056c00008" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" bus2="_044b7072-c766-11e1-8775-005056c00008" connectableBus2="_044b7072-c766-11e1-8775-005056c00008" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_79d9d9c2-3ecc-40f2-99c0-c26a56c19fe7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_467ba04d-dbad-4fe1-81c8-3bc87b41fcd1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.0126553" g1="0.0" b1="7.11662E-5" g2="0.0" b2="7.11662E-5" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_04862f81-c766-11e1-8775-005056c00008" connectableBus2="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_58073794-ab85-4c83-b59e-07d01d71ec5f" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_d0737ab4-5a3a-46c8-8aeb-789313f0f332" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.52648" x="8.380943" g1="0.0" b1="3.437785E-5" g2="0.0" b2="3.437785E-5" bus1="_04716f04-c766-11e1-8775-005056c00008" connectableBus1="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" bus2="_0479102a-c766-11e1-8775-005056c00008" connectableBus2="_0479102a-c766-11e1-8775-005056c00008" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_4ea8b910-752d-4475-8141-89e03e629b4e" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_173dc7ff-ae18-4410-b2e1-a4c2abac8ff6" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.687056" x="15.1414566" g1="0.0" b1="6.60009E-5" g2="0.0" b2="6.60009E-5" bus1="_045c8773-c766-11e1-8775-005056c00008" connectableBus1="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" bus2="_0479fa80-c766-11e1-8775-005056c00008" connectableBus2="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_15760a98-ef2d-4bd9-9370-acb8533d07b8" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_efde58bf-c92e-496d-b558-d0095a271083" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.495392" x="20.38608" g1="0.0" b1="8.895775E-5" g2="0.0" b2="8.895775E-5" bus1="_044b9787-c766-11e1-8775-005056c00008" connectableBus1="_044b9787-c766-11e1-8775-005056c00008" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" bus2="_04812671-c766-11e1-8775-005056c00008" connectableBus2="_04812671-c766-11e1-8775-005056c00008" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_bb70f086-9826-4662-b5f7-d88e35724d27" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_8a81d4ae-2bc8-4038-8650-27a6150946b1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.327984" x="10.89" g1="0.0" b1="4.602845E-5" g2="0.0" b2="4.602845E-5" bus1="_045d23b1-c766-11e1-8775-005056c00008" connectableBus1="_045d23b1-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_36231d1d-0ec0-42d3-a72a-d56bd20ed7b0" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_8d6a074c-900d-4a37-830c-5da4c1de1ab5" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.90096" g1="0.0" b1="1.779155E-4" g2="0.0" b2="1.779155E-4" bus1="_0468bc75-c766-11e1-8775-005056c00008" connectableBus1="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" bus2="_044ef2e3-c766-11e1-8775-005056c00008" connectableBus2="_044ef2e3-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_2da72d83-6a1a-4a6d-a873-847a8741dc7f" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3154dc30-b0e5-4570-8e52-9333bae20ef2" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.160576" g1="0.0" b1="3.62718E-5" g2="0.0" b2="3.62718E-5" bus1="_04719616-c766-11e1-8775-005056c00008" connectableBus1="_04719616-c766-11e1-8775-005056c00008" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" bus2="_0482860b-c766-11e1-8775-005056c00008" connectableBus2="_0482860b-c766-11e1-8775-005056c00008" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f6dcf23b-e28d-4722-9b81-e4ae2b782a53" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_cce754c5-b9d5-4105-a431-32da96e4a6cf" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.799762" x="3.624192" g1="0.0" b1="1.578285E-5" g2="0.0" b2="1.578285E-5" bus1="_046b066a-c766-11e1-8775-005056c00008" connectableBus1="_046b066a-c766-11e1-8775-005056c00008" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" bus2="_04684743-c766-11e1-8775-005056c00008" connectableBus2="_04684743-c766-11e1-8775-005056c00008" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ecaca589-8952-4cab-b3dc-f787858d46a9" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_361a9cc3-fb33-4037-9b9a-c20adb90b66b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.122656" x="18.2952" g1="0.0" b1="6.5427E-5" g2="0.0" b2="6.5427E-5" bus1="_04719616-c766-11e1-8775-005056c00008" connectableBus1="_04719616-c766-11e1-8775-005056c00008" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" bus2="_04898ae9-c766-11e1-8775-005056c00008" connectableBus2="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_fdae333c-349a-484b-9226-2b694611f4fe" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_da00c66f-a882-4938-923b-f2455f7f9a81" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135" x="4.251456" g1="0.0" b1="1.859505E-5" g2="0.0" b2="1.859505E-5" bus1="_0482860b-c766-11e1-8775-005056c00008" connectableBus1="_0482860b-c766-11e1-8775-005056c00008" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" bus2="_0447ee09-c766-11e1-8775-005056c00008" connectableBus2="_0447ee09-c766-11e1-8775-005056c00008" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_1f58489c-4298-48ca-914f-1a86392e8a4d" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ba4abe9d-8490-4c19-b19b-c9d2c3597fc9" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.119584" x="27.5996151" g1="0.0" b1="1.1679295E-4" g2="0.0" b2="1.1679295E-4" bus1="_04597a36-c766-11e1-8775-005056c00008" connectableBus1="_04597a36-c766-11e1-8775-005056c00008" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" bus2="_046783f5-c766-11e1-8775-005056c00008" connectableBus2="_046783f5-c766-11e1-8775-005056c00008" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_e286f134-f966-4dd2-b24b-b8388ca849a5" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2320da74-eda7-4f7f-ade9-1ed0e994f3af" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.979504" x="9.530928" g1="0.0" b1="4.2298E-5" g2="0.0" b2="4.2298E-5" bus1="_047e6750-c766-11e1-8775-005056c00008" connectableBus1="_047e6750-c766-11e1-8775-005056c00008" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" bus2="_0479fa80-c766-11e1-8775-005056c00008" connectableBus2="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_489df699-65e3-4b74-b657-04f7e24da3e0" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3bc03415-e95f-47a7-8e92-01089d304a9c" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.96208" x="8.450641" g1="0.0" b1="1.3544535E-4" g2="0.0" b2="1.3544535E-4" bus1="_04719616-c766-11e1-8775-005056c00008" connectableBus1="_04719616-c766-11e1-8775-005056c00008" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" bus2="_04898ae9-c766-11e1-8775-005056c00008" connectableBus2="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_bb9699a6-dcec-459a-b50a-7c7ff7419b33" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_f93b6d4c-39fa-4f6f-a42d-c63a4cf21a67" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.537072" x="11.8831682" g1="0.0" b1="4.987375E-5" g2="0.0" b2="4.987375E-5" bus1="_047147f0-c766-11e1-8775-005056c00008" connectableBus1="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" bus2="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus2="_0458b6e4-c766-11e1-8775-005056c00008" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_55d07074-4a4b-419b-819d-8d6048fcfd1c" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3bc4ab96-7a0d-4e18-b9f5-d89f63a82f0a" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.771104" x="31.3632011" g1="0.0" b1="1.2752525E-4" g2="0.0" b2="1.2752525E-4" bus1="_04878f11-c766-11e1-8775-005056c00008" connectableBus1="_04878f11-c766-11e1-8775-005056c00008" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" bus2="_0472a783-c766-11e1-8775-005056c00008" connectableBus2="_0472a783-c766-11e1-8775-005056c00008" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7a622384-0095-408a-9cc5-b561a4bec039" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_bcb69c6e-125e-449c-acb3-a4deb151668d" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.902976" x="17.68536" g1="0.0" b1="7.69628E-5" g2="0.0" b2="7.69628E-5" bus1="_04862f81-c766-11e1-8775-005056c00008" connectableBus1="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" bus2="_04812671-c766-11e1-8775-005056c00008" connectableBus2="_04812671-c766-11e1-8775-005056c00008" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_fd2f6dbe-d54c-4d17-9492-da52445d0640" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b4b8a31d-dc3c-4b51-88ad-a22e070eb96c" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.196112" x="29.2897434" g1="0.0" b1="1.212695E-4" g2="0.0" b2="1.212695E-4" bus1="_044e56a4-c766-11e1-8775-005056c00008" connectableBus1="_044e56a4-c766-11e1-8775-005056c00008" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" bus2="_046bf0cb-c766-11e1-8775-005056c00008" connectableBus2="_046bf0cb-c766-11e1-8775-005056c00008" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_498a5fc8-8519-4545-b941-9e3648608651" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_5585c67a-0839-48e6-8847-4393e1e9b9c7" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.05672" x="28.48824" g1="0.0" b1="1.164486E-4" g2="0.0" b2="1.164486E-4" bus1="_048c22f1-c766-11e1-8775-005056c00008" connectableBus1="_048c22f1-c766-11e1-8775-005056c00008" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" bus2="_04494d93-c766-11e1-8775-005056c00008" connectableBus2="_04494d93-c766-11e1-8775-005056c00008" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_005c0497-2c3d-4384-b39b-e1c8e4695081" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_e7c9dfab-fb45-4470-964f-4ba9e391f60b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.23472" x="31.88592" g1="0.0" b1="1.3544535E-4" g2="0.0" b2="1.3544535E-4" bus1="_04876809-c766-11e1-8775-005056c00008" connectableBus1="_04876809-c766-11e1-8775-005056c00008" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" bus2="_0483be8a-c766-11e1-8775-005056c00008" connectableBus2="_0483be8a-c766-11e1-8775-005056c00008" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_78d5285a-1f72-4d4e-a8ce-d760901cdf1e" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_fff133bf-25fd-46b2-b144-a227c31ee882" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.826448" x="21.9890881" g1="0.0" b1="9.412305E-5" g2="0.0" b2="9.412305E-5" bus1="_0468bc75-c766-11e1-8775-005056c00008" connectableBus1="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" bus2="_0485ba50-c766-11e1-8775-005056c00008" connectableBus2="_0485ba50-c766-11e1-8775-005056c00008" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_78f10485-1742-4778-93bc-90854ee15eb6" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_217e3c95-24b5-438f-a721-d2257e1a43b4" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.8315849" g1="0.0" b1="6.944445E-5" g2="0.0" b2="6.944445E-5" bus1="_045b9d15-c766-11e1-8775-005056c00008" connectableBus1="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" bus2="_047c9297-c766-11e1-8775-005056c00008" connectableBus2="_047c9297-c766-11e1-8775-005056c00008" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_1b2b5b52-3ac1-40eb-af2e-e5a724e34ed4" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_f5547027-3d48-4a53-937b-bd5ba63ef70d" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.7058554" x="48.40387" g1="0.0" b1="2.035124E-4" g2="0.0" b2="2.035124E-4" bus1="_045d23b1-c766-11e1-8775-005056c00008" connectableBus1="_045d23b1-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" bus2="_044a8615-c766-11e1-8775-005056c00008" connectableBus2="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_2e74f628-a179-44d3-bd7f-1d262370e8d2" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_e9fec217-cf6f-4d39-9495-26ed10c05100" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.83328" x="13.1551189" g1="0.0" b1="5.73921E-5" g2="0.0" b2="5.73921E-5" bus1="_04550d63-c766-11e1-8775-005056c00008" connectableBus1="_04550d63-c766-11e1-8775-005056c00008" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" bus2="_045fe2d4-c766-11e1-8775-005056c00008" connectableBus2="_045fe2d4-c766-11e1-8775-005056c00008" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_489598c7-fb80-48bb-abdc-7fbc89ff0fd7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ea48fee0-31b6-4990-a332-25d08b7d731f" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.5224018" g1="0.0" b1="9.87144E-5" g2="0.0" b2="9.87144E-5" bus1="_04544a19-c766-11e1-8775-005056c00008" connectableBus1="_04544a19-c766-11e1-8775-005056c00008" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" bus2="_04577e63-c766-11e1-8775-005056c00008" connectableBus2="_04577e63-c766-11e1-8775-005056c00008" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_91e7cb96-de23-4948-881e-3112959809d0" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_063af52c-fe10-4c1e-85d4-dd80dcc1d2f9" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.910496" x="35.89344" g1="0.0" b1="1.5668045E-4" g2="0.0" b2="1.5668045E-4" bus1="_04898ae9-c766-11e1-8775-005056c00008" connectableBus1="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" bus2="_048c4a07-c766-11e1-8775-005056c00008" connectableBus2="_048c4a07-c766-11e1-8775-005056c00008" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_b3ada113-b597-41a3-b96c-e2d6413ccd2b" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_c05229ce-6abb-4209-ad4f-0dcd4a070f28" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.764272" x="39.95323" g1="0.0" b1="1.716024E-4" g2="0.0" b2="1.716024E-4" bus1="_04549837-c766-11e1-8775-005056c00008" connectableBus1="_04549837-c766-11e1-8775-005056c00008" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f947c23d-f412-4092-bee0-955d804a356e" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ac528cbe-6fc1-41dd-ba9d-d8b7a4c77576" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.380943" x="27.52992" g1="0.0" b1="1.1650595E-4" g2="0.0" b2="1.1650595E-4" bus1="_04502b6a-c766-11e1-8775-005056c00008" connectableBus1="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" bus2="_045c8773-c766-11e1-8775-005056c00008" connectableBus2="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_288185b8-2129-4450-a2c7-ad8080ce1f0a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6ac84228-6b04-4b10-b560-29655c8e93b4" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.593104" x="18.46944" g1="0.0" b1="7.747935E-5" g2="0.0" b2="7.747935E-5" bus1="_048b86b5-c766-11e1-8775-005056c00008" connectableBus1="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" bus2="_04778983-c766-11e1-8775-005056c00008" connectableBus2="_04778983-c766-11e1-8775-005056c00008" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_dfe3b6e2-9b9f-400e-93a7-90b35c43d3ea" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2ccdc288-c132-40d1-a928-3887bec4ff67" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.62112" x="22.12848" g1="0.0" b1="9.06795E-5" g2="0.0" b2="9.06795E-5" bus1="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus1="_0462a1f3-c766-11e1-8775-005056c00008" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" bus2="_045d23b1-c766-11e1-8775-005056c00008" connectableBus2="_045d23b1-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_81e5d0c5-7cb3-42c7-829e-11059f8a64c3" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_06ca3245-2668-448f-a5c6-961924217a5c" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0473e004-c766-11e1-8775-005056c00008" name="30-38" r="2.24576" x="26.1360016" g1="0.0" b1="4.359504E-4" g2="0.0" b2="4.359504E-4" bus1="_046c3ee8-c766-11e1-8775-005056c00008" connectableBus1="_046c3ee8-c766-11e1-8775-005056c00008" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" bus2="_0451b206-c766-11e1-8775-005056c00008" connectableBus2="_0451b206-c766-11e1-8775-005056c00008" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_29165bcc-a0d7-4427-a8b8-8393eb928631" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.951488" x="6.385896" g1="0.0" b1="1.089302E-4" g2="0.0" b2="1.089302E-4" bus1="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus1="_044ea4c4-c766-11e1-8775-005056c00008" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" bus2="_046a9133-c766-11e1-8775-005056c00008" connectableBus2="_046a9133-c766-11e1-8775-005056c00008" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_31992d9c-cc50-4558-b52a-f9a597797818" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_dfbd2f07-76ab-41e3-910f-dc706979ea4b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.018112" g1="0.0" b1="2.1809E-5" g2="0.0" b2="2.1809E-5" bus1="_046b7b91-c766-11e1-8775-005056c00008" connectableBus1="_046b7b91-c766-11e1-8775-005056c00008" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" bus2="_046c17da-c766-11e1-8775-005056c00008" connectableBus2="_046c17da-c766-11e1-8775-005056c00008" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ce219edd-f122-4f03-ae4f-0dd3493375e7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_11451cec-81c7-4f83-a7db-df7dcaffa94e" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.987024" x="23.0519524" g1="0.0" b1="9.66483E-5" g2="0.0" b2="9.66483E-5" bus1="_04499bb3-c766-11e1-8775-005056c00008" connectableBus1="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" bus2="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus2="_0486f2d6-c766-11e1-8775-005056c00008" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_fa81f928-3439-4353-ac4c-3785ae142ba2" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_37a5cc00-bd7f-4ec7-a77c-e140e23450d2" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.192352" x="14.8626719" g1="0.0" b1="2.345615E-4" g2="0.0" b2="2.345615E-4" bus1="_04719616-c766-11e1-8775-005056c00008" connectableBus1="_04719616-c766-11e1-8775-005056c00008" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" bus2="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus2="_044ea4c4-c766-11e1-8775-005056c00008" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_1f7aa218-1550-426b-9fd1-6361f5c3e363" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_e9798d58-b518-4fab-984c-c72076dfc2ae" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.35224" x="8.572608" g1="0.0" b1="1.4290635E-4" g2="0.0" b2="1.4290635E-4" bus1="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus1="_0449e9d4-c766-11e1-8775-005056c00008" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" bus2="_04520021-c766-11e1-8775-005056c00008" connectableBus2="_04520021-c766-11e1-8775-005056c00008" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_8b924c6b-d010-4981-b109-fc33cd937313" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_e8ec73b8-1ecf-4d18-9ef9-80eabf3a4969" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.299968" x="7.614288" g1="0.0" b1="1.2741045E-4" g2="0.0" b2="1.2741045E-4" bus1="_0474071a-c766-11e1-8775-005056c00008" connectableBus1="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" bus2="_0476c631-c766-11e1-8775-005056c00008" connectableBus2="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_0a1e553e-a285-429e-a660-00078dd05878" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2ceac3d1-f73d-43db-8d37-9e329f1787bb" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.08604" x="24.3936" g1="0.0" b1="5.3099176E-4" g2="0.0" b2="5.3099176E-4" bus1="_045163e5-c766-11e1-8775-005056c00008" connectableBus1="_045163e5-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" bus2="_046c3ee8-c766-11e1-8775-005056c00008" connectableBus2="_046c3ee8-c766-11e1-8775-005056c00008" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_2e5a9b0c-24d7-4bb6-9761-484be58c5bf6" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ca795ad3-97e5-4416-aaba-53cce27f6434" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.4537621" g1="0.0" b1="2.376033E-4" g2="0.0" b2="2.376033E-4" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_044a8615-c766-11e1-8775-005056c00008" connectableBus2="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_4f55c6a7-4a84-47ac-84a2-f7da319866f4" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_c42dc3ef-3a2e-4070-8efb-78e5c0cd5554" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.5842552" g1="0.0" b1="1.7986685E-4" g2="0.0" b2="1.7986685E-4" bus1="_045b4ef9-c766-11e1-8775-005056c00008" connectableBus1="_045b4ef9-c766-11e1-8775-005056c00008" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" bus2="_0474071a-c766-11e1-8775-005056c00008" connectableBus2="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_40c3caa3-b6ce-4e62-ada3-2053aaadb18b" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ad988fd9-9270-4230-95a2-1858f32259df" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2272" x="22.12848" g1="0.0" b1="3.5009185E-4" g2="0.0" b2="3.5009185E-4" bus1="_044a8615-c766-11e1-8775-005056c00008" connectableBus1="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" bus2="_04499bb3-c766-11e1-8775-005056c00008" connectableBus2="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f71ac0ab-1003-49e3-baae-6860eaa27ea1" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_519e3ecb-3561-4d11-ac6b-172a0b4b09b2" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.390848" x="20.38608" g1="0.0" b1="8.551425E-5" g2="0.0" b2="8.551425E-5" bus1="_04670ec8-c766-11e1-8775-005056c00008" connectableBus1="_04670ec8-c766-11e1-8775-005056c00008" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" bus2="_0474f17a-c766-11e1-8775-005056c00008" connectableBus2="_0474f17a-c766-11e1-8775-005056c00008" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_e0ff2082-d064-46f0-89c2-f6597d7c5acb" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b88528bf-cb1c-4c00-ad79-d5937197d40c" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.299968" x="7.562016" g1="0.0" b1="3.18526E-5" g2="0.0" b2="3.18526E-5" bus1="_045c8773-c766-11e1-8775-005056c00008" connectableBus1="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" bus2="_047e6750-c766-11e1-8775-005056c00008" connectableBus2="_047e6750-c766-11e1-8775-005056c00008" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_9b58679f-8c7f-489f-884a-30224849053b" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b70e76a1-6e79-4fb6-b487-dffa9bfeab7b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.693888" x="14.5316162" g1="0.0" b1="6.140955E-5" g2="0.0" b2="6.140955E-5" bus1="_047566a8-c766-11e1-8775-005056c00008" connectableBus1="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" bus2="_04531195-c766-11e1-8775-005056c00008" connectableBus2="_04531195-c766-11e1-8775-005056c00008" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_25cb43d7-517b-4c25-b213-a01c4afe495d" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_af73f526-c58b-40e7-8e1c-14f05a39f6a2" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.78784" x="9.1476" g1="0.0" b1="1.5381085E-4" g2="0.0" b2="1.5381085E-4" bus1="_0468bc75-c766-11e1-8775-005056c00008" connectableBus1="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" bus2="_04597a36-c766-11e1-8775-005056c00008" connectableBus2="_04597a36-c766-11e1-8775-005056c00008" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ce5f31b6-0de2-41fb-8091-c2d5742b1828" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_1631e50b-21a3-470b-803b-f9665b6fcd60" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.990096" x="13.1551189" g1="0.0" b1="5.52686E-5" g2="0.0" b2="5.52686E-5" bus1="_04483c26-c766-11e1-8775-005056c00008" connectableBus1="_04483c26-c766-11e1-8775-005056c00008" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" bus2="_04675ce7-c766-11e1-8775-005056c00008" connectableBus2="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_cd4a9202-6aaa-4709-8293-bc142c0c9bc0" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_52eb4b09-42bb-4106-ac26-fe1059639d3a" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.715072" x="26.1360016" g1="0.0" b1="1.113407E-4" g2="0.0" b2="1.113407E-4" bus1="_045645e7-c766-11e1-8775-005056c00008" connectableBus1="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" bus2="_04814d88-c766-11e1-8775-005056c00008" connectableBus2="_04814d88-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_13d74b35-2eae-4bb7-9968-655ba9ecd015" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b5a7dea0-bfce-4548-a04d-7bb7b6d9f80a" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.858224" x="35.54496" g1="0.0" b1="1.5524565E-4" g2="0.0" b2="1.5524565E-4" bus1="_0468bc75-c766-11e1-8775-005056c00008" connectableBus1="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" bus2="_046783f5-c766-11e1-8775-005056c00008" connectableBus2="_046783f5-c766-11e1-8775-005056c00008" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_80225115-e6ed-47cd-b7d2-04f198d2417f" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_17a10cd0-b653-4dcf-bdc3-4d5005ea9591" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.8305779" g1="0.0" b1="1.4284895E-4" g2="0.0" b2="1.4284895E-4" bus1="_04716f04-c766-11e1-8775-005056c00008" connectableBus1="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" bus2="_04719616-c766-11e1-8775-005056c00008" connectableBus2="_04719616-c766-11e1-8775-005056c00008" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f64d2e1f-164f-4cd3-b7bd-9be3300eacb1" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6f81df11-7e71-4b6e-a6ee-a8c5f72f4ba5" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.523408" x="20.0898724" g1="0.0" b1="3.3660465E-4" g2="0.0" b2="3.3660465E-4" bus1="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus1="_0449e9d4-c766-11e1-8775-005056c00008" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" bus2="_04675ce7-c766-11e1-8775-005056c00008" connectableBus2="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ac71ed2f-6a14-4b3d-aa1b-b7a3cd071a96" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_a8f6a7d2-e58d-4671-a776-97be7291355e" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.014352" x="15.42024" g1="0.0" b1="6.887055E-5" g2="0.0" b2="6.887055E-5" bus1="_0479fa80-c766-11e1-8775-005056c00008" connectableBus1="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" bus2="_04667284-c766-11e1-8775-005056c00008" connectableBus2="_04667284-c766-11e1-8775-005056c00008" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_b6767a5e-0078-4311-b973-464b8f35bbfd" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ea6d39aa-df95-4d3e-b7b6-a800e552e72a" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.540833" x="28.4011211" g1="0.0" b1="5.06198385E-4" g2="0.0" b2="5.06198385E-4" bus1="_04689567-c766-11e1-8775-005056c00008" connectableBus1="_04689567-c766-11e1-8775-005056c00008" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" bus2="_04483c26-c766-11e1-8775-005056c00008" connectableBus2="_04483c26-c766-11e1-8775-005056c00008" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_8a1cb557-29ed-49ae-9120-65b4bdb8d2b1" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_d9d53af2-5ffa-4f2a-a4e6-ed22371332d6" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.303728" x="11.1513615" g1="0.0" b1="1.779155E-4" g2="0.0" b2="1.779155E-4" bus1="_04550d63-c766-11e1-8775-005056c00008" connectableBus1="_04550d63-c766-11e1-8775-005056c00008" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" bus2="_0482d420-c766-11e1-8775-005056c00008" connectableBus2="_0482d420-c766-11e1-8775-005056c00008" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_e55ac0b9-b111-4207-b7ee-59ac708a4e23" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_d50299b9-a055-408a-aa1e-2e93a715120f" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.724976" x="8.79912" g1="0.0" b1="1.5725435E-4" g2="0.0" b2="1.5725435E-4" bus1="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" bus2="_04502b6a-c766-11e1-8775-005056c00008" connectableBus2="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_4f767c6c-7f3a-4cb0-8a7d-04b1b4897817" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_eee9ca2b-764f-4ab8-a745-405338044743" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.7038422" g1="0.0" b1="2.094812E-4" g2="0.0" b2="2.094812E-4" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_04549837-c766-11e1-8775-005056c00008" connectableBus2="_04549837-c766-11e1-8775-005056c00008" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_c1091068-8e12-44e2-bdc4-44450556f80f" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_690202a4-aad2-4ad3-8842-961b39e37709" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.52648" x="8.485488" g1="0.0" b1="3.50666E-5" g2="0.0" b2="3.50666E-5" bus1="_045868c7-c766-11e1-8775-005056c00008" connectableBus1="_045868c7-c766-11e1-8775-005056c00008" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" bus2="_04544a19-c766-11e1-8775-005056c00008" connectableBus2="_04544a19-c766-11e1-8775-005056c00008" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_3d919b23-d14b-4639-a104-ce09f5d78235" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_34f2ef7c-32da-4444-b989-d02f5f931c50" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0.0" b1="4.453625E-5" g2="0.0" b2="4.453625E-5" bus1="_04778983-c766-11e1-8775-005056c00008" connectableBus1="_04778983-c766-11e1-8775-005056c00008" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" bus2="_045868c7-c766-11e1-8775-005056c00008" connectableBus2="_045868c7-c766-11e1-8775-005056c00008" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_d8fb151e-0854-45a9-8df9-177e6bfebf52" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_38d58455-5205-46bb-8e44-c66873f62938" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.847632" x="27.5473423" g1="0.0" b1="1.1880165E-4" g2="0.0" b2="1.1880165E-4" bus1="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" bus2="_04502b6a-c766-11e1-8775-005056c00008" connectableBus2="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_135d109b-ce06-4ee9-9fdc-bc39b1cd4791" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_0cce41c7-b99f-4fec-93d2-73ea24433fa1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.23096" x="24.74208" g1="0.0" b1="1.0502755E-4" g2="0.0" b2="1.0502755E-4" bus1="_045e0e10-c766-11e1-8775-005056c00008" connectableBus1="_045e0e10-c766-11e1-8775-005056c00008" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" bus2="_048b86b5-c766-11e1-8775-005056c00008" connectableBus2="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f5fb6f64-e16e-422b-b721-de1a781e8c01" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_343677c6-7477-4bf6-a12c-2c7e4a684d6f" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.547664" x="12.2490721" g1="0.0" b1="5.29155E-5" g2="0.0" b2="5.29155E-5" bus1="_04876809-c766-11e1-8775-005056c00008" connectableBus1="_04876809-c766-11e1-8775-005056c00008" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" bus2="_046b7b91-c766-11e1-8775-005056c00008" connectableBus2="_046b7b91-c766-11e1-8775-005056c00008" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_072c26b8-9b37-418f-b9a6-338f9a198a84" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_74cf84b9-e14f-4f81-9e8b-3a791cd474a0" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.446054" x="1.637856" g1="0.0" b1="2.82369E-5" g2="0.0" b2="2.82369E-5" bus1="_044e56a4-c766-11e1-8775-005056c00008" connectableBus1="_044e56a4-c766-11e1-8775-005056c00008" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" bus2="_048b86b5-c766-11e1-8775-005056c00008" connectableBus2="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_1ee3b9bf-743b-4bcb-b6a3-faa02fc44cc1" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_8e90bf2e-3be4-41be-a84e-c1d4e709f8a1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.551424" g1="0.0" b1="2.812215E-5" g2="0.0" b2="2.812215E-5" bus1="_04814d88-c766-11e1-8775-005056c00008" connectableBus1="_04814d88-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" bus2="_044b9787-c766-11e1-8775-005056c00008" connectableBus2="_044b9787-c766-11e1-8775-005056c00008" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_b653b5eb-5efc-4bcc-9e10-1eb6bfa6f57c" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_39a23399-348e-44d9-8032-8fc62e6c7d63" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.286304" x="19.5148811" g1="0.0" b1="8.43664E-5" g2="0.0" b2="8.43664E-5" bus1="_0485ba50-c766-11e1-8775-005056c00008" connectableBus1="_0485ba50-c766-11e1-8775-005056c00008" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" bus2="_04845ac5-c766-11e1-8775-005056c00008" connectableBus2="_04845ac5-c766-11e1-8775-005056c00008" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_6be4027d-eae3-4d93-8b3a-bd3ecbefb0a1" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_0501dacc-29fc-44a2-8cad-31a20b011d25" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.86716" x="41.624" g1="0.0" b1="9.380165E-4" g2="0.0" b2="9.380165E-4" bus1="_0455a9a6-c766-11e1-8775-005056c00008" connectableBus1="_0455a9a6-c766-11e1-8775-005056c00008" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" bus2="_046c3ee8-c766-11e1-8775-005056c00008" connectableBus2="_046c3ee8-c766-11e1-8775-005056c00008" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_0b8a340a-b8d4-4498-8223-9e70f54345ff" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_c95a66fd-913c-48c7-b8ef-cf3007c60af6" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.45816" x="56.2795219" g1="0.0" b1="2.4678605E-4" g2="0.0" b2="2.4678605E-4" bus1="_04577e63-c766-11e1-8775-005056c00008" connectableBus1="_04577e63-c766-11e1-8775-005056c00008" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_1aa29312-557e-4a5f-965c-219d32569822" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6cd83bc2-204f-44d5-afd4-fbfef8d2146f" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.43936" x="9.530928" g1="0.0" b1="4.115015E-5" g2="0.0" b2="4.115015E-5" bus1="_04876809-c766-11e1-8775-005056c00008" connectableBus1="_04876809-c766-11e1-8775-005056c00008" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" bus2="_044ef2e3-c766-11e1-8775-005056c00008" connectableBus2="_044ef2e3-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_6a482321-ff03-47e5-8d69-0a211cec9016" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_487e1317-48f9-4747-b931-f3f79e95f55a" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.459994" x="2.35224" g1="0.0" b1="4.178145E-5" g2="0.0" b2="4.178145E-5" bus1="_047d2ed4-c766-11e1-8775-005056c00008" connectableBus1="_047d2ed4-c766-11e1-8775-005056c00008" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" bus2="_04814d88-c766-11e1-8775-005056c00008" connectableBus2="_04814d88-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_8f379d20-b516-4eec-b535-925586132d69" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3c55a929-a755-409b-af5f-bae188892af1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.718144" x="13.9391994" g1="0.0" b1="2.479339E-4" g2="0.0" b2="2.479339E-4" bus1="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus1="_0449e9d4-c766-11e1-8775-005056c00008" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" bus2="_04689567-c766-11e1-8775-005056c00008" connectableBus2="_04689567-c766-11e1-8775-005056c00008" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_3e4b7d9a-4e85-4b10-9dba-a83fb76bf6b7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_9658628a-596f-41a9-96a7-c5a8aaf5400c" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.1028481" x="43.0372772" g1="0.0" b1="1.8135905E-4" g2="0.0" b2="1.8135905E-4" bus1="_04670ec8-c766-11e1-8775-005056c00008" connectableBus1="_04670ec8-c766-11e1-8775-005056c00008" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" bus2="_044e56a4-c766-11e1-8775-005056c00008" connectableBus2="_044e56a4-c766-11e1-8775-005056c00008" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7d1b5b44-e965-446d-b0a2-2abd8f995343" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b69ab61b-751d-487a-a538-2d47eea7572e" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.523408" x="25.2648" g1="0.0" b1="1.0789715E-4" g2="0.0" b2="1.0789715E-4" bus1="_045645e7-c766-11e1-8775-005056c00008" connectableBus1="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" bus2="_047d2ed4-c766-11e1-8775-005056c00008" connectableBus2="_047d2ed4-c766-11e1-8775-005056c00008" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_37b8abba-f482-471a-a82d-65606ca1d4d5" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_a38d4859-b54a-482f-a2ad-0b4ce4c4da2a" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.09088" x="6.865056" g1="0.0" b1="2.8983E-5" g2="0.0" b2="2.8983E-5" bus1="_0474071a-c766-11e1-8775-005056c00008" connectableBus1="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" bus2="_04670ec8-c766-11e1-8775-005056c00008" connectableBus2="_04670ec8-c766-11e1-8775-005056c00008" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_beec41ff-5166-438d-8178-950089f889c8" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_15d16bd2-d87c-4584-93d2-b294dc1be116" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.425696" x="14.5664635" g1="0.0" b1="6.140955E-5" g2="0.0" b2="6.140955E-5" bus1="_048433b2-c766-11e1-8775-005056c00008" connectableBus1="_048433b2-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" bus2="_04675ce9-c766-11e1-8775-005056c00008" connectableBus2="_04675ce9-c766-11e1-8775-005056c00008" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ff16ab37-609f-4d89-97e0-8f4fd8cfa2e3" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_7d2a67fb-9d8c-4745-a67e-ce6ade5e520e" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.959008" x="27.7041588" g1="0.0" b1="1.1593205E-4" g2="0.0" b2="1.1593205E-4" bus1="_0461b794-c766-11e1-8775-005056c00008" connectableBus1="_0461b794-c766-11e1-8775-005056c00008" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" bus2="_0449e9d4-c766-11e1-8775-005056c00008" connectableBus2="_0449e9d4-c766-11e1-8775-005056c00008" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_55a45a23-6031-4a23-956f-992afb08c743" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6477d99a-dd64-4083-8f56-1396610879f0" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.49232" x="25.78752" g1="0.0" b1="9.986225E-5" g2="0.0" b2="9.986225E-5" bus1="_046a9133-c766-11e1-8775-005056c00008" connectableBus1="_046a9133-c766-11e1-8775-005056c00008" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" bus2="_045f1f84-c766-11e1-8775-005056c00008" connectableBus2="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ad873b1b-014a-4c65-b7cd-22ebb86236bc" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_38cb3e5b-af1a-4684-aa2f-242826ed460c" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.258976" x="27.2337112" g1="0.0" b1="1.1449725E-4" g2="0.0" b2="1.1449725E-4" bus1="_0476c631-c766-11e1-8775-005056c00008" connectableBus1="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" bus2="_04723255-c766-11e1-8775-005056c00008" connectableBus2="_04723255-c766-11e1-8775-005056c00008" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_55a3f358-a56b-467d-96f8-1bfbe09799dc" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_9066b19a-f404-42c3-88ce-51d375f6fdb5" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.025632" x="32.75712" g1="0.0" b1="1.5151515E-4" g2="0.0" b2="1.5151515E-4" bus1="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" bus2="_048433b2-c766-11e1-8775-005056c00008" connectableBus2="_048433b2-c766-11e1-8775-005056c00008" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_d228fae3-2cfd-42c2-85bf-6ed2417949ef" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_924b4a0b-bef5-432a-ad87-ab5c10d9c019" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.457472" x="24.56784" g1="0.0" b1="1.033058E-4" g2="0.0" b2="1.033058E-4" bus1="_04499bb3-c766-11e1-8775-005056c00008" connectableBus1="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" bus2="_04716f04-c766-11e1-8775-005056c00008" connectableBus2="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_30aabccf-8ec8-46a2-a3a1-ba354c62f10a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_d432d118-553c-4f4c-a734-e98e0762ec40" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.258976" x="23.34816" g1="0.0" b1="9.52709E-5" g2="0.0" b2="9.52709E-5" bus1="_044a5f04-c766-11e1-8775-005056c00008" connectableBus1="_044a5f04-c766-11e1-8775-005056c00008" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" bus2="_047c9297-c766-11e1-8775-005056c00008" connectableBus2="_047c9297-c766-11e1-8775-005056c00008" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_aff34ffe-0ef8-42ff-99bd-8e286c8073a8" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2f32bda4-7275-4485-9901-12f8cff9e4a1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.073456" x="9.40896" g1="0.0" b1="4.092055E-5" g2="0.0" b2="4.092055E-5" bus1="_047147f0-c766-11e1-8775-005056c00008" connectableBus1="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" bus2="_046b066a-c766-11e1-8775-005056c00008" connectableBus2="_046b066a-c766-11e1-8775-005056c00008" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_3678bd5d-c47e-4eb0-8620-7f9e24a10618" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b3b0e81b-a434-4e9c-ad94-1161ff47b077" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.257234" x="37.6009941" g1="0.0" b1="1.620179E-4" g2="0.0" b2="1.620179E-4" bus1="_04769f21-c766-11e1-8775-005056c00008" connectableBus1="_04769f21-c766-11e1-8775-005056c00008" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_4a915430-984f-4a53-9533-53efa325d9e5" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6db0d250-4a2e-4169-abf0-f842aeca485d" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.279472" x="17.4065762" g1="0.0" b1="7.288795E-5" g2="0.0" b2="7.288795E-5" bus1="_044a8618-c766-11e1-8775-005056c00008" connectableBus1="_044a8618-c766-11e1-8775-005056c00008" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" bus2="_045fe2d7-c766-11e1-8775-005056c00008" connectableBus2="_045fe2d7-c766-11e1-8775-005056c00008" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ebd82352-16ad-454f-8920-32a110d327d1" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_9f39cb45-314c-445e-b177-909854a9ce45" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.036728" x="3.415104" g1="0.0" b1="1.44054E-5" g2="0.0" b2="1.44054E-5" bus1="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus1="_0458b6e4-c766-11e1-8775-005056c00008" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" bus2="_047566a8-c766-11e1-8775-005056c00008" connectableBus2="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_c0261082-5d30-4965-882d-3c1719e82054" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_70fad3e1-4529-4a7f-9e6c-8ab249d65460" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0.0" b1="0.001200413215" g2="0.0" b2="0.001200413215" bus1="_045163e5-c766-11e1-8775-005056c00008" connectableBus1="_045163e5-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" bus2="_044e7db1-c766-11e1-8775-005056c00008" connectableBus2="_044e7db1-c766-11e1-8775-005056c00008" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_0ea6e870-9b01-4226-80d3-5ff1a2f88c40" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_205e5d8a-f05a-479d-adaa-3514f48f6857" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0.0" b1="3.92562E-4" g2="0.0" b2="3.92562E-4" bus1="_0457f395-c766-11e1-8775-005056c00008" connectableBus1="_0457f395-c766-11e1-8775-005056c00008" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" bus2="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus2="_0458ddf2-c766-11e1-8775-005056c00008" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_09341906-df9b-4a95-a073-d9e12f3841be" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_8cee2b62-2953-439b-ba4b-4a48d55116c0" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47916" x="1.663992" g1="0.0" b1="2.10055E-5" g2="0.0" b2="2.10055E-5" bus1="_04549837-c766-11e1-8775-005056c00008" connectableBus1="_04549837-c766-11e1-8775-005056c00008" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" bus2="_045b9d15-c766-11e1-8775-005056c00008" connectableBus2="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_665fcc7f-38d1-4204-95fa-0c63c2a2ddc5" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_640627c7-0672-413e-8dc8-c9965709a5cb" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.262048" x="11.1687832" g1="0.0" b1="3.541095E-5" g2="0.0" b2="3.541095E-5" bus1="_04716f02-c766-11e1-8775-005056c00008" connectableBus1="_04716f02-c766-11e1-8775-005056c00008" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" bus2="_045f1f84-c766-11e1-8775-005056c00008" connectableBus2="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_eeb51357-560f-40d7-89d7-4fdfd53a167f" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_8b888209-5038-4b98-80fc-062b5ea55747" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0.0" b1="1.629935E-5" g2="0.0" b2="1.629935E-5" bus1="_044e56a4-c766-11e1-8775-005056c00008" connectableBus1="_044e56a4-c766-11e1-8775-005056c00008" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" bus2="_0480d858-c766-11e1-8775-005056c00008" connectableBus2="_0480d858-c766-11e1-8775-005056c00008" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_52f8cd12-1364-4ef3-ae3d-0285817f0354" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_c0a08025-3a61-4d24-9944-f3ef0b079f64" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507" x="71.69976" g1="0.0" b1="2.9264235E-4" g2="0.0" b2="2.9264235E-4" bus1="_04520021-c766-11e1-8775-005056c00008" connectableBus1="_04520021-c766-11e1-8775-005056c00008" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" bus2="_04499bb3-c766-11e1-8775-005056c00008" connectableBus2="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_66b89c81-20ba-41de-82a2-f999d5085ebd" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_32793450-bbfd-4dcd-a911-89e199600780" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0984" x="21.43152" g1="0.0" b1="7.92011E-5" g2="0.0" b2="7.92011E-5" bus1="_045f1f84-c766-11e1-8775-005056c00008" connectableBus1="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" bus2="_04689561-c766-11e1-8775-005056c00008" connectableBus2="_04689561-c766-11e1-8775-005056c00008" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_a9a5c23c-642d-4ae6-9eda-818565194dc7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2ec4bef5-7abb-4f52-bb62-49ee474d672b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.910496" x="31.3806229" g1="0.0" b1="1.337236E-4" g2="0.0" b2="1.337236E-4" bus1="_04531195-c766-11e1-8775-005056c00008" connectableBus1="_04531195-c766-11e1-8775-005056c00008" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" bus2="_0476c631-c766-11e1-8775-005056c00008" connectableBus2="_0476c631-c766-11e1-8775-005056c00008" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_142dbec6-04c3-4fb9-becf-7e45d36725bc" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_9280074c-8555-49ff-9e62-8ed8f7d95060" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.398368" x="37.9843178" g1="0.0" b1="1.6586315E-4" g2="0.0" b2="1.6586315E-4" bus1="_044b9787-c766-11e1-8775-005056c00008" connectableBus1="_044b9787-c766-11e1-8775-005056c00008" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" bus2="_04862f81-c766-11e1-8775-005056c00008" connectableBus2="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_c3ef7069-26cb-4184-bb94-4ac49df0603d" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ace48562-0a49-4b76-ae82-c896a00b04f9" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.78752" g1="0.0" b1="1.0560145E-4" g2="0.0" b2="1.0560145E-4" bus1="_047ba835-c766-11e1-8775-005056c00008" connectableBus1="_047ba835-c766-11e1-8775-005056c00008" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" bus2="_04719616-c766-11e1-8775-005056c00008" connectableBus2="_04719616-c766-11e1-8775-005056c00008" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_bc06dfbb-eb99-4db7-8c9d-ec079e03009f" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3f744dba-88dc-4d89-90d4-a6f196054b28" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.143152" x="9.774864" g1="0.0" b1="4.21258E-5" g2="0.0" b2="4.21258E-5" bus1="_047d2ed4-c766-11e1-8775-005056c00008" connectableBus1="_047d2ed4-c766-11e1-8775-005056c00008" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" bus2="_044b9787-c766-11e1-8775-005056c00008" connectableBus2="_044b9787-c766-11e1-8775-005056c00008" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7da82087-b318-404c-9514-65732f211e14" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_43f91aaf-c5f4-4995-85a2-37afac616331" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.333211" x="14.89752" g1="0.0" b1="6.19835E-5" g2="0.0" b2="6.19835E-5" bus1="_04483c26-c766-11e1-8775-005056c00008" connectableBus1="_04483c26-c766-11e1-8775-005056c00008" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" bus2="_046c8d0b-c766-11e1-8775-005056c00008" connectableBus2="_046c8d0b-c766-11e1-8775-005056c00008" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_611015af-1467-451a-a0ba-6c093df0fde0" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2c20e8bd-84e6-4a1e-b88e-071f631327cb" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9696" x="23.6269436" g1="0.0" b1="9.52709E-5" g2="0.0" b2="9.52709E-5" bus1="_04725962-c766-11e1-8775-005056c00008" connectableBus1="_04725962-c766-11e1-8775-005056c00008" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" bus2="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus2="_0462a1f3-c766-11e1-8775-005056c00008" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7a4b30c3-e92f-4a39-aeff-e9554d8ce96e" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6ad31f7e-233f-4801-898f-9ffc883ec724" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.590032" g1="0.0" b1="3.27709E-5" g2="0.0" b2="3.27709E-5" bus1="_04686e54-c766-11e1-8775-005056c00008" connectableBus1="_04686e54-c766-11e1-8775-005056c00008" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" bus2="_04670ec8-c766-11e1-8775-005056c00008" connectableBus2="_04670ec8-c766-11e1-8775-005056c00008" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_917c1ba3-4b76-4e83-a631-84a088996b57" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_a025c9d8-58f9-4320-a1fe-73ecc68d4147" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.24872" x="15.5848007" g1="0.0" b1="0.00127066113" g2="0.0" b2="0.00127066113" bus1="_044e7db1-c766-11e1-8775-005056c00008" connectableBus1="_044e7db1-c766-11e1-8775-005056c00008" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" bus2="_047ba832-c766-11e1-8775-005056c00008" connectableBus2="_047ba832-c766-11e1-8775-005056c00008" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_a0202601-e216-4568-ab78-b4fe21fd1fba" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b7fac0a3-c5af-48b9-af49-261fd8d46e00" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4848" x="17.77248" g1="0.0" b1="7.92011E-5" g2="0.0" b2="7.92011E-5" bus1="_045f1f84-c766-11e1-8775-005056c00008" connectableBus1="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" bus2="_047a96c0-c766-11e1-8775-005056c00008" connectableBus2="_047a96c0-c766-11e1-8775-005056c00008" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_1662e4d0-c8bc-4830-a853-01d4c6f3c737" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_51646744-d343-42b5-8ba7-fcedc7cc3a98" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.384016" x="17.59824" g1="0.0" b1="2.97865E-4" g2="0.0" b2="2.97865E-4" bus1="_044a8615-c766-11e1-8775-005056c00008" connectableBus1="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" bus2="_04719616-c766-11e1-8775-005056c00008" connectableBus2="_04719616-c766-11e1-8775-005056c00008" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_2dd1be0d-4305-4e5a-af1e-424eda4251b7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_76311a15-b79a-4439-a7ce-47afa8fa6fe2" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.87684" x="12.7369442" g1="0.0" b1="5.38338E-5" g2="0.0" b2="5.38338E-5" bus1="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus1="_0458b6e4-c766-11e1-8775-005056c00008" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" bus2="_045b4ef9-c766-11e1-8775-005056c00008" connectableBus2="_045b4ef9-c766-11e1-8775-005056c00008" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7bf0d6eb-6015-4b67-b5f5-7e9417da9602" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_efbf8de7-4b84-4834-bb7c-6250b6072211" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.32184" x="28.314" g1="0.0" b1="1.170799E-4" g2="0.0" b2="1.170799E-4" bus1="_04597a36-c766-11e1-8775-005056c00008" connectableBus1="_04597a36-c766-11e1-8775-005056c00008" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" bus2="_04876809-c766-11e1-8775-005056c00008" connectableBus2="_04876809-c766-11e1-8775-005056c00008" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_77f8dc85-1e26-4f69-8f9d-2e85760a932b" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_22b6919a-a7a0-49fc-9e90-329069c55055" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.9180164" x="32.40864" g1="0.0" b1="1.2741045E-4" g2="0.0" b2="1.2741045E-4" bus1="_04725962-c766-11e1-8775-005056c00008" connectableBus1="_04725962-c766-11e1-8775-005056c00008" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_3ad3799b-5f8c-4ba0-9e85-81d48157adf6" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_8b91f4fd-4038-45b7-870c-fbc08592b95a" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.421936" x="12.4058876" g1="0.0" b1="5.549815E-5" g2="0.0" b2="5.549815E-5" bus1="_047a96c0-c766-11e1-8775-005056c00008" connectableBus1="_047a96c0-c766-11e1-8775-005056c00008" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" bus2="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus2="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_6dd129f4-2730-4d27-b5dd-b91c16fc6588" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_970bc323-73bf-440d-a3c5-00aebc3a1992" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.146912" x="18.81792" g1="0.0" b1="8.20707E-5" g2="0.0" b2="8.20707E-5" bus1="_04898ae9-c766-11e1-8775-005056c00008" connectableBus1="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" bus2="_044b7076-c766-11e1-8775-005056c00008" connectableBus2="_044b7076-c766-11e1-8775-005056c00008" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_70ad4f3f-a659-48e9-8383-8ac70b8bce31" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_cb084dc7-1b26-415f-9495-4695df661912" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.743088" x="22.16333" g1="0.0" b1="9.37787E-5" g2="0.0" b2="9.37787E-5" bus1="_04675ce9-c766-11e1-8775-005056c00008" connectableBus1="_04675ce9-c766-11e1-8775-005056c00008" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" bus2="_04502b6a-c766-11e1-8775-005056c00008" connectableBus2="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_a688473b-de97-456e-afb7-e65c079e3b34" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3a165a76-f6ba-461b-84d6-159a5e0b5077" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.92416" g1="0.0" b1="2.508035E-5" g2="0.0" b2="2.508035E-5" bus1="_04684743-c766-11e1-8775-005056c00008" connectableBus1="_04684743-c766-11e1-8775-005056c00008" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" bus2="_047566a8-c766-11e1-8775-005056c00008" connectableBus2="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_bed061b3-3663-40ad-956f-90cda64cbaab" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b19bc945-cc51-4d77-8eaa-3f6afe2d9316" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.1657114" g1="0.0" b1="6.19835E-5" g2="0.0" b2="6.19835E-5" bus1="_048c4a07-c766-11e1-8775-005056c00008" connectableBus1="_048c4a07-c766-11e1-8775-005056c00008" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" bus2="_0468bc75-c766-11e1-8775-005056c00008" connectableBus2="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_1bb497d6-1d54-49c9-bdd5-c8634a07cfb5" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_a9e283ed-fcad-4f4c-ab57-8531875bb098" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.812096" g1="0.0" b1="7.9201E-6" g2="0.0" b2="7.9201E-6" bus1="_046f9a47-c766-11e1-8775-005056c00008" connectableBus1="_046f9a47-c766-11e1-8775-005056c00008" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" bus2="_044fdd40-c766-11e1-8775-005056c00008" connectableBus2="_044fdd40-c766-11e1-8775-005056c00008" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_683d7e84-46ea-46ad-9327-754235536ac4" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_c59e4022-b1c0-4811-a32e-f54656bff32d" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.89" x="22.99968" g1="0.0" b1="7.40358E-5" g2="0.0" b2="7.40358E-5" bus1="_046a9133-c766-11e1-8775-005056c00008" connectableBus1="_046a9133-c766-11e1-8775-005056c00008" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" bus2="_04716f02-c766-11e1-8775-005056c00008" connectableBus2="_04716f02-c766-11e1-8775-005056c00008" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_204653d4-8c5b-43bc-9283-a2a842f366a9" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_1268eb09-e233-44ce-b8af-22dc30eb16ad" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.36728" x="33.9768" g1="0.0" b1="1.440542E-4" g2="0.0" b2="1.440542E-4" bus1="_047e4045-c766-11e1-8775-005056c00008" connectableBus1="_047e4045-c766-11e1-8775-005056c00008" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" bus2="_0474071a-c766-11e1-8775-005056c00008" connectableBus2="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ff77fc37-c585-41b5-90d2-a44430227501" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_9c0c454b-ecc3-40f6-b505-f32fec412522" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.202944" x="31.71168" g1="0.0" b1="1.417585E-4" g2="0.0" b2="1.417585E-4" bus1="_04898ae9-c766-11e1-8775-005056c00008" connectableBus1="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" bus2="_0479fa80-c766-11e1-8775-005056c00008" connectableBus2="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_d63c0548-9f5e-4d60-bae2-0566a6473e46" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_1432f4d6-9299-4b0d-bd7f-16e059f9de66" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.64336" g1="0.0" b1="1.5381085E-4" g2="0.0" b2="1.5381085E-4" bus1="_045b9d15-c766-11e1-8775-005056c00008" connectableBus1="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_08a97648-23dd-422a-a403-bdb89143a421" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_193f6952-4267-4cc8-a541-726c095028ba" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.2907524" x="51.4008" g1="0.0" b1="1.3544535E-4" g2="0.0" b2="1.3544535E-4" bus1="_04502b6a-c766-11e1-8775-005056c00008" connectableBus1="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" bus2="_0468bc75-c766-11e1-8775-005056c00008" connectableBus2="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_07757788-2dda-494c-9038-c1d010214558" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_579249ce-1c81-4d29-8d3f-5fc627a18f99" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792" x="42.7584953" g1="0.0" b1="1.7412765E-4" g2="0.0" b2="1.7412765E-4" bus1="_046bf0cb-c766-11e1-8775-005056c00008" connectableBus1="_046bf0cb-c766-11e1-8775-005056c00008" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" bus2="_047c4478-c766-11e1-8775-005056c00008" connectableBus2="_047c4478-c766-11e1-8775-005056c00008" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f1be8c91-71cf-4d95-bcee-a6e3c19c9a0a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3d2cb4b5-ee82-4866-9855-4a5f4803cd3b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.843872" x="13.2770882" g1="0.0" b1="5.7966E-5" g2="0.0" b2="5.7966E-5" bus1="_046c17da-c766-11e1-8775-005056c00008" connectableBus1="_046c17da-c766-11e1-8775-005056c00008" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" bus2="_04550d63-c766-11e1-8775-005056c00008" connectableBus2="_04550d63-c766-11e1-8775-005056c00008" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_4895e133-ecd4-4a69-b358-c2d8d11bd39d" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6fc48d8d-05f8-4104-a6a2-3686d430a091" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.847" x="9.776799" g1="0.0" b1="8.3471078E-4" g2="0.0" b2="8.3471078E-4" bus1="_044aad28-c766-11e1-8775-005056c00008" connectableBus1="_044aad28-c766-11e1-8775-005056c00008" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" bus2="_0453d4e3-c766-11e1-8775-005056c00008" connectableBus2="_0453d4e3-c766-11e1-8775-005056c00008" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_4428a1f2-00f5-474c-b891-600c8f530e1f" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_191836a1-39cd-402b-8dcf-4f3867c45bd0" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.164336" x="30.1435184" g1="0.0" b1="1.3487145E-4" g2="0.0" b2="1.3487145E-4" bus1="_045f1f84-c766-11e1-8775-005056c00008" connectableBus1="_045f1f84-c766-11e1-8775-005056c00008" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" bus2="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus2="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_4d831a76-7147-4776-a08a-9b166d2dcc7d" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_66cbdeeb-a4e4-4bfc-aec1-9fb7a2d2b6bc" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.146912" x="17.371727" g1="0.0" b1="3.0417815E-4" g2="0.0" b2="3.0417815E-4" bus1="_0453d4e4-c766-11e1-8775-005056c00008" connectableBus1="_0453d4e4-c766-11e1-8775-005056c00008" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" bus2="_048433b2-c766-11e1-8775-005056c00008" connectableBus2="_048433b2-c766-11e1-8775-005056c00008" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_2eff6ba2-5d90-4d71-bcc6-a0c31c1d028d" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_8489e809-6588-4ed2-a9a4-43c44a0d47da" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.917328" x="31.188961" g1="0.0" b1="1.365932E-4" g2="0.0" b2="1.365932E-4" bus1="_044b7076-c766-11e1-8775-005056c00008" connectableBus1="_044b7076-c766-11e1-8775-005056c00008" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" bus2="_0468bc75-c766-11e1-8775-005056c00008" connectableBus2="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_a27844ae-f43e-4dea-82b7-bbfa8265a2d2" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_620beaaf-63c8-4020-bea5-c3609c0eaadf" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.129488" x="16.4308319" g1="0.0" b1="6.82966E-5" g2="0.0" b2="6.82966E-5" bus1="_046c8d0b-c766-11e1-8775-005056c00008" connectableBus1="_046c8d0b-c766-11e1-8775-005056c00008" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" bus2="_04885267-c766-11e1-8775-005056c00008" connectableBus2="_04885267-c766-11e1-8775-005056c00008" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.199184" x="18.81792" g1="0.0" b1="8.14968E-5" g2="0.0" b2="8.14968E-5" bus1="_0471bd2a-c766-11e1-8775-005056c00008" connectableBus1="_0471bd2a-c766-11e1-8775-005056c00008" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" bus2="_047147f0-c766-11e1-8775-005056c00008" connectableBus2="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_751f81c5-bc0f-47d9-8bf1-215d33c20a33" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_828ca44c-560b-4f94-b825-21e237285fae" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.822688" x="9.23472" g1="0.0" b1="1.561065E-4" g2="0.0" b2="1.561065E-4" bus1="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus1="_044ea4c4-c766-11e1-8775-005056c00008" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" bus2="_0479fa80-c766-11e1-8775-005056c00008" connectableBus2="_0479fa80-c766-11e1-8775-005056c00008" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_c0d073c0-9e3c-443a-898c-1b775bffd91a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_233b7735-85f4-4a6f-9d87-15129fe42ef5" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.36084" x="47.7224" g1="0.0" b1="0.0010805785" g2="0.0" b2="0.0010805785" bus1="_0451b206-c766-11e1-8775-005056c00008" connectableBus1="_0451b206-c766-11e1-8775-005056c00008" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" bus2="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus2="_0458ddf2-c766-11e1-8775-005056c00008" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_bbea6b5b-db2c-40f6-afef-3da510b3b212" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_990ce3c5-c90c-41b9-abee-fb803d9df3a5" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.23472" x="31.88592" g1="0.0" b1="1.3544535E-4" g2="0.0" b2="1.3544535E-4" bus1="_044ef2e3-c766-11e1-8775-005056c00008" connectableBus1="_044ef2e3-c766-11e1-8775-005056c00008" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" bus2="_0483be8a-c766-11e1-8775-005056c00008" connectableBus2="_0483be8a-c766-11e1-8775-005056c00008" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_9bb71092-9fe9-497f-9296-4a8b4d9b2bf6" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_1372c3b0-62d7-47d7-a8c0-ed8e10bc1f1a" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.857536" x="12.9111843" g1="0.0" b1="5.65886E-5" g2="0.0" b2="5.65886E-5" bus1="_04483c26-c766-11e1-8775-005056c00008" connectableBus1="_04483c26-c766-11e1-8775-005056c00008" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" bus2="_044fdd40-c766-11e1-8775-005056c00008" connectableBus2="_044fdd40-c766-11e1-8775-005056c00008" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_e8ff318f-6a55-4c01-9fcf-9cfe688188ce" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_64cfd0fb-1d8e-45d2-a52f-469238dfc0c6" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.74616" x="12.3187675" g1="0.0" b1="5.211205E-5" g2="0.0" b2="5.211205E-5" bus1="_047566a8-c766-11e1-8775-005056c00008" connectableBus1="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" bus2="_047e4045-c766-11e1-8775-005056c00008" connectableBus2="_047e4045-c766-11e1-8775-005056c00008" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_cd9654e8-0619-442a-898e-2fc144b2abec" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_efe2501d-bcee-42ff-a037-3d8a280487b0" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.857536" x="9.478656" g1="0.0" b1="3.891185E-5" g2="0.0" b2="3.891185E-5" bus1="_047ba835-c766-11e1-8775-005056c00008" connectableBus1="_047ba835-c766-11e1-8775-005056c00008" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" bus2="_0479102a-c766-11e1-8775-005056c00008" connectableBus2="_0479102a-c766-11e1-8775-005056c00008" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_9c2c041c-d52f-4062-836d-c76e124232b0" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2ae204bf-78cc-49cb-b886-a933b33057e4" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.143152" x="7.074144" g1="0.0" b1="2.96717E-5" g2="0.0" b2="2.96717E-5" bus1="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus1="_0486f2d6-c766-11e1-8775-005056c00008" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" bus2="_04716f04-c766-11e1-8775-005056c00008" connectableBus2="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_340906fe-83b3-451f-8724-1708b8dc630b" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_e822432e-79af-4bba-8f40-5250468f81a0" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.433216" x="27.8783989" g1="0.0" b1="1.1650595E-4" g2="0.0" b2="1.1650595E-4" bus1="_0471bd2a-c766-11e1-8775-005056c00008" connectableBus1="_0471bd2a-c766-11e1-8775-005056c00008" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" bus2="_047566a8-c766-11e1-8775-005056c00008" connectableBus2="_047566a8-c766-11e1-8775-005056c00008" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_00e770fb-802e-479b-ae76-a52f5614bc15" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_c437e52c-43d7-4ae9-87ad-dc19396dc6ff" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0.0" b1="9.81405E-5" g2="0.0" b2="9.81405E-5" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_046a4314-c766-11e1-8775-005056c00008" connectableBus2="_046a4314-c766-11e1-8775-005056c00008" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_3904e93a-ed7a-4222-9cbc-575270ef2037" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_90dcdbe1-437b-443f-b0b5-c2353f7c6954" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.670321" x="31.88592" g1="0.0" b1="1.337236E-4" g2="0.0" b2="1.337236E-4" bus1="_045868c7-c766-11e1-8775-005056c00008" connectableBus1="_045868c7-c766-11e1-8775-005056c00008" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" bus2="_04577e63-c766-11e1-8775-005056c00008" connectableBus2="_04577e63-c766-11e1-8775-005056c00008" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_b9ea0da8-57a8-46d3-bfa0-dc21a2f40ee7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_9b8510fa-bd0e-4e63-8f4c-0e5443a3eb63" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.37072" g1="0.0" b1="1.4864555E-4" g2="0.0" b2="1.4864555E-4" bus1="_04675ce7-c766-11e1-8775-005056c00008" connectableBus1="_04675ce7-c766-11e1-8775-005056c00008" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" bus2="_0453d4eb-c766-11e1-8775-005056c00008" connectableBus2="_0453d4eb-c766-11e1-8775-005056c00008" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7a4d98b5-2e0c-4af5-b1d0-c41bea482943" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_336bfd86-a922-4154-9e06-cd87382cdc5f" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.44312" x="12.5278568" g1="0.0" b1="5.130855E-5" g2="0.0" b2="5.130855E-5" bus1="_046a4314-c766-11e1-8775-005056c00008" connectableBus1="_046a4314-c766-11e1-8775-005056c00008" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" bus2="_0467f927-c766-11e1-8775-005056c00008" connectableBus2="_0467f927-c766-11e1-8775-005056c00008" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_9c6f5c6b-1c48-486d-817d-544297fbef05" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2be10dec-f0ac-470d-83f7-a2a4e70f3491" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.881792" x="5.767344" g1="0.0" b1="2.38177E-5" g2="0.0" b2="2.38177E-5" bus1="_04885267-c766-11e1-8775-005056c00008" connectableBus1="_04885267-c766-11e1-8775-005056c00008" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" bus2="_04723255-c766-11e1-8775-005056c00008" connectableBus2="_04723255-c766-11e1-8775-005056c00008" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_ee57814f-f263-4a45-87db-86c93966cf99" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_f0e21213-6535-44a7-89b6-3063f8738d6b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66792" x="7.744" g1="0.0" b1="6.5909093E-4" g2="0.0" b2="6.5909093E-4" bus1="_0458ddf2-c766-11e1-8775-005056c00008" connectableBus1="_0458ddf2-c766-11e1-8775-005056c00008" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" bus2="_044aad28-c766-11e1-8775-005056c00008" connectableBus2="_044aad28-c766-11e1-8775-005056c00008" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_be72c97f-9801-4b6e-acc0-fd79b256c7ab" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ab31cd46-6d0c-4d9c-95f1-396a45a237e1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.71952" x="50.3553619" g1="0.0" b1="2.1177685E-4" g2="0.0" b2="2.1177685E-4" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_04549837-c766-11e1-8775-005056c00008" connectableBus2="_04549837-c766-11e1-8775-005056c00008" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_c929168a-b558-48fa-aa86-314a35dd7d82" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_1bf78539-b6fa-4d8b-ba8e-9b5970019be6" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.18552" g1="0.0" b1="2.519515E-5" g2="0.0" b2="2.519515E-5" bus1="_04499bb3-c766-11e1-8775-005056c00008" connectableBus1="_04499bb3-c766-11e1-8775-005056c00008" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" bus2="_04878f11-c766-11e1-8775-005056c00008" connectableBus2="_04878f11-c766-11e1-8775-005056c00008" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_173c0b25-4aa7-4c49-a38e-daf8ddd9b8b7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_08ff3ae4-d1dd-49f7-9eda-32ffc8eb0010" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.850291" x="2.631024" g1="0.0" b1="1.07323E-5" g2="0.0" b2="1.07323E-5" bus1="_04769f21-c766-11e1-8775-005056c00008" connectableBus1="_04769f21-c766-11e1-8775-005056c00008" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" bus2="_045b9d15-c766-11e1-8775-005056c00008" connectableBus2="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f19aeba4-5612-451d-a2d5-8f8415f42907" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_94316214-afd8-4c0d-bca4-916acb92af85" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.91664" x="8.659728" g1="0.0" b1="3.78214E-5" g2="0.0" b2="3.78214E-5" bus1="_045ef874-c766-11e1-8775-005056c00008" connectableBus1="_045ef874-c766-11e1-8775-005056c00008" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" bus2="_048b86b5-c766-11e1-8775-005056c00008" connectableBus2="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_a9ea718f-3a70-4590-bdc8-a638045c7097" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_4ea6b532-d914-4b0c-97ee-9f02a14a40b3" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.306662" x="1.390435" g1="0.0" b1="6.02615E-6" g2="0.0" b2="6.02615E-6" bus1="_04555b87-c766-11e1-8775-005056c00008" connectableBus1="_04555b87-c766-11e1-8775-005056c00008" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" bus2="_047147f0-c766-11e1-8775-005056c00008" connectableBus2="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7ecdb83b-300c-47f9-a746-141b4e88f5d1" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_2a95fb2b-6661-46e7-a9f6-fe63c1b7433c" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.188592" x="14.7929754" g1="0.0" b1="6.19835E-5" g2="0.0" b2="6.19835E-5" bus1="_0474f17a-c766-11e1-8775-005056c00008" connectableBus1="_0474f17a-c766-11e1-8775-005056c00008" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" bus2="_045a1670-c766-11e1-8775-005056c00008" connectableBus2="_045a1670-c766-11e1-8775-005056c00008" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_9c62dbd2-5c0b-4651-9a3e-60685bcfdf52" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_4b67f5f5-f0e1-4bfb-9d57-4d3474720a45" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.586272" g1="0.0" b1="2.82943E-5" g2="0.0" b2="2.82943E-5" bus1="_046783f5-c766-11e1-8775-005056c00008" connectableBus1="_046783f5-c766-11e1-8775-005056c00008" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" bus2="_04876809-c766-11e1-8775-005056c00008" connectableBus2="_04876809-c766-11e1-8775-005056c00008" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_d4cfc077-4796-4a02-b938-a43c0f88d615" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_1ca40dc7-6736-4fa8-b4cb-ca696949e421" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.902976" x="15.6990232" g1="0.0" b1="6.427915E-5" g2="0.0" b2="6.427915E-5" bus1="_047c4478-c766-11e1-8775-005056c00008" connectableBus1="_047c4478-c766-11e1-8775-005056c00008" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" bus2="_04725962-c766-11e1-8775-005056c00008" connectableBus2="_04725962-c766-11e1-8775-005056c00008" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_9ba5e8b2-6a11-456a-aac4-3a733a324ddf" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ba738481-ddba-4ebe-a218-8aad0b537f5b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0.0" b1="5.01607E-5" g2="0.0" b2="5.01607E-5" bus1="_04555b87-c766-11e1-8775-005056c00008" connectableBus1="_04555b87-c766-11e1-8775-005056c00008" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" bus2="_0458b6e4-c766-11e1-8775-005056c00008" connectableBus2="_0458b6e4-c766-11e1-8775-005056c00008" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_16d1fe69-1ba4-46ed-870c-952d884df26b" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_b1d87c24-e527-4174-aa04-cd0b9de271ea" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.495392" x="14.7755518" g1="0.0" b1="6.25574E-5" g2="0.0" b2="6.25574E-5" bus1="_04502b6a-c766-11e1-8775-005056c00008" connectableBus1="_04502b6a-c766-11e1-8775-005056c00008" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" bus2="_04667289-c766-11e1-8775-005056c00008" connectableBus2="_04667289-c766-11e1-8775-005056c00008" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_341ddbb0-3a2a-4eb9-bc29-2e0f7900c00a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_4e1daf8e-7708-4b96-8d3f-67f58f2505f9" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.45816" x="56.2795219" g1="0.0" b1="2.4678605E-4" g2="0.0" b2="2.4678605E-4" bus1="_04577e63-c766-11e1-8775-005056c00008" connectableBus1="_04577e63-c766-11e1-8775-005056c00008" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_9f7663d9-452e-4006-88ac-295dc5108fe7" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_c58940cb-bd36-4dfc-9615-11716dd652a7" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.05672" x="21.25728" g1="0.0" b1="3.5583105E-4" g2="0.0" b2="3.5583105E-4" bus1="_044a8615-c766-11e1-8775-005056c00008" connectableBus1="_044a8615-c766-11e1-8775-005056c00008" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" bus2="_04716f04-c766-11e1-8775-005056c00008" connectableBus2="_04716f04-c766-11e1-8775-005056c00008" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_f2cd1019-50d4-4961-a413-a74f33221b99" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3c9a454c-10ee-4c72-a059-77f723f5b7c7" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.718144" x="12.2664957" g1="0.0" b1="5.36616E-5" g2="0.0" b2="5.36616E-5" bus1="_0447ee09-c766-11e1-8775-005056c00008" connectableBus1="_0447ee09-c766-11e1-8775-005056c00008" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" bus2="_04898ae9-c766-11e1-8775-005056c00008" connectableBus2="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7452c739-95b4-4967-9703-6790355cb281" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_270a7d04-9ff9-4178-8b72-b610735a72ac" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.537072" x="10.2453117" g1="0.0" b1="4.00597E-5" g2="0.0" b2="4.00597E-5" bus1="_046a4314-c766-11e1-8775-005056c00008" connectableBus1="_046a4314-c766-11e1-8775-005056c00008" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" bus2="_048c22f1-c766-11e1-8775-005056c00008" connectableBus2="_048c22f1-c766-11e1-8775-005056c00008" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_701af727-7df8-4c87-9615-f7ade9c35e3a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_9d1eb182-ceb5-426e-9440-5f4d426a31cb" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.582512" x="21.25728" g1="0.0" b1="8.895775E-5" g2="0.0" b2="8.895775E-5" bus1="_04494d93-c766-11e1-8775-005056c00008" connectableBus1="_04494d93-c766-11e1-8775-005056c00008" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" bus2="_04549837-c766-11e1-8775-005056c00008" connectableBus2="_04549837-c766-11e1-8775-005056c00008" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7f361a6a-3949-46c7-a8dd-e212dd07dfcc" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_735ac8df-6a6a-43f0-86f2-49d3280c9a3b" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.944656" x="12.3187675" g1="0.0" b1="5.7966E-5" g2="0.0" b2="5.7966E-5" bus1="_04549837-c766-11e1-8775-005056c00008" connectableBus1="_04549837-c766-11e1-8775-005056c00008" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" bus2="_04769f21-c766-11e1-8775-005056c00008" connectableBus2="_04769f21-c766-11e1-8775-005056c00008" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_83d1a365-5ebd-48e1-b477-f4bdcb1c880b" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_52aadf8d-53f2-4827-8c70-421bdf1ba822" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.188592" x="16.2740154" g1="0.0" b1="7.288795E-5" g2="0.0" b2="7.288795E-5" bus1="_04898ae9-c766-11e1-8775-005056c00008" connectableBus1="_04898ae9-c766-11e1-8775-005056c00008" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" bus2="_04667284-c766-11e1-8775-005056c00008" connectableBus2="_04667284-c766-11e1-8775-005056c00008" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_77813798-83ae-4088-a129-0c46810ef5f1" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_fece5807-6af8-4161-8de8-8f8473d92f11" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.805814" x="31.5897121" g1="0.0" b1="1.322888E-4" g2="0.0" b2="1.322888E-4" bus1="_04597a36-c766-11e1-8775-005056c00008" connectableBus1="_04597a36-c766-11e1-8775-005056c00008" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" bus2="_04550d63-c766-11e1-8775-005056c00008" connectableBus2="_04550d63-c766-11e1-8775-005056c00008" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_07a99745-5437-4372-a0a7-3b4704c6e20c" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_3eacc034-737e-41de-a7b6-b610d3bd0921" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.8315849" g1="0.0" b1="6.944445E-5" g2="0.0" b2="6.944445E-5" bus1="_045b9d15-c766-11e1-8775-005056c00008" connectableBus1="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" bus2="_0467f927-c766-11e1-8775-005056c00008" connectableBus2="_0467f927-c766-11e1-8775-005056c00008" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_5e786d5a-d8b0-4e68-8b0e-80418c4a25da" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_0d0c3ec5-798a-48a4-9bc8-d19c57128a13" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.62112" x="21.6754551" g1="0.0" b1="9.16552E-5" g2="0.0" b2="9.16552E-5" bus1="_0474071a-c766-11e1-8775-005056c00008" connectableBus1="_0474071a-c766-11e1-8775-005056c00008" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" bus2="_045e0e10-c766-11e1-8775-005056c00008" connectableBus2="_045e0e10-c766-11e1-8775-005056c00008" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_92371c95-ca5e-4604-96b0-3ee21aa98f9b" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_5b0395f4-534d-4975-a1af-e0b6ef439193" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.390298" x="1.777248" g1="0.0" b1="7.69055E-6" g2="0.0" b2="7.69055E-6" bus1="_045ef874-c766-11e1-8775-005056c00008" connectableBus1="_045ef874-c766-11e1-8775-005056c00008" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" bus2="_0480d858-c766-11e1-8775-005056c00008" connectableBus2="_0480d858-c766-11e1-8775-005056c00008" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7100ff8d-0038-4fea-b382-1114fdbbbb80" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_74c4b341-7b99-4a81-b88a-2ed3b0c4b1de" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0475dbd8-c766-11e1-8775-005056c00008" name="63-64" r="0.83248" x="9.679999" g1="0.0" b1="2.231405E-4" g2="0.0" b2="2.231405E-4" bus1="_047f2aa7-c766-11e1-8775-005056c00008" connectableBus1="_047f2aa7-c766-11e1-8775-005056c00008" voltageLevelId1="_04854527-c766-11e1-8775-005056c00008" bus2="_0457f395-c766-11e1-8775-005056c00008" connectableBus2="_0457f395-c766-11e1-8775-005056c00008" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_eb59d486-fc89-4f4e-9fa7-ec08a3c9cf64" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_ae4eadea-f3fc-4ac6-8899-c1698ece7a89" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.27232" g1="0.0" b1="1.205234E-4" g2="0.0" b2="1.205234E-4" bus1="_048b86b5-c766-11e1-8775-005056c00008" connectableBus1="_048b86b5-c766-11e1-8775-005056c00008" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" bus2="_045868c7-c766-11e1-8775-005056c00008" connectableBus2="_045868c7-c766-11e1-8775-005056c00008" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_7c0938b3-2f8c-437c-8ed9-3d743f305160" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_e98d56fe-a54b-45e4-acff-0ac310beb3dd" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.118896" x="8.79912" g1="0.0" b1="3.609965E-5" g2="0.0" b2="3.609965E-5" bus1="_044b7072-c766-11e1-8775-005056c00008" connectableBus1="_044b7072-c766-11e1-8775-005056c00008" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" bus2="_0454e653-c766-11e1-8775-005056c00008" connectableBus2="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_472d8096-6f57-454e-a3d8-3f306b4f4f27" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_f2e58700-2366-46e0-8408-9472d85acd23" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.7342377" g1="0.0" b1="1.632805E-4" g2="0.0" b2="1.632805E-4" bus1="_045b9d15-c766-11e1-8775-005056c00008" connectableBus1="_045b9d15-c766-11e1-8775-005056c00008" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" bus2="_045645e7-c766-11e1-8775-005056c00008" connectableBus2="_045645e7-c766-11e1-8775-005056c00008" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_3b9aa0d5-4cdd-4527-91e2-89d797598afe" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_89654167-95a6-4c76-aad7-63a881116e17" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.101472" x="10.10592" g1="0.0" b1="1.7332415E-4" g2="0.0" b2="1.7332415E-4" bus1="_045c8773-c766-11e1-8775-005056c00008" connectableBus1="_045c8773-c766-11e1-8775-005056c00008" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" bus2="_0468bc75-c766-11e1-8775-005056c00008" connectableBus2="_0468bc75-c766-11e1-8775-005056c00008" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_45d8a8d9-59e4-412f-8e4e-ac26b87c52b6" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_216c0f3b-03e8-4b7d-96fc-a5f891331f7f" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.0126553" g1="0.0" b1="7.11662E-5" g2="0.0" b2="7.11662E-5" bus1="_0454e653-c766-11e1-8775-005056c00008" connectableBus1="_0454e653-c766-11e1-8775-005056c00008" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" bus2="_04862f81-c766-11e1-8775-005056c00008" connectableBus2="_04862f81-c766-11e1-8775-005056c00008" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_1451f44e-543d-4c6f-b201-d7a52943238a" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_32655e4f-e7da-46b0-a908-b601224ddb73" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.9012814" g1="0.0" b1="7.05923E-5" g2="0.0" b2="7.05923E-5" bus1="_045a1670-c766-11e1-8775-005056c00008" connectableBus1="_045a1670-c766-11e1-8775-005056c00008" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" bus2="_0461b794-c766-11e1-8775-005056c00008" connectableBus2="_0461b794-c766-11e1-8775-005056c00008" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_a4ca519a-5dee-49fc-9d34-d25e4d3e0430" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_bafaeace-e459-4dc2-87a0-467a9ea25f8d" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+</iidm:network>

--- a/dynaflow/src/test/resources/SmallBusBranch/powsybl-inputs/contingencies.groovy
+++ b/dynaflow/src/test/resources/SmallBusBranch/powsybl-inputs/contingencies.groovy
@@ -1,0 +1,3 @@
+contingency('contingency1') {
+    equipments '_0483e594-c766-11e1-8775-005056c00008'
+}

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,12 @@
             </dependency>
             <dependency>
                 <groupId>com.powsybl</groupId>
+                <artifactId>powsybl-contingency-dsl</artifactId>
+                <version>${powsyblcore.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.powsybl</groupId>
                 <artifactId>powsybl-dynamic-simulation-api</artifactId>
                 <version>${powsyblcore.version}</version>
             </dependency>


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature

**What is the current behavior?** *(You can also link to an open issue here)*
Results were returned only if the summarised result file was produced by DynaFlow launcher.

**What is the new behavior (if this is a feature change)?**
If DynaFlow has not produced a file with the summarised results of the security analysis, it will be built by loading the output networks written by Dynawo for every contingency and checking the limit violations on them.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
Results for monitored equipment will also be built in a separate PR.