### PR TITLE
Clean up dependencies

### DIFF
--- a/dynaflow/pom.xml
+++ b/dynaflow/pom.xml
@@ -39,10 +39,6 @@
             <artifactId>powsybl-security-analysis-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-time-series-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-dynawo-commons</artifactId>
             <version>${project.version}</version>

--- a/dynawaltz-dsl/pom.xml
+++ b/dynawaltz-dsl/pom.xml
@@ -50,6 +50,7 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-dynawaltz</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -97,6 +98,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-dynawaltz</artifactId>
+            <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -136,18 +136,6 @@
                 <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
-            <dependency>
-                <groupId>${project.groupId}</groupId>
-                <artifactId>powsybl-dynawaltz</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>${project.groupId}</groupId>
-                <artifactId>powsybl-dynawaltz</artifactId>
-                <version>${project.version}</version>
-                <type>test-jar</type>
-                <scope>test</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Removed dependency not required in dynaflow (time-series).
Removed dependency information for sub-modules in main pom (dynawaltz, dynawaltz-dsl).


**What is the current behavior?** *(You can also link to an open issue here)*
Dynaflow does not need to use time-series module from powsybl-core. 

**Other information**
The unneeded dependency in dynaflow (time-series) was found when testing the integration of dynaflow in pypowsybl. Adding powsybl-dynaflow to pypowsybl forced the inclusion of Groovy in the set of java libraries being used, and that provoked an error when building the GraalVM native-image.


