### PR TITLE
Update dynaflow parameters

### DIFF
--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowConstants.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowConstants.java
@@ -28,6 +28,12 @@ public final class DynaFlowConstants {
         CONSTRAINTS;
     }
 
+    public enum ActivePowerCompensation {
+        P,
+        TARGET_P,
+        PMAX
+    }
+
     private DynaFlowConstants() {
     }
 

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowParameters.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowParameters.java
@@ -60,7 +60,7 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
 
         @JsonIgnore
         public boolean isSerializable() {
-            return Objects.nonNull(timeOfEvent);
+            return timeOfEvent != null;
         }
     }
 
@@ -74,7 +74,7 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
     private static final String ASSEMBLING_PATH = "assemblingPath";
     private static final String START_TIME = "startTime";
     private static final String STOP_TIME = "stopTime";
-    private static final String PRECISION = "precision";
+    private static final String PRECISION_NAME = "precision";
     private static final String CHOSEN_OUTPUTS = "chosenOutputs";
     private static final String TIME_STEP = "timeStep";
 
@@ -184,11 +184,11 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
 
     @JsonIgnore
     public Double getTimeOfEvent() {
-        return Objects.isNull(securityAnalysis) ? null : securityAnalysis.getTimeOfEvent();
+        return securityAnalysis == null ? null : securityAnalysis.getTimeOfEvent();
     }
 
     public DynaFlowParameters setTimeOfEvent(Double timeOfEvent) {
-        if (Objects.isNull(this.securityAnalysis)) {
+        if (this.securityAnalysis == null) {
             securityAnalysis = new Sa();
         }
         securityAnalysis.setTimeOfEvent(timeOfEvent);
@@ -239,7 +239,7 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
                 .add(ASSEMBLING_PATH, assemblingPath)
                 .add(START_TIME, startTime)
                 .add(STOP_TIME, stopTime)
-                .add(PRECISION, precision)
+                .add(PRECISION_NAME, precision)
                 .add(Sa.SECURITY_ANALYSIS, securityAnalysis)
                 .add(CHOSEN_OUTPUTS, chosenOutputs)
                 .add(TIME_STEP, timeStep)
@@ -293,8 +293,8 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
         if (config.hasProperty(STOP_TIME)) {
             parameters.setStopTime(config.getDoubleProperty(STOP_TIME));
         }
-        if (config.hasProperty(PRECISION)) {
-            parameters.setPrecision(config.getDoubleProperty(PRECISION));
+        if (config.hasProperty(PRECISION_NAME)) {
+            parameters.setPrecision(config.getDoubleProperty(PRECISION_NAME));
         }
         if (config.hasProperty(Sa.TIME_OF_EVENT)) {
             parameters.setTimeOfEvent(config.getDoubleProperty(Sa.TIME_OF_EVENT));
@@ -318,9 +318,9 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
         Optional.ofNullable(properties.get(ASSEMBLING_PATH)).ifPresent(this::setAssemblingPath);
         Optional.ofNullable(properties.get(START_TIME)).ifPresent(prop -> setStartTime(Double.parseDouble(prop)));
         Optional.ofNullable(properties.get(STOP_TIME)).ifPresent(prop -> setStopTime(Double.parseDouble(prop)));
-        Optional.ofNullable(properties.get(PRECISION)).ifPresent(prop -> setPrecision(Double.parseDouble(prop)));
+        Optional.ofNullable(properties.get(PRECISION_NAME)).ifPresent(prop -> setPrecision(Double.parseDouble(prop)));
         Optional.ofNullable(properties.get(Sa.TIME_OF_EVENT)).ifPresent(prop -> {
-            if (Objects.isNull(securityAnalysis)) {
+            if (securityAnalysis == null) {
                 securityAnalysis = new Sa();
             }
             securityAnalysis.setTimeOfEvent(Double.parseDouble(prop));
@@ -339,7 +339,7 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
     public static List<String> getSpecificParametersNames() {
         return Arrays.asList(
                 SVC_REGULATION_ON, SHUNT_REGULATION_ON, AUTOMATIC_SLACK_BUS_ON, DSO_VOLTAGE_LEVEL,
-                ACTIVE_POWER_COMPENSATION, SETTING_PATH, ASSEMBLING_PATH, START_TIME, STOP_TIME, PRECISION,
+                ACTIVE_POWER_COMPENSATION, SETTING_PATH, ASSEMBLING_PATH, START_TIME, STOP_TIME, PRECISION_NAME,
                 Sa.TIME_OF_EVENT, CHOSEN_OUTPUTS, TIME_STEP
         );
     }

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowParameters.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowParameters.java
@@ -6,12 +6,16 @@
  */
 package com.powsybl.dynaflow;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.google.common.base.MoreObjects;
 import com.powsybl.commons.config.ModuleConfig;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.loadflow.LoadFlowParameters;
+import com.powsybl.dynaflow.DynaFlowConstants.ActivePowerCompensation;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -23,21 +27,68 @@ import static com.powsybl.dynaflow.DynaFlowProvider.MODULE_SPECIFIC_PARAMETERS;
  */
 public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
 
-    private static final String CHOSEN_OUTPUT_STRING_DELIMITER = ",";
+    /**
+     * Inner class dedicated to Security Analysis (SA) namespace
+     */
+    public static class Sa {
+        private static final String SECURITY_ANALYSIS = "sa"; //Security analysis
+        private static final String TIME_OF_EVENT = "timeOfEvent";
 
+        private Double timeOfEvent = null;
+
+        public Double getTimeOfEvent() {
+            return timeOfEvent;
+        }
+
+        public void setTimeOfEvent(Double timeOfEvent) {
+            this.timeOfEvent = timeOfEvent;
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper("").omitNullValues()
+                    .add(TIME_OF_EVENT, timeOfEvent).toString();
+        }
+
+        public static void writeJson(JsonGenerator jsonGenerator, DynaFlowParameters dynaFlowParameters) throws IOException {
+            if (dynaFlowParameters.getSa().isSerializable()) {
+                jsonGenerator.writeObjectFieldStart("sa");
+                jsonGenerator.writeNumberField("TimeOfEvent", dynaFlowParameters.getTimeOfEvent());
+                jsonGenerator.writeEndObject();
+            }
+        }
+
+        @JsonIgnore
+        public boolean isSerializable() {
+            return Objects.nonNull(timeOfEvent);
+        }
+    }
+
+    private static final String CHOSEN_OUTPUT_STRING_DELIMITER = ",";
     private static final String SVC_REGULATION_ON = "svcRegulationOn";
     private static final String SHUNT_REGULATION_ON = "shuntRegulationOn";
     private static final String AUTOMATIC_SLACK_BUS_ON = "automaticSlackBusOn";
     private static final String DSO_VOLTAGE_LEVEL = "dsoVoltageLevel";
-
+    private static final String ACTIVE_POWER_COMPENSATION = "activePowerCompensation";
+    private static final String SETTING_PATH = "settingPath";
+    private static final String ASSEMBLING_PATH = "assemblingPath";
+    private static final String START_TIME = "startTime";
+    private static final String STOP_TIME = "stopTime";
+    private static final String PRECISION = "precision";
     private static final String CHOSEN_OUTPUTS = "chosenOutputs";
-
     private static final String TIME_STEP = "timeStep";
 
     private Boolean svcRegulationOn = null;
     private Boolean shuntRegulationOn = null;
     private Boolean automaticSlackBusOn = null;
     private Double dsoVoltageLevel = null;
+    private ActivePowerCompensation activePowerCompensation = null;
+    private String settingPath = null;
+    private String assemblingPath = null;
+    private Double startTime = null;
+    private Double stopTime = null;
+    private Double precision = null;
+    private Sa securityAnalysis = null;
     private List<String> chosenOutputs = null;
     private Double timeStep = null;
 
@@ -77,6 +128,73 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
         return this;
     }
 
+    public ActivePowerCompensation getActivePowerCompensation() {
+        return activePowerCompensation;
+    }
+
+    public DynaFlowParameters setActivePowerCompensation(ActivePowerCompensation activePowerCompensation) {
+        this.activePowerCompensation = activePowerCompensation;
+        return this;
+    }
+
+    public String getSettingPath() {
+        return settingPath;
+    }
+
+    public DynaFlowParameters setSettingPath(String settingPath) {
+        this.settingPath = settingPath;
+        return this;
+    }
+
+    public String getAssemblingPath() {
+        return assemblingPath;
+    }
+
+    public DynaFlowParameters setAssemblingPath(String assemblingPath) {
+        this.assemblingPath = assemblingPath;
+        return this;
+    }
+
+    public Double getStartTime() {
+        return startTime;
+    }
+
+    public DynaFlowParameters setStartTime(Double startTime) {
+        this.startTime = startTime;
+        return this;
+    }
+
+    public Double getStopTime() {
+        return stopTime;
+    }
+
+    public DynaFlowParameters setStopTime(Double stopTime) {
+        this.stopTime = stopTime;
+        return this;
+    }
+
+    public Double getPrecision() {
+        return precision;
+    }
+
+    public DynaFlowParameters setPrecision(Double precision) {
+        this.precision = precision;
+        return this;
+    }
+
+    @JsonIgnore
+    public Double getTimeOfEvent() {
+        return Objects.isNull(securityAnalysis) ? null : securityAnalysis.getTimeOfEvent();
+    }
+
+    public DynaFlowParameters setTimeOfEvent(Double timeOfEvent) {
+        if (Objects.isNull(this.securityAnalysis)) {
+            securityAnalysis = new Sa();
+        }
+        securityAnalysis.setTimeOfEvent(timeOfEvent);
+        return this;
+    }
+
     public List<String> getChosenOutputs() {
         return chosenOutputs;
     }
@@ -95,6 +213,15 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
         return this;
     }
 
+    public Sa getSa() {
+        return this.securityAnalysis;
+    }
+
+    public DynaFlowParameters setSa(Sa securityAnalysis) {
+        this.securityAnalysis = securityAnalysis;
+        return this;
+    }
+
     @Override
     public String getName() {
         return "DynaFlowParameters";
@@ -107,6 +234,13 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
                 .add(SHUNT_REGULATION_ON, shuntRegulationOn)
                 .add(AUTOMATIC_SLACK_BUS_ON, automaticSlackBusOn)
                 .add(DSO_VOLTAGE_LEVEL, dsoVoltageLevel)
+                .add(ACTIVE_POWER_COMPENSATION, activePowerCompensation)
+                .add(SETTING_PATH, settingPath)
+                .add(ASSEMBLING_PATH, assemblingPath)
+                .add(START_TIME, startTime)
+                .add(STOP_TIME, stopTime)
+                .add(PRECISION, precision)
+                .add(Sa.SECURITY_ANALYSIS, securityAnalysis)
                 .add(CHOSEN_OUTPUTS, chosenOutputs)
                 .add(TIME_STEP, timeStep)
                 .toString();
@@ -131,6 +265,7 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
     }
 
     private static void load(DynaFlowParameters parameters, ModuleConfig config) {
+
         if (config.hasProperty(SVC_REGULATION_ON)) {
             parameters.setSvcRegulationOn(config.getBooleanProperty(SVC_REGULATION_ON));
         }
@@ -142,6 +277,27 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
         }
         if (config.hasProperty(DSO_VOLTAGE_LEVEL)) {
             parameters.setDsoVoltageLevel(config.getDoubleProperty(DSO_VOLTAGE_LEVEL));
+        }
+        if (config.hasProperty(ACTIVE_POWER_COMPENSATION)) {
+            parameters.setActivePowerCompensation(config.getEnumProperty(ACTIVE_POWER_COMPENSATION, ActivePowerCompensation.class));
+        }
+        if (config.hasProperty(SETTING_PATH)) {
+            parameters.setSettingPath(config.getStringProperty(SETTING_PATH));
+        }
+        if (config.hasProperty(ASSEMBLING_PATH)) {
+            parameters.setAssemblingPath(config.getStringProperty(ASSEMBLING_PATH));
+        }
+        if (config.hasProperty(START_TIME)) {
+            parameters.setStartTime(config.getDoubleProperty(START_TIME));
+        }
+        if (config.hasProperty(STOP_TIME)) {
+            parameters.setStopTime(config.getDoubleProperty(STOP_TIME));
+        }
+        if (config.hasProperty(PRECISION)) {
+            parameters.setPrecision(config.getDoubleProperty(PRECISION));
+        }
+        if (config.hasProperty(Sa.TIME_OF_EVENT)) {
+            parameters.setTimeOfEvent(config.getDoubleProperty(Sa.TIME_OF_EVENT));
         }
         if (config.hasProperty(CHOSEN_OUTPUTS)) {
             parameters.setChosenOutputs(config.getStringListProperty(CHOSEN_OUTPUTS));
@@ -157,6 +313,18 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
         Optional.ofNullable(properties.get(SHUNT_REGULATION_ON)).ifPresent(prop -> setShuntRegulationOn(Boolean.parseBoolean(prop)));
         Optional.ofNullable(properties.get(AUTOMATIC_SLACK_BUS_ON)).ifPresent(prop -> setAutomaticSlackBusOn(Boolean.parseBoolean(prop)));
         Optional.ofNullable(properties.get(DSO_VOLTAGE_LEVEL)).ifPresent(prop -> setDsoVoltageLevel(Double.parseDouble(prop)));
+        Optional.ofNullable(properties.get(ACTIVE_POWER_COMPENSATION)).ifPresent(prop -> setActivePowerCompensation(ActivePowerCompensation.valueOf(prop)));
+        Optional.ofNullable(properties.get(SETTING_PATH)).ifPresent(this::setSettingPath);
+        Optional.ofNullable(properties.get(ASSEMBLING_PATH)).ifPresent(this::setAssemblingPath);
+        Optional.ofNullable(properties.get(START_TIME)).ifPresent(prop -> setStartTime(Double.parseDouble(prop)));
+        Optional.ofNullable(properties.get(STOP_TIME)).ifPresent(prop -> setStopTime(Double.parseDouble(prop)));
+        Optional.ofNullable(properties.get(PRECISION)).ifPresent(prop -> setPrecision(Double.parseDouble(prop)));
+        Optional.ofNullable(properties.get(Sa.TIME_OF_EVENT)).ifPresent(prop -> {
+            if (Objects.isNull(securityAnalysis)) {
+                securityAnalysis = new Sa();
+            }
+            securityAnalysis.setTimeOfEvent(Double.parseDouble(prop));
+        });
         Optional.ofNullable(properties.get(CHOSEN_OUTPUTS)).ifPresent(prop ->
                 setChosenOutputs(Stream.of(prop.split(CHOSEN_OUTPUT_STRING_DELIMITER)).map(String::trim).collect(Collectors.toList())));
         Optional.ofNullable(properties.get(TIME_STEP)).ifPresent(prop -> setTimeStep(Double.parseDouble(prop)));
@@ -171,7 +339,8 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
     public static List<String> getSpecificParametersNames() {
         return Arrays.asList(
                 SVC_REGULATION_ON, SHUNT_REGULATION_ON, AUTOMATIC_SLACK_BUS_ON, DSO_VOLTAGE_LEVEL,
-                CHOSEN_OUTPUTS, TIME_STEP
+                ACTIVE_POWER_COMPENSATION, SETTING_PATH, ASSEMBLING_PATH, START_TIME, STOP_TIME, PRECISION,
+                Sa.TIME_OF_EVENT, CHOSEN_OUTPUTS, TIME_STEP
         );
     }
 

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowParameters.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowParameters.java
@@ -32,10 +32,6 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
 
     private static final String CHOSEN_OUTPUTS = "chosenOutputs";
 
-    private static final String VSC_AS_GENERATORS = "vscAsGenerators";
-
-    private static final String LCC_AS_LOADS = "lccAsLoads";
-
     private static final String TIME_STEP = "timeStep";
 
     private Boolean svcRegulationOn = null;
@@ -43,8 +39,6 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
     private Boolean automaticSlackBusOn = null;
     private Double dsoVoltageLevel = null;
     private List<String> chosenOutputs = null;
-    private Boolean vscAsGenerators = null;
-    private Boolean lccAsLoads = null;
     private Double timeStep = null;
 
     public Boolean getSvcRegulationOn() {
@@ -92,24 +86,6 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
         return this;
     }
 
-    public Boolean getVscAsGenerators() {
-        return vscAsGenerators;
-    }
-
-    public DynaFlowParameters setVscAsGenerators(boolean vscAsGenerators) {
-        this.vscAsGenerators = vscAsGenerators;
-        return this;
-    }
-
-    public Boolean getLccAsLoads() {
-        return lccAsLoads;
-    }
-
-    public DynaFlowParameters setLccAsLoads(boolean lccAsLoads) {
-        this.lccAsLoads = lccAsLoads;
-        return this;
-    }
-
     public Double getTimeStep() {
         return timeStep;
     }
@@ -132,8 +108,6 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
                 .add(AUTOMATIC_SLACK_BUS_ON, automaticSlackBusOn)
                 .add(DSO_VOLTAGE_LEVEL, dsoVoltageLevel)
                 .add(CHOSEN_OUTPUTS, chosenOutputs)
-                .add(VSC_AS_GENERATORS, vscAsGenerators)
-                .add(LCC_AS_LOADS, lccAsLoads)
                 .add(TIME_STEP, timeStep)
                 .toString();
     }
@@ -172,12 +146,6 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
         if (config.hasProperty(CHOSEN_OUTPUTS)) {
             parameters.setChosenOutputs(config.getStringListProperty(CHOSEN_OUTPUTS));
         }
-        if (config.hasProperty(VSC_AS_GENERATORS)) {
-            parameters.setVscAsGenerators(config.getBooleanProperty(VSC_AS_GENERATORS));
-        }
-        if (config.hasProperty(LCC_AS_LOADS)) {
-            parameters.setLccAsLoads(config.getBooleanProperty(LCC_AS_LOADS));
-        }
         if (config.hasProperty(TIME_STEP)) {
             parameters.setTimeStep(config.getDoubleProperty(TIME_STEP));
         }
@@ -191,8 +159,6 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
         Optional.ofNullable(properties.get(DSO_VOLTAGE_LEVEL)).ifPresent(prop -> setDsoVoltageLevel(Double.parseDouble(prop)));
         Optional.ofNullable(properties.get(CHOSEN_OUTPUTS)).ifPresent(prop ->
                 setChosenOutputs(Stream.of(prop.split(CHOSEN_OUTPUT_STRING_DELIMITER)).map(String::trim).collect(Collectors.toList())));
-        Optional.ofNullable(properties.get(VSC_AS_GENERATORS)).ifPresent(prop -> setVscAsGenerators(Boolean.parseBoolean(prop)));
-        Optional.ofNullable(properties.get(LCC_AS_LOADS)).ifPresent(prop -> setLccAsLoads(Boolean.parseBoolean(prop)));
         Optional.ofNullable(properties.get(TIME_STEP)).ifPresent(prop -> setTimeStep(Double.parseDouble(prop)));
     }
 
@@ -205,7 +171,7 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
     public static List<String> getSpecificParametersNames() {
         return Arrays.asList(
                 SVC_REGULATION_ON, SHUNT_REGULATION_ON, AUTOMATIC_SLACK_BUS_ON, DSO_VOLTAGE_LEVEL,
-                CHOSEN_OUTPUTS, VSC_AS_GENERATORS, LCC_AS_LOADS, TIME_STEP
+                CHOSEN_OUTPUTS, TIME_STEP
         );
     }
 

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowParameters.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowParameters.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.dynaflow;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.base.MoreObjects;
 import com.powsybl.commons.config.ModuleConfig;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.extensions.AbstractExtension;
@@ -17,7 +17,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.powsybl.dynaflow.DynaFlowProvider.MODULE_SPECIFIC_PARAMETERS;
-import static com.powsybl.dynaflow.DynaFlowConstants.OutputTypes;
 
 /**
  * @author Guillaume Pernin <guillaume.pernin at rte-france.com>
@@ -39,32 +38,16 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
 
     private static final String TIME_STEP = "timeStep";
 
-    public static final boolean DEFAULT_SVC_REGULATION_ON = false;
-    public static final boolean DEFAULT_SHUNT_REGULATION_ON = false;
-    public static final boolean DEFAULT_AUTOMATIC_SLACK_BUS_ON = false;
-    public static final double DEFAULT_DSO_VOLTAGE_LEVEL = 45.0;
+    private Boolean svcRegulationOn = null;
+    private Boolean shuntRegulationOn = null;
+    private Boolean automaticSlackBusOn = null;
+    private Double dsoVoltageLevel = null;
+    private List<String> chosenOutputs = null;
+    private Boolean vscAsGenerators = null;
+    private Boolean lccAsLoads = null;
+    private Double timeStep = null;
 
-    public static final boolean DEFAULT_VSC_AS_GENERATORS = true;
-    public static final boolean DEFAULT_LCC_AS_LOADS = true;
-
-    public static final double DEFAULT_TIME_STEP = 2.6;
-
-    public static final List<String> DEFAULT_CHOSEN_OUTPUT = Collections.singletonList(OutputTypes.STEADYSTATE.name());
-
-    private boolean svcRegulationOn = DEFAULT_SVC_REGULATION_ON;
-    private boolean shuntRegulationOn = DEFAULT_SHUNT_REGULATION_ON;
-    private boolean automaticSlackBusOn = DEFAULT_AUTOMATIC_SLACK_BUS_ON;
-    private double dsoVoltageLevel = DEFAULT_DSO_VOLTAGE_LEVEL;
-
-    private List<String> chosenOutputs = DEFAULT_CHOSEN_OUTPUT;
-
-    private boolean vscAsGenerators = DEFAULT_VSC_AS_GENERATORS;
-
-    private boolean lccAsLoads = DEFAULT_LCC_AS_LOADS;
-
-    private double timeStep = DEFAULT_TIME_STEP;
-
-    public boolean getSvcRegulationOn() {
+    public Boolean getSvcRegulationOn() {
         return svcRegulationOn;
     }
 
@@ -73,7 +56,7 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
         return this;
     }
 
-    public boolean getShuntRegulationOn() {
+    public Boolean getShuntRegulationOn() {
         return shuntRegulationOn;
     }
 
@@ -82,7 +65,7 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
         return this;
     }
 
-    public boolean getAutomaticSlackBusOn() {
+    public Boolean getAutomaticSlackBusOn() {
         return automaticSlackBusOn;
     }
 
@@ -91,7 +74,7 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
         return this;
     }
 
-    public double getDsoVoltageLevel() {
+    public Double getDsoVoltageLevel() {
         return dsoVoltageLevel;
     }
 
@@ -109,7 +92,7 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
         return this;
     }
 
-    public boolean getVscAsGenerators() {
+    public Boolean getVscAsGenerators() {
         return vscAsGenerators;
     }
 
@@ -118,7 +101,7 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
         return this;
     }
 
-    public boolean getLccAsLoads() {
+    public Boolean getLccAsLoads() {
         return lccAsLoads;
     }
 
@@ -127,7 +110,7 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
         return this;
     }
 
-    public double getTimeStep() {
+    public Double getTimeStep() {
         return timeStep;
     }
 
@@ -143,18 +126,16 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
 
     @Override
     public String toString() {
-        ImmutableMap.Builder<String, Object> immutableMapBuilder = ImmutableMap.builder();
-        immutableMapBuilder
-                .put(SVC_REGULATION_ON, svcRegulationOn)
-                .put(SHUNT_REGULATION_ON, shuntRegulationOn)
-                .put(AUTOMATIC_SLACK_BUS_ON, automaticSlackBusOn)
-                .put(DSO_VOLTAGE_LEVEL, dsoVoltageLevel)
-                .put(CHOSEN_OUTPUTS, chosenOutputs)
-                .put(VSC_AS_GENERATORS, vscAsGenerators)
-                .put(LCC_AS_LOADS, lccAsLoads)
-                .put(TIME_STEP, timeStep);
-
-        return immutableMapBuilder.build().toString();
+        return MoreObjects.toStringHelper("").omitNullValues()
+                .add(SVC_REGULATION_ON, svcRegulationOn)
+                .add(SHUNT_REGULATION_ON, shuntRegulationOn)
+                .add(AUTOMATIC_SLACK_BUS_ON, automaticSlackBusOn)
+                .add(DSO_VOLTAGE_LEVEL, dsoVoltageLevel)
+                .add(CHOSEN_OUTPUTS, chosenOutputs)
+                .add(VSC_AS_GENERATORS, vscAsGenerators)
+                .add(LCC_AS_LOADS, lccAsLoads)
+                .add(TIME_STEP, timeStep)
+                .toString();
     }
 
     public static DynaFlowParameters load(PlatformConfig platformConfig) {
@@ -176,14 +157,30 @@ public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
     }
 
     private static void load(DynaFlowParameters parameters, ModuleConfig config) {
-        parameters.setSvcRegulationOn(config.getBooleanProperty(SVC_REGULATION_ON, DEFAULT_SVC_REGULATION_ON))
-                .setShuntRegulationOn(config.getBooleanProperty(SHUNT_REGULATION_ON, DEFAULT_SHUNT_REGULATION_ON))
-                .setAutomaticSlackBusOn(config.getBooleanProperty(AUTOMATIC_SLACK_BUS_ON, DEFAULT_AUTOMATIC_SLACK_BUS_ON))
-                .setDsoVoltageLevel(config.getDoubleProperty(DSO_VOLTAGE_LEVEL, DEFAULT_DSO_VOLTAGE_LEVEL))
-                .setChosenOutputs(config.getStringListProperty(CHOSEN_OUTPUTS, DEFAULT_CHOSEN_OUTPUT))
-                .setVscAsGenerators(config.getBooleanProperty(VSC_AS_GENERATORS, DEFAULT_VSC_AS_GENERATORS))
-                .setLccAsLoads(config.getBooleanProperty(LCC_AS_LOADS, DEFAULT_LCC_AS_LOADS))
-                .setTimeStep(config.getDoubleProperty(TIME_STEP, DEFAULT_TIME_STEP));
+        if (config.hasProperty(SVC_REGULATION_ON)) {
+            parameters.setSvcRegulationOn(config.getBooleanProperty(SVC_REGULATION_ON));
+        }
+        if (config.hasProperty(SHUNT_REGULATION_ON)) {
+            parameters.setShuntRegulationOn(config.getBooleanProperty(SHUNT_REGULATION_ON));
+        }
+        if (config.hasProperty(AUTOMATIC_SLACK_BUS_ON)) {
+            parameters.setAutomaticSlackBusOn(config.getBooleanProperty(AUTOMATIC_SLACK_BUS_ON));
+        }
+        if (config.hasProperty(DSO_VOLTAGE_LEVEL)) {
+            parameters.setDsoVoltageLevel(config.getDoubleProperty(DSO_VOLTAGE_LEVEL));
+        }
+        if (config.hasProperty(CHOSEN_OUTPUTS)) {
+            parameters.setChosenOutputs(config.getStringListProperty(CHOSEN_OUTPUTS));
+        }
+        if (config.hasProperty(VSC_AS_GENERATORS)) {
+            parameters.setVscAsGenerators(config.getBooleanProperty(VSC_AS_GENERATORS));
+        }
+        if (config.hasProperty(LCC_AS_LOADS)) {
+            parameters.setLccAsLoads(config.getBooleanProperty(LCC_AS_LOADS));
+        }
+        if (config.hasProperty(TIME_STEP)) {
+            parameters.setTimeStep(config.getDoubleProperty(TIME_STEP));
+        }
     }
 
     public void update(Map<String, String> properties) {

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/json/DynaFlowConfigSerializer.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/json/DynaFlowConfigSerializer.java
@@ -56,7 +56,27 @@ public final class DynaFlowConfigSerializer {
                 jsonGenerator.writeNumberField("DsoVoltageLevel", dynaFlowParameters.getDsoVoltageLevel());
             }
             jsonGenerator.writeBooleanField("InfiniteReactiveLimits", lfParameters.isNoGeneratorReactiveLimits());
-            jsonGenerator.writeBooleanField("PSTRegulationOn", lfParameters.isPhaseShifterRegulationOn());
+            if (Objects.nonNull(dynaFlowParameters.getActivePowerCompensation())) {
+                jsonGenerator.writeStringField("ActivePowerCompensation", dynaFlowParameters.getActivePowerCompensation().name());
+            }
+            if (Objects.nonNull(dynaFlowParameters.getSettingPath())) {
+                jsonGenerator.writeStringField("SettingPath", dynaFlowParameters.getSettingPath());
+            }
+            if (Objects.nonNull(dynaFlowParameters.getAssemblingPath())) {
+                jsonGenerator.writeStringField("AssemblingPath", dynaFlowParameters.getAssemblingPath());
+            }
+            if (Objects.nonNull(dynaFlowParameters.getStartTime())) {
+                jsonGenerator.writeNumberField("StartTime", dynaFlowParameters.getStartTime());
+            }
+            if (Objects.nonNull(dynaFlowParameters.getStopTime())) {
+                jsonGenerator.writeNumberField("StopTime", dynaFlowParameters.getStopTime());
+            }
+            if (Objects.nonNull(dynaFlowParameters.getPrecision())) {
+                jsonGenerator.writeNumberField("Precision", dynaFlowParameters.getPrecision());
+            }
+            if (Objects.nonNull(dynaFlowParameters.getSa())) {
+                DynaFlowParameters.Sa.writeJson(jsonGenerator, dynaFlowParameters);
+            }
             if (Objects.nonNull(dynaFlowParameters.getChosenOutputs())) {
                 jsonGenerator.writeFieldName("ChosenOutputs");
                 jsonGenerator.writeStartArray();

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/json/DynaFlowConfigSerializer.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/json/DynaFlowConfigSerializer.java
@@ -18,7 +18,6 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Objects;
 
 /**
  *
@@ -43,41 +42,41 @@ public final class DynaFlowConfigSerializer {
         try {
             jsonGenerator.writeStartObject();
             jsonGenerator.writeObjectFieldStart("dfl-config");
-            if (Objects.nonNull(dynaFlowParameters.getSvcRegulationOn())) {
+            if (dynaFlowParameters.getSvcRegulationOn() != null) {
                 jsonGenerator.writeBooleanField("SVCRegulationOn", dynaFlowParameters.getSvcRegulationOn());
             }
-            if (Objects.nonNull(dynaFlowParameters.getShuntRegulationOn())) {
+            if (dynaFlowParameters.getShuntRegulationOn() != null) {
                 jsonGenerator.writeBooleanField("ShuntRegulationOn", dynaFlowParameters.getShuntRegulationOn());
             }
-            if (Objects.nonNull(dynaFlowParameters.getAutomaticSlackBusOn())) {
+            if (dynaFlowParameters.getAutomaticSlackBusOn() != null) {
                 jsonGenerator.writeBooleanField("AutomaticSlackBusOn", dynaFlowParameters.getAutomaticSlackBusOn());
             }
-            if (Objects.nonNull(dynaFlowParameters.getDsoVoltageLevel())) {
+            if (dynaFlowParameters.getDsoVoltageLevel() != null) {
                 jsonGenerator.writeNumberField("DsoVoltageLevel", dynaFlowParameters.getDsoVoltageLevel());
             }
             jsonGenerator.writeBooleanField("InfiniteReactiveLimits", lfParameters.isNoGeneratorReactiveLimits());
-            if (Objects.nonNull(dynaFlowParameters.getActivePowerCompensation())) {
+            if (dynaFlowParameters.getActivePowerCompensation() != null) {
                 jsonGenerator.writeStringField("ActivePowerCompensation", dynaFlowParameters.getActivePowerCompensation().name());
             }
-            if (Objects.nonNull(dynaFlowParameters.getSettingPath())) {
+            if (dynaFlowParameters.getSettingPath() != null) {
                 jsonGenerator.writeStringField("SettingPath", dynaFlowParameters.getSettingPath());
             }
-            if (Objects.nonNull(dynaFlowParameters.getAssemblingPath())) {
+            if (dynaFlowParameters.getAssemblingPath() != null) {
                 jsonGenerator.writeStringField("AssemblingPath", dynaFlowParameters.getAssemblingPath());
             }
-            if (Objects.nonNull(dynaFlowParameters.getStartTime())) {
+            if (dynaFlowParameters.getStartTime() != null) {
                 jsonGenerator.writeNumberField("StartTime", dynaFlowParameters.getStartTime());
             }
-            if (Objects.nonNull(dynaFlowParameters.getStopTime())) {
+            if (dynaFlowParameters.getStopTime() != null) {
                 jsonGenerator.writeNumberField("StopTime", dynaFlowParameters.getStopTime());
             }
-            if (Objects.nonNull(dynaFlowParameters.getPrecision())) {
+            if (dynaFlowParameters.getPrecision() != null) {
                 jsonGenerator.writeNumberField("Precision", dynaFlowParameters.getPrecision());
             }
-            if (Objects.nonNull(dynaFlowParameters.getSa())) {
+            if (dynaFlowParameters.getSa() != null) {
                 DynaFlowParameters.Sa.writeJson(jsonGenerator, dynaFlowParameters);
             }
-            if (Objects.nonNull(dynaFlowParameters.getChosenOutputs())) {
+            if (dynaFlowParameters.getChosenOutputs() != null) {
                 jsonGenerator.writeFieldName("ChosenOutputs");
                 jsonGenerator.writeStartArray();
                 for (String outputType : dynaFlowParameters.getChosenOutputs()) {
@@ -85,7 +84,7 @@ public final class DynaFlowConfigSerializer {
                 }
                 jsonGenerator.writeEndArray();
             }
-            if (Objects.nonNull(dynaFlowParameters.getTimeStep())) {
+            if (dynaFlowParameters.getTimeStep() != null) {
                 jsonGenerator.writeNumberField("TimeStep", dynaFlowParameters.getTimeStep());
             }
             jsonGenerator.writeStringField("OutputDir", workingDir.toAbsolutePath().toString());

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/json/DynaFlowConfigSerializer.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/json/DynaFlowConfigSerializer.java
@@ -65,12 +65,6 @@ public final class DynaFlowConfigSerializer {
                 }
                 jsonGenerator.writeEndArray();
             }
-            if (Objects.nonNull(dynaFlowParameters.getVscAsGenerators())) {
-                jsonGenerator.writeBooleanField("VscAsGenerators", dynaFlowParameters.getVscAsGenerators());
-            }
-            if (Objects.nonNull(dynaFlowParameters.getLccAsLoads())) {
-                jsonGenerator.writeBooleanField("LccAsLoads", dynaFlowParameters.getLccAsLoads());
-            }
             if (Objects.nonNull(dynaFlowParameters.getTimeStep())) {
                 jsonGenerator.writeNumberField("TimeStep", dynaFlowParameters.getTimeStep());
             }

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/json/DynaFlowConfigSerializer.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/json/DynaFlowConfigSerializer.java
@@ -18,6 +18,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 
 /**
  *
@@ -42,21 +43,37 @@ public final class DynaFlowConfigSerializer {
         try {
             jsonGenerator.writeStartObject();
             jsonGenerator.writeObjectFieldStart("dfl-config");
-            jsonGenerator.writeBooleanField("SVCRegulationOn", dynaFlowParameters.getSvcRegulationOn());
-            jsonGenerator.writeBooleanField("ShuntRegulationOn", dynaFlowParameters.getShuntRegulationOn());
-            jsonGenerator.writeBooleanField("AutomaticSlackBusOn", dynaFlowParameters.getAutomaticSlackBusOn());
-            jsonGenerator.writeNumberField("DsoVoltageLevel", dynaFlowParameters.getDsoVoltageLevel());
+            if (Objects.nonNull(dynaFlowParameters.getSvcRegulationOn())) {
+                jsonGenerator.writeBooleanField("SVCRegulationOn", dynaFlowParameters.getSvcRegulationOn());
+            }
+            if (Objects.nonNull(dynaFlowParameters.getShuntRegulationOn())) {
+                jsonGenerator.writeBooleanField("ShuntRegulationOn", dynaFlowParameters.getShuntRegulationOn());
+            }
+            if (Objects.nonNull(dynaFlowParameters.getAutomaticSlackBusOn())) {
+                jsonGenerator.writeBooleanField("AutomaticSlackBusOn", dynaFlowParameters.getAutomaticSlackBusOn());
+            }
+            if (Objects.nonNull(dynaFlowParameters.getDsoVoltageLevel())) {
+                jsonGenerator.writeNumberField("DsoVoltageLevel", dynaFlowParameters.getDsoVoltageLevel());
+            }
             jsonGenerator.writeBooleanField("InfiniteReactiveLimits", lfParameters.isNoGeneratorReactiveLimits());
             jsonGenerator.writeBooleanField("PSTRegulationOn", lfParameters.isPhaseShifterRegulationOn());
-            jsonGenerator.writeFieldName("ChosenOutputs");
-            jsonGenerator.writeStartArray();
-            for (String outputType : dynaFlowParameters.getChosenOutputs()) {
-                jsonGenerator.writeString(outputType);
+            if (Objects.nonNull(dynaFlowParameters.getChosenOutputs())) {
+                jsonGenerator.writeFieldName("ChosenOutputs");
+                jsonGenerator.writeStartArray();
+                for (String outputType : dynaFlowParameters.getChosenOutputs()) {
+                    jsonGenerator.writeString(outputType);
+                }
+                jsonGenerator.writeEndArray();
             }
-            jsonGenerator.writeEndArray();
-            jsonGenerator.writeBooleanField("VscAsGenerators", dynaFlowParameters.getVscAsGenerators());
-            jsonGenerator.writeBooleanField("LccAsLoads", dynaFlowParameters.getLccAsLoads());
-            jsonGenerator.writeNumberField("TimeStep", dynaFlowParameters.getTimeStep());
+            if (Objects.nonNull(dynaFlowParameters.getVscAsGenerators())) {
+                jsonGenerator.writeBooleanField("VscAsGenerators", dynaFlowParameters.getVscAsGenerators());
+            }
+            if (Objects.nonNull(dynaFlowParameters.getLccAsLoads())) {
+                jsonGenerator.writeBooleanField("LccAsLoads", dynaFlowParameters.getLccAsLoads());
+            }
+            if (Objects.nonNull(dynaFlowParameters.getTimeStep())) {
+                jsonGenerator.writeNumberField("TimeStep", dynaFlowParameters.getTimeStep());
+            }
             jsonGenerator.writeStringField("OutputDir", workingDir.toAbsolutePath().toString());
             jsonGenerator.writeEndObject();
             jsonGenerator.writeEndObject();

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/json/JsonDynaFlowParametersSerializer.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/json/JsonDynaFlowParametersSerializer.java
@@ -7,6 +7,7 @@
 package com.powsybl.dynaflow.json;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -57,7 +58,8 @@ public class JsonDynaFlowParametersSerializer implements ExtensionJsonSerializer
 
     private static ObjectMapper createMapper() {
         return JsonUtil.createObjectMapper()
-                .addMixIn(DynaFlowParameters.class, SerializationSpec.class);
+                .addMixIn(DynaFlowParameters.class, SerializationSpec.class)
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL);
     }
 
     @Override

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowParametersTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowParametersTest.java
@@ -96,16 +96,16 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         assertEquals(svcRegulationOn, parameters.getSvcRegulationOn());
         assertEquals(shuntRegulationOn, parameters.getShuntRegulationOn());
         assertEquals(automaticSlackBusOn, parameters.getAutomaticSlackBusOn());
-        assert dsoVoltageLevel == parameters.getDsoVoltageLevel();
+        assertEquals(dsoVoltageLevel, parameters.getDsoVoltageLevel(), 0.1d);
         assertEquals(activePowerCompensation, parameters.getActivePowerCompensation());
         assertEquals(settingPath, parameters.getSettingPath());
         assertEquals(assemblingPath, parameters.getAssemblingPath());
-        assert startTime == parameters.getStartTime();
-        assert stopTime == parameters.getStopTime();
-        assert precision == parameters.getPrecision();
-        assert timeOfEvent == parameters.getTimeOfEvent();
+        assertEquals(startTime, parameters.getStartTime(), 0.1d);
+        assertEquals(stopTime, parameters.getStopTime(), 0.1d);
+        assertEquals(precision, parameters.getPrecision(), 0.1d);
+        assertEquals(timeOfEvent, parameters.getTimeOfEvent(), 0.1d);
         assertArrayEquals(chosenOutputs.toArray(), parameters.getChosenOutputs().toArray());
-        assert timeStep == parameters.getTimeStep();
+        assertEquals(timeStep, parameters.getTimeStep(), 0.1d);
     }
 
     @Test
@@ -281,15 +281,15 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         assertTrue(dynaFlowParameters.getSvcRegulationOn());
         assertTrue(dynaFlowParameters.getShuntRegulationOn());
         assertFalse(dynaFlowParameters.getAutomaticSlackBusOn());
-        assert dsoVoltageLevel == dynaFlowParameters.getDsoVoltageLevel();
+        assertEquals(dsoVoltageLevel, dynaFlowParameters.getDsoVoltageLevel(), 0.1d);
         assertEquals(activePowerCompensation, dynaFlowParameters.getActivePowerCompensation());
         assertEquals(settingPath, dynaFlowParameters.getSettingPath());
         assertEquals(assemblingPath, dynaFlowParameters.getAssemblingPath());
-        assert startTime == dynaFlowParameters.getStartTime();
-        assert stopTime == dynaFlowParameters.getStopTime();
-        assert precision == dynaFlowParameters.getPrecision();
-        assert timeOfEvent == dynaFlowParameters.getTimeOfEvent();
+        assertEquals(startTime, dynaFlowParameters.getStartTime(), 0.1d);
+        assertEquals(stopTime, dynaFlowParameters.getStopTime(), 0.1d);
+        assertEquals(precision, dynaFlowParameters.getPrecision(), 0.1d);
+        assertEquals(timeOfEvent, dynaFlowParameters.getTimeOfEvent(), 0.1d);
         assertArrayEquals(chosenOutputs.toArray(), dynaFlowParameters.getChosenOutputs().toArray());
-        assert timeStep == dynaFlowParameters.getTimeStep();
+        assertEquals(timeStep, dynaFlowParameters.getTimeStep(), 0.1d);
     }
 }

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowParametersTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowParametersTest.java
@@ -288,7 +288,7 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         assert startTime == dynaFlowParameters.getStartTime();
         assert stopTime == dynaFlowParameters.getStopTime();
         assert precision == dynaFlowParameters.getPrecision();
-        //assert timeOfEvent == dynaFlowParameters.getTimeOfEvent();
+        assert timeOfEvent == dynaFlowParameters.getTimeOfEvent();
         assertArrayEquals(chosenOutputs.toArray(), dynaFlowParameters.getChosenOutputs().toArray());
         assert timeStep == dynaFlowParameters.getTimeStep();
     }

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowParametersTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowParametersTest.java
@@ -62,8 +62,6 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         boolean automaticSlackBusOn = true;
         double dsoVoltageLevel = 87.32;
         List<String> chosenOutputs = Arrays.asList(OutputTypes.STEADYSTATE.name(), OutputTypes.TIMELINE.name());
-        boolean vscAsGenerators = false;
-        boolean lccAsLoads = false;
         double timeStep = 0;
 
         MapModuleConfig moduleConfig = platformConfig.createModuleConfig(MODULE_SPECIFIC_PARAMETERS);
@@ -72,8 +70,6 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         moduleConfig.setStringProperty("automaticSlackBusOn", Boolean.toString(automaticSlackBusOn));
         moduleConfig.setStringProperty("dsoVoltageLevel", Double.toString(dsoVoltageLevel));
         moduleConfig.setStringListProperty("chosenOutputs", chosenOutputs);
-        moduleConfig.setStringProperty("vscAsGenerators", Boolean.toString(vscAsGenerators));
-        moduleConfig.setStringProperty("lccAsLoads", Boolean.toString(lccAsLoads));
         moduleConfig.setStringProperty("timeStep", Double.toString(timeStep));
 
         DynaFlowParameters parameters = DynaFlowParameters.load(platformConfig);
@@ -83,8 +79,6 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         assertEquals(automaticSlackBusOn, parameters.getAutomaticSlackBusOn());
         assert dsoVoltageLevel == parameters.getDsoVoltageLevel();
         assertArrayEquals(chosenOutputs.toArray(), parameters.getChosenOutputs().toArray());
-        assertEquals(vscAsGenerators, parameters.getVscAsGenerators());
-        assertEquals(lccAsLoads, parameters.getLccAsLoads());
         assert timeStep == parameters.getTimeStep();
     }
 
@@ -99,8 +93,6 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         assertNull(parametersExt.getAutomaticSlackBusOn());
         assertNull(parametersExt.getDsoVoltageLevel());
         assertNull(parametersExt.getChosenOutputs());
-        assertNull(parametersExt.getVscAsGenerators());
-        assertNull(parametersExt.getLccAsLoads());
         assertNull(parametersExt.getTimeStep());
     }
 
@@ -124,8 +116,6 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         boolean automaticSlackBusOn = true;
         Double dsoVoltage = 45.0;
         List<String> chosenOutputs = Arrays.asList(OutputTypes.STEADYSTATE.name(), OutputTypes.TIMELINE.name());
-        boolean vscAsGenerators = false;
-        boolean lccAsLoads = false;
         Double timeStep = 2.6;
 
         Map<String, String> properties = Map.of(
@@ -134,8 +124,6 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
                 "automaticSlackBusOn", Boolean.toString(automaticSlackBusOn),
                 "dsoVoltageLevel", Double.toString(dsoVoltage),
                 "chosenOutputs", OutputTypes.STEADYSTATE.name() + "," + OutputTypes.TIMELINE.name(),
-                "vscAsGenerators", Boolean.toString(vscAsGenerators),
-                "lccAsLoads", Boolean.toString(lccAsLoads),
                 "timeStep", Double.toString(timeStep));
 
         parametersExt.update(properties);
@@ -145,8 +133,6 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
                 ", automaticSlackBusOn=" + automaticSlackBusOn +
                 ", dsoVoltageLevel=" + dsoVoltage +
                 ", chosenOutputs=" + chosenOutputs +
-                ", vscAsGenerators=" + vscAsGenerators +
-                ", lccAsLoads=" + lccAsLoads +
                 ", timeStep=" + timeStep + "}";
         assertEquals(expectedString, parametersExt.toString());
         System.out.println(expectedString);
@@ -183,8 +169,6 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         dynaFlowParameters.setAutomaticSlackBusOn(true);
         dynaFlowParameters.setDsoVoltageLevel(32.4);
         dynaFlowParameters.setChosenOutputs(Collections.singletonList(OutputTypes.STEADYSTATE.name()));
-        dynaFlowParameters.setVscAsGenerators(true);
-        dynaFlowParameters.setLccAsLoads(true);
         dynaFlowParameters.setTimeStep(2.6);
         lfParameters.addExtension(DynaFlowParameters.class, dynaFlowParameters);
 
@@ -206,8 +190,6 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
                 "automaticSlackBusOn", "false",
                 "dsoVoltageLevel", "2.0",
                 "chosenOutputs", "STEADYSTATE, CONSTRAINTS",
-                "vscAsGenerators", "false",
-                "lccAsLoads", "false",
                 "timeStep", "0");
 
         DynaFlowParameters dynaFlowParameters = DynaFlowParameters.load(properties);
@@ -217,8 +199,6 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         assertFalse(dynaFlowParameters.getAutomaticSlackBusOn());
         assert 2 == dynaFlowParameters.getDsoVoltageLevel();
         assertArrayEquals(Arrays.asList(OutputTypes.STEADYSTATE.name(), OutputTypes.CONSTRAINTS.name()).toArray(), dynaFlowParameters.getChosenOutputs().toArray());
-        assertFalse(dynaFlowParameters.getVscAsGenerators());
-        assertFalse(dynaFlowParameters.getLccAsLoads());
         assert 0 == dynaFlowParameters.getTimeStep();
     }
 }

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowParametersTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowParametersTest.java
@@ -13,6 +13,7 @@ import com.powsybl.commons.config.InMemoryPlatformConfig;
 import com.powsybl.commons.config.MapModuleConfig;
 import com.powsybl.dynaflow.json.DynaFlowConfigSerializer;
 import com.powsybl.dynaflow.DynaFlowConstants.OutputTypes;
+import com.powsybl.dynaflow.DynaFlowConstants.ActivePowerCompensation;
 import com.powsybl.loadflow.LoadFlowParameters;
 import org.junit.After;
 import org.junit.Before;
@@ -24,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -61,14 +63,31 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         boolean shuntRegulationOn = false;
         boolean automaticSlackBusOn = true;
         double dsoVoltageLevel = 87.32;
+        ActivePowerCompensation activePowerCompensation = ActivePowerCompensation.PMAX;
+        String settingPath = "path/to/settingFile";
+        String assemblingPath = "path/to/assemblingFile";
+        double startTime = 0.;
+        double stopTime = 100.;
+        double precision = 15.45;
+        double timeOfEvent = 10.;
         List<String> chosenOutputs = Arrays.asList(OutputTypes.STEADYSTATE.name(), OutputTypes.TIMELINE.name());
         double timeStep = 0;
+
+        DynaFlowParameters.Sa securityAnalysis = new DynaFlowParameters.Sa();
+        securityAnalysis.setTimeOfEvent(2.);
 
         MapModuleConfig moduleConfig = platformConfig.createModuleConfig(MODULE_SPECIFIC_PARAMETERS);
         moduleConfig.setStringProperty("svcRegulationOn", Boolean.toString(svcRegulationOn));
         moduleConfig.setStringProperty("shuntRegulationOn", Boolean.toString(shuntRegulationOn));
         moduleConfig.setStringProperty("automaticSlackBusOn", Boolean.toString(automaticSlackBusOn));
         moduleConfig.setStringProperty("dsoVoltageLevel", Double.toString(dsoVoltageLevel));
+        moduleConfig.setStringProperty("activePowerCompensation", activePowerCompensation.name());
+        moduleConfig.setStringProperty("settingPath", settingPath);
+        moduleConfig.setStringProperty("assemblingPath", assemblingPath);
+        moduleConfig.setStringProperty("startTime", Double.toString(startTime));
+        moduleConfig.setStringProperty("stopTime", Double.toString(stopTime));
+        moduleConfig.setStringProperty("precision", Double.toString(precision));
+        moduleConfig.setStringProperty("timeOfEvent", Double.toString(timeOfEvent));
         moduleConfig.setStringListProperty("chosenOutputs", chosenOutputs);
         moduleConfig.setStringProperty("timeStep", Double.toString(timeStep));
 
@@ -78,6 +97,13 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         assertEquals(shuntRegulationOn, parameters.getShuntRegulationOn());
         assertEquals(automaticSlackBusOn, parameters.getAutomaticSlackBusOn());
         assert dsoVoltageLevel == parameters.getDsoVoltageLevel();
+        assertEquals(activePowerCompensation, parameters.getActivePowerCompensation());
+        assertEquals(settingPath, parameters.getSettingPath());
+        assertEquals(assemblingPath, parameters.getAssemblingPath());
+        assert startTime == parameters.getStartTime();
+        assert stopTime == parameters.getStopTime();
+        assert precision == parameters.getPrecision();
+        assert timeOfEvent == parameters.getTimeOfEvent();
         assertArrayEquals(chosenOutputs.toArray(), parameters.getChosenOutputs().toArray());
         assert timeStep == parameters.getTimeStep();
     }
@@ -92,6 +118,13 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         assertNull(parametersExt.getShuntRegulationOn());
         assertNull(parametersExt.getAutomaticSlackBusOn());
         assertNull(parametersExt.getDsoVoltageLevel());
+        assertNull(parametersExt.getActivePowerCompensation());
+        assertNull(parametersExt.getSettingPath());
+        assertNull(parametersExt.getAssemblingPath());
+        assertNull(parametersExt.getStartTime());
+        assertNull(parametersExt.getStopTime());
+        assertNull(parametersExt.getPrecision());
+        assertNull(parametersExt.getSa());
         assertNull(parametersExt.getChosenOutputs());
         assertNull(parametersExt.getTimeStep());
     }
@@ -114,24 +147,46 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         boolean svcRegulationOn = true;
         boolean shuntRegulationOn = false;
         boolean automaticSlackBusOn = true;
-        Double dsoVoltage = 45.0;
+        double dsoVoltageLevel = 87.32;
+        ActivePowerCompensation activePowerCompensation = ActivePowerCompensation.PMAX;
+        String settingPath = "path/to/settingFile";
+        String assemblingPath = "path/to/assemblingFile";
+        double startTime = 0.;
+        double stopTime = 100.;
+        double precision = 15.45;
+        double timeOfEvent = 10.;
         List<String> chosenOutputs = Arrays.asList(OutputTypes.STEADYSTATE.name(), OutputTypes.TIMELINE.name());
-        Double timeStep = 2.6;
+        double timeStep = 0;
 
-        Map<String, String> properties = Map.of(
-                "svcRegulationOn", Boolean.toString(svcRegulationOn),
-                "shuntRegulationOn", Boolean.toString(shuntRegulationOn),
-                "automaticSlackBusOn", Boolean.toString(automaticSlackBusOn),
-                "dsoVoltageLevel", Double.toString(dsoVoltage),
-                "chosenOutputs", OutputTypes.STEADYSTATE.name() + "," + OutputTypes.TIMELINE.name(),
-                "timeStep", Double.toString(timeStep));
+        Map<String, String> properties = new HashMap<>();
+        properties.put("svcRegulationOn", Boolean.toString(svcRegulationOn));
+        properties.put("shuntRegulationOn", Boolean.toString(shuntRegulationOn));
+        properties.put("automaticSlackBusOn", Boolean.toString(automaticSlackBusOn));
+        properties.put("dsoVoltageLevel", Double.toString(dsoVoltageLevel));
+        properties.put("activePowerCompensation", activePowerCompensation.name());
+        properties.put("settingPath", settingPath);
+        properties.put("assemblingPath", assemblingPath);
+        properties.put("startTime", Double.toString(startTime));
+        properties.put("stopTime", Double.toString(stopTime));
+        properties.put("precision", Double.toString(precision));
+        properties.put("timeOfEvent", Double.toString(timeOfEvent));
+        properties.put("chosenOutputs", OutputTypes.STEADYSTATE.name() + "," + OutputTypes.TIMELINE.name());
+        properties.put("timeStep", Double.toString(timeStep));
 
         parametersExt.update(properties);
 
         String expectedString = "{svcRegulationOn=" + svcRegulationOn +
                 ", shuntRegulationOn=" + shuntRegulationOn +
                 ", automaticSlackBusOn=" + automaticSlackBusOn +
-                ", dsoVoltageLevel=" + dsoVoltage +
+                ", dsoVoltageLevel=" + dsoVoltageLevel +
+                ", activePowerCompensation=" + activePowerCompensation +
+                ", settingPath=" + settingPath +
+                ", assemblingPath=" + assemblingPath +
+                ", startTime=" + startTime +
+                ", stopTime=" + stopTime +
+                ", precision=" + precision +
+                ", sa=" +
+                "{timeOfEvent=" + timeOfEvent + "}" +
                 ", chosenOutputs=" + chosenOutputs +
                 ", timeStep=" + timeStep + "}";
         assertEquals(expectedString, parametersExt.toString());
@@ -168,6 +223,13 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
         dynaFlowParameters.setShuntRegulationOn(false);
         dynaFlowParameters.setAutomaticSlackBusOn(true);
         dynaFlowParameters.setDsoVoltageLevel(32.4);
+        dynaFlowParameters.setActivePowerCompensation(ActivePowerCompensation.P);
+        dynaFlowParameters.setSettingPath("path/to/settingFile");
+        dynaFlowParameters.setAssemblingPath("path/to/assemblingFile");
+        dynaFlowParameters.setStartTime(0.);
+        dynaFlowParameters.setStopTime(100.);
+        dynaFlowParameters.setPrecision(0.);
+        dynaFlowParameters.setTimeOfEvent(10.);
         dynaFlowParameters.setChosenOutputs(Collections.singletonList(OutputTypes.STEADYSTATE.name()));
         dynaFlowParameters.setTimeStep(2.6);
         lfParameters.addExtension(DynaFlowParameters.class, dynaFlowParameters);
@@ -184,21 +246,50 @@ public class DynaFlowParametersTest extends AbstractConverterTest {
 
     @Test
     public void loadMapDynaflowParameters() {
-        Map<String, String> properties = Map.of(
-                "svcRegulationOn", "true",
-                "shuntRegulationOn", "true",
-                "automaticSlackBusOn", "false",
-                "dsoVoltageLevel", "2.0",
-                "chosenOutputs", "STEADYSTATE, CONSTRAINTS",
-                "timeStep", "0");
+
+        boolean svcRegulationOn = true;
+        boolean shuntRegulationOn = true;
+        boolean automaticSlackBusOn = false;
+        double dsoVoltageLevel = 2.0;
+        ActivePowerCompensation activePowerCompensation = ActivePowerCompensation.PMAX;
+        String settingPath = "path/to/settingFile";
+        String assemblingPath = "path/to/assemblingFile";
+        double startTime = 0.;
+        double stopTime = 100.;
+        double precision = 15.45;
+        double timeOfEvent = 10.;
+        List<String> chosenOutputs = Arrays.asList(OutputTypes.STEADYSTATE.name(), OutputTypes.TIMELINE.name());
+        double timeStep = 0;
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("svcRegulationOn", Boolean.toString(svcRegulationOn));
+        properties.put("shuntRegulationOn", Boolean.toString(shuntRegulationOn));
+        properties.put("automaticSlackBusOn", Boolean.toString(automaticSlackBusOn));
+        properties.put("dsoVoltageLevel", Double.toString(dsoVoltageLevel));
+        properties.put("activePowerCompensation", activePowerCompensation.name());
+        properties.put("settingPath", settingPath);
+        properties.put("assemblingPath", assemblingPath);
+        properties.put("startTime", Double.toString(startTime));
+        properties.put("stopTime", Double.toString(stopTime));
+        properties.put("precision", Double.toString(precision));
+        properties.put("timeOfEvent", Double.toString(timeOfEvent));
+        properties.put("chosenOutputs", OutputTypes.STEADYSTATE.name() + ", " + OutputTypes.TIMELINE.name());
+        properties.put("timeStep", Double.toString(timeStep));
 
         DynaFlowParameters dynaFlowParameters = DynaFlowParameters.load(properties);
 
         assertTrue(dynaFlowParameters.getSvcRegulationOn());
         assertTrue(dynaFlowParameters.getShuntRegulationOn());
         assertFalse(dynaFlowParameters.getAutomaticSlackBusOn());
-        assert 2 == dynaFlowParameters.getDsoVoltageLevel();
-        assertArrayEquals(Arrays.asList(OutputTypes.STEADYSTATE.name(), OutputTypes.CONSTRAINTS.name()).toArray(), dynaFlowParameters.getChosenOutputs().toArray());
-        assert 0 == dynaFlowParameters.getTimeStep();
+        assert dsoVoltageLevel == dynaFlowParameters.getDsoVoltageLevel();
+        assertEquals(activePowerCompensation, dynaFlowParameters.getActivePowerCompensation());
+        assertEquals(settingPath, dynaFlowParameters.getSettingPath());
+        assertEquals(assemblingPath, dynaFlowParameters.getAssemblingPath());
+        assert startTime == dynaFlowParameters.getStartTime();
+        assert stopTime == dynaFlowParameters.getStopTime();
+        assert precision == dynaFlowParameters.getPrecision();
+        //assert timeOfEvent == dynaFlowParameters.getTimeOfEvent();
+        assertArrayEquals(chosenOutputs.toArray(), dynaFlowParameters.getChosenOutputs().toArray());
+        assert timeStep == dynaFlowParameters.getTimeStep();
     }
 }

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowProviderTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowProviderTest.java
@@ -194,9 +194,9 @@ public class DynaFlowProviderTest extends AbstractConverterTest {
         assertTrue(dynaParams.getSvcRegulationOn());
         assertTrue(dynaParams.getShuntRegulationOn());
         assertFalse(dynaParams.getAutomaticSlackBusOn());
-        assert 2 == dynaParams.getDsoVoltageLevel();
+        assertEquals(2, dynaParams.getDsoVoltageLevel(), 0.1d);
         assertArrayEquals(Arrays.asList(OutputTypes.STEADYSTATE.name(), OutputTypes.CONSTRAINTS.name()).toArray(), dynaParams.getChosenOutputs().toArray());
-        assert 0 == dynaParams.getTimeStep();
+        assertEquals(0, dynaParams.getTimeStep(), 0.1d);
     }
 
     private void compare(Network expected, Network actual) throws IOException {

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowProviderTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowProviderTest.java
@@ -185,8 +185,6 @@ public class DynaFlowProviderTest extends AbstractConverterTest {
                 "automaticSlackBusOn", "false",
                 "dsoVoltageLevel", "2.0",
                 "chosenOutputs", "STEADYSTATE, CONSTRAINTS",
-                "vscAsGenerators", "false",
-                "lccAsLoads", "false",
                 "timeStep", "0");
 
         LoadFlowParameters params = LoadFlowParameters.load();
@@ -198,8 +196,6 @@ public class DynaFlowProviderTest extends AbstractConverterTest {
         assertFalse(dynaParams.getAutomaticSlackBusOn());
         assert 2 == dynaParams.getDsoVoltageLevel();
         assertArrayEquals(Arrays.asList(OutputTypes.STEADYSTATE.name(), OutputTypes.CONSTRAINTS.name()).toArray(), dynaParams.getChosenOutputs().toArray());
-        assertFalse(dynaParams.getVscAsGenerators());
-        assertFalse(dynaParams.getLccAsLoads());
         assert 0 == dynaParams.getTimeStep();
     }
 

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysisTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysisTest.java
@@ -101,7 +101,7 @@ public class DynaFlowSecurityAnalysisTest {
             try {
                 if (args.get(0).equals("--version")) {
                     copyFile(stdOutFileRef, errFile);
-                }  else {
+                } else {
                     assertEquals("--network", args.get(0));
                     assertEquals("--config", args.get(2));
                     assertEquals("--contingencies", args.get(4));
@@ -191,7 +191,7 @@ public class DynaFlowSecurityAnalysisTest {
             try {
                 if (args.get(0).equals("--version")) {
                     copyFile(stdOutFileRef, errFile);
-                }  else {
+                } else {
                     validateInputs(workingDir);
                     copyOutputs(workingDir);
                 }

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/json/JsonDynaFlowParametersSerializerTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/json/JsonDynaFlowParametersSerializerTest.java
@@ -63,6 +63,16 @@ public class JsonDynaFlowParametersSerializerTest extends AbstractConverterTest 
         parameters.addExtension(DynaFlowParameters.class, params);
 
         roundTripTest(parameters, JsonLoadFlowParameters::write,
+                JsonLoadFlowParameters::read, "/dynaflow_parameters_set_serialization.json");
+    }
+
+    @Test
+    public void serializeWithDefaultDynaflowParameters() throws IOException {
+        InMemoryPlatformConfig platformConfig = new InMemoryPlatformConfig(fileSystem);
+
+        LoadFlowParameters parameters = LoadFlowParameters.load(platformConfig);
+
+        roundTripTest(parameters, JsonLoadFlowParameters::write,
                 JsonLoadFlowParameters::read, "/dynaflow_default_serialization.json");
     }
 }

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/json/JsonDynaFlowParametersSerializerTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/json/JsonDynaFlowParametersSerializerTest.java
@@ -56,8 +56,6 @@ public class JsonDynaFlowParametersSerializerTest extends AbstractConverterTest 
         params.setAutomaticSlackBusOn(true);
         params.setDsoVoltageLevel(54.23);
         params.setChosenOutputs(Collections.singletonList(DynaFlowConstants.OutputTypes.STEADYSTATE.name()));
-        params.setVscAsGenerators(false);
-        params.setLccAsLoads(false);
         params.setTimeStep(2.6);
 
         parameters.addExtension(DynaFlowParameters.class, params);

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/json/JsonDynaFlowParametersSerializerTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/json/JsonDynaFlowParametersSerializerTest.java
@@ -52,12 +52,12 @@ public class JsonDynaFlowParametersSerializerTest extends AbstractConverterTest 
         assertEquals(DynaFlowConstants.ActivePowerCompensation.P, dynaFlowParameters.getActivePowerCompensation());
         assertEquals(expectedSettingPath, dynaFlowParameters.getSettingPath());
         assertEquals(expectedAssemblingPath, dynaFlowParameters.getAssemblingPath());
-        assert expectedStartTime == dynaFlowParameters.getStartTime();
-        assert expectedStopTime == dynaFlowParameters.getStopTime();
-        assert expectedPrecision == dynaFlowParameters.getPrecision();
-        assert expectedTimeOfEvent == dynaFlowParameters.getTimeOfEvent();
+        assertEquals(expectedStartTime, dynaFlowParameters.getStartTime(), 0.1d);
+        assertEquals(expectedStopTime, dynaFlowParameters.getStopTime(), 0.1d);
+        assertEquals(expectedPrecision, dynaFlowParameters.getPrecision(), 0.1d);
+        assertEquals(expectedTimeOfEvent, dynaFlowParameters.getTimeOfEvent(), 0.1d);
         assertArrayEquals(expectedChosenOutputs.toArray(), dynaFlowParameters.getChosenOutputs().toArray());
-        assert expectedTimeStep == dynaFlowParameters.getTimeStep();
+        assertEquals(expectedTimeStep, dynaFlowParameters.getTimeStep(), 0.1d);
 
         assertTrue(lfParameters.isTransformerVoltageControlOn());
         assertFalse(lfParameters.isPhaseShifterRegulationOn());

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/json/JsonDynaFlowParametersSerializerTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/json/JsonDynaFlowParametersSerializerTest.java
@@ -15,7 +15,9 @@ import com.powsybl.loadflow.json.JsonLoadFlowParameters;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -27,6 +29,17 @@ public class JsonDynaFlowParametersSerializerTest extends AbstractConverterTest 
 
     @Test
     public void testDeserialize() {
+
+        double expectedDsoVoltageLevelValue = 987.6;
+        String expectedSettingPath = "path/to/settingFile";
+        String expectedAssemblingPath = "path/to/assemblingFile";
+        double expectedStartTime = 0.;
+        double expectedStopTime = 100.;
+        double expectedPrecision = 0.;
+        double expectedTimeOfEvent = 10.;
+        List<String> expectedChosenOutputs = Arrays.asList(DynaFlowConstants.OutputTypes.STEADYSTATE.name(), DynaFlowConstants.OutputTypes.TIMELINE.name());
+        double expectedTimeStep = 2.6;
+
         LoadFlowParameters lfParameters = LoadFlowParameters.load();
         JsonLoadFlowParameters.update(lfParameters, getClass().getResourceAsStream("/config.json"));
         DynaFlowParameters dynaFlowParameters = lfParameters.getExtension(DynaFlowParameters.class);
@@ -35,8 +48,16 @@ public class JsonDynaFlowParametersSerializerTest extends AbstractConverterTest 
         assertTrue(dynaFlowParameters.getSvcRegulationOn());
         assertFalse(dynaFlowParameters.getShuntRegulationOn());
         assertTrue(dynaFlowParameters.getAutomaticSlackBusOn());
-        double expectedDsoVoltageLevelValue = 987.6;
         assertEquals(expectedDsoVoltageLevelValue, dynaFlowParameters.getDsoVoltageLevel(), 0);
+        assertEquals(DynaFlowConstants.ActivePowerCompensation.P, dynaFlowParameters.getActivePowerCompensation());
+        assertEquals(expectedSettingPath, dynaFlowParameters.getSettingPath());
+        assertEquals(expectedAssemblingPath, dynaFlowParameters.getAssemblingPath());
+        assert expectedStartTime == dynaFlowParameters.getStartTime();
+        assert expectedStopTime == dynaFlowParameters.getStopTime();
+        assert expectedPrecision == dynaFlowParameters.getPrecision();
+        assert expectedTimeOfEvent == dynaFlowParameters.getTimeOfEvent();
+        assertArrayEquals(expectedChosenOutputs.toArray(), dynaFlowParameters.getChosenOutputs().toArray());
+        assert expectedTimeStep == dynaFlowParameters.getTimeStep();
 
         assertTrue(lfParameters.isTransformerVoltageControlOn());
         assertFalse(lfParameters.isPhaseShifterRegulationOn());
@@ -55,6 +76,13 @@ public class JsonDynaFlowParametersSerializerTest extends AbstractConverterTest 
         params.setShuntRegulationOn(false);
         params.setAutomaticSlackBusOn(true);
         params.setDsoVoltageLevel(54.23);
+        params.setActivePowerCompensation(DynaFlowConstants.ActivePowerCompensation.P);
+        params.setSettingPath("path/to/settingFile");
+        params.setAssemblingPath("path/to/assemblingFile");
+        params.setStartTime(0.);
+        params.setStopTime(100.);
+        params.setPrecision(0.);
+        params.setTimeOfEvent(10.);
         params.setChosenOutputs(Collections.singletonList(DynaFlowConstants.OutputTypes.STEADYSTATE.name()));
         params.setTimeStep(2.6);
 

--- a/dynaflow/src/test/resources/config.json
+++ b/dynaflow/src/test/resources/config.json
@@ -12,8 +12,6 @@
       "automaticSlackBusOn": true,
       "dsoVoltageLevel": 987.6,
       "chosenOutputs" : [ "STEADYSTATE" ],
-      "vscAsGenerators" : true,
-      "lccAsLoads" : true,
       "timeStep" : 2.6
     }
   }

--- a/dynaflow/src/test/resources/config.json
+++ b/dynaflow/src/test/resources/config.json
@@ -7,11 +7,20 @@
   "specificCompatibility" : false,
   "extensions" : {
     "DynaFlowParameters" : {
-      "svcRegulationOn": true,
-      "shuntRegulationOn": false,
-      "automaticSlackBusOn": true,
-      "dsoVoltageLevel": 987.6,
-      "chosenOutputs" : [ "STEADYSTATE" ],
+      "svcRegulationOn" : true,
+      "shuntRegulationOn" : false,
+      "automaticSlackBusOn" : true,
+      "dsoVoltageLevel" : 987.6,
+      "activePowerCompensation" : "P",
+      "settingPath" : "path/to/settingFile",
+      "assemblingPath" : "path/to/assemblingFile",
+      "startTime" : 0.0,
+      "stopTime" : 100.0,
+      "precision" : 0.0,
+      "sa" : {
+        "timeOfEvent" : 10.0
+      },
+      "chosenOutputs" : [ "STEADYSTATE", "TIMELINE" ],
       "timeStep" : 2.6
     }
   }

--- a/dynaflow/src/test/resources/dynaflow_parameters_set_serialization.json
+++ b/dynaflow/src/test/resources/dynaflow_parameters_set_serialization.json
@@ -3,7 +3,7 @@
   "voltageInitMode" : "UNIFORM_VALUES",
   "transformerVoltageControlOn" : false,
   "phaseShifterRegulationOn" : false,
-  "noGeneratorReactiveLimits" : false,
+  "noGeneratorReactiveLimits" : true,
   "twtSplitShuntAdmittance" : false,
   "shuntCompensatorVoltageControlOn" : false,
   "readSlackBus" : true,
@@ -16,6 +16,15 @@
   "connectedComponentMode" : "MAIN",
   "hvdcAcEmulation" : true,
   "extensions" : {
-    "DynaFlowParameters" : { }
+    "DynaFlowParameters" : {
+      "svcRegulationOn" : true,
+      "shuntRegulationOn" : false,
+      "automaticSlackBusOn" : true,
+      "dsoVoltageLevel" : 54.23,
+      "chosenOutputs" : [ "STEADYSTATE" ],
+      "vscAsGenerators" : false,
+      "lccAsLoads" : false,
+      "timeStep" : 2.6
+    }
   }
 }

--- a/dynaflow/src/test/resources/dynaflow_parameters_set_serialization.json
+++ b/dynaflow/src/test/resources/dynaflow_parameters_set_serialization.json
@@ -22,8 +22,6 @@
       "automaticSlackBusOn" : true,
       "dsoVoltageLevel" : 54.23,
       "chosenOutputs" : [ "STEADYSTATE" ],
-      "vscAsGenerators" : false,
-      "lccAsLoads" : false,
       "timeStep" : 2.6
     }
   }

--- a/dynaflow/src/test/resources/dynaflow_parameters_set_serialization.json
+++ b/dynaflow/src/test/resources/dynaflow_parameters_set_serialization.json
@@ -21,8 +21,17 @@
       "shuntRegulationOn" : false,
       "automaticSlackBusOn" : true,
       "dsoVoltageLevel" : 54.23,
+      "activePowerCompensation" : "P",
+      "settingPath" : "path/to/settingFile",
+      "assemblingPath" : "path/to/assemblingFile",
+      "startTime" : 0.0,
+      "stopTime" : 100.0,
+      "precision" : 0.0,
       "chosenOutputs" : [ "STEADYSTATE" ],
-      "timeStep" : 2.6
+      "timeStep" : 2.6,
+      "sa" : {
+        "timeOfEvent" : 10.0
+      }
     }
   }
 }

--- a/dynaflow/src/test/resources/params.json
+++ b/dynaflow/src/test/resources/params.json
@@ -5,7 +5,15 @@
     "AutomaticSlackBusOn" : true,
     "DsoVoltageLevel" : 32.4,
     "InfiniteReactiveLimits" : true,
-    "PSTRegulationOn" : false,
+    "ActivePowerCompensation" : "P",
+    "SettingPath" : "path/to/settingFile",
+    "AssemblingPath" : "path/to/assemblingFile",
+    "StartTime" : 0.0,
+    "StopTime" : 100.0,
+    "Precision" : 0.0,
+    "sa" : {
+      "TimeOfEvent" : 10.0
+    },
     "ChosenOutputs" : [ "STEADYSTATE" ],
     "TimeStep" : 2.6,
     "OutputDir" : "/work/dynaflow/workingDir"

--- a/dynaflow/src/test/resources/params.json
+++ b/dynaflow/src/test/resources/params.json
@@ -7,8 +7,6 @@
     "InfiniteReactiveLimits" : true,
     "PSTRegulationOn" : false,
     "ChosenOutputs" : [ "STEADYSTATE" ],
-    "VscAsGenerators" : true,
-    "LccAsLoads" : true,
     "TimeStep" : 2.6,
     "OutputDir" : "/work/dynaflow/workingDir"
   }

--- a/dynaflow/src/test/resources/params_default.json
+++ b/dynaflow/src/test/resources/params_default.json
@@ -1,0 +1,7 @@
+{
+  "dfl-config" : {
+    "InfiniteReactiveLimits" : true,
+    "PSTRegulationOn" : false,
+    "OutputDir" : "/work/dynaflow/workingDir"
+  }
+}

--- a/dynaflow/src/test/resources/params_default.json
+++ b/dynaflow/src/test/resources/params_default.json
@@ -1,7 +1,6 @@
 {
   "dfl-config" : {
     "InfiniteReactiveLimits" : true,
-    "PSTRegulationOn" : false,
     "OutputDir" : "/work/dynaflow/workingDir"
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
The Dynaflow Launcher team has requested to not export Dynaflow parameters if they're not set by a user or the configuration platform.
By default, there's no exported parameter.


**What is the current behavior?** *(You can also link to an open issue here)*
All the Dynaflow parameters have a default value, and are all exported when serialized in JSON format.


**What is the new behavior (if this is a feature change)?**
If a parameter is set by the user or by the platform configuration, then this parameter wiill be exported to a serialized JSON format.
Otherwise, it will be ignored.


**Other information**:
In addition, a commit that deletes 2 parameters, as requested : VscAdGenerators and LccAsLoads
