### PR TITLE
MacroStaticReference is included into AbstractBlackBoxModel

### DIFF
--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzContext.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzContext.java
@@ -37,7 +37,6 @@ public class DynaWaltzContext {
     private final List<BlackBoxModel> dynamicModels;
     private final List<BlackBoxModel> eventModels;
     private final List<Curve> curves;
-    private final Map<String, MacroStaticReference> macroStaticReferences = new LinkedHashMap<>();
     private final Map<ConnectedModelTypes, MacroConnector> connectorsMap = new LinkedHashMap<>();
     private final Map<ConnectedModelTypes, MacroConnector> eventConnectorsMap = new LinkedHashMap<>();
     private final Map<BlackBoxModel, List<Model>> modelsConnections = new LinkedHashMap<>();

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzContext.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzContext.java
@@ -64,8 +64,6 @@ public class DynaWaltzContext {
         this.omegaRef = new OmegaRef(synchronousGenerators);
 
         for (BlackBoxModel bbm : Stream.concat(dynamicModels.stream(), Stream.of(omegaRef)).collect(Collectors.toList())) {
-            macroStaticReferences.computeIfAbsent(bbm.getName(), k -> new MacroStaticReference(k, bbm.getVarsMapping()));
-
             List<Model> modelsConnected = bbm.getModelsConnectedTo(this);
             modelsConnections.put(bbm, modelsConnected);
 
@@ -107,7 +105,12 @@ public class DynaWaltzContext {
     }
 
     public Collection<MacroStaticReference> getMacroStaticReferences() {
-        return macroStaticReferences.values();
+        return getBlackBoxModelStream()
+                .filter(BlackBoxModel.class::isInstance)
+                .map(BlackBoxModel.class::cast)
+                .map(BlackBoxModel::getMacroStaticReference)
+                .distinct()
+                .collect(Collectors.toList());
     }
 
     public Map<String, BlackBoxModel> getStaticIdBlackBoxModelMap() {

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/AbstractBlackBoxModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/AbstractBlackBoxModel.java
@@ -12,7 +12,9 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -26,6 +28,7 @@ public abstract class AbstractBlackBoxModel implements BlackBoxModel {
     private final String dynamicModelId;
     private final String staticId;
     private final String parameterSetId;
+    private static final Map<Class<? extends BlackBoxModel>, MacroStaticReference> MACRO_STATIC_REFERENCE_PER_CLASS = new HashMap<>();
 
     protected AbstractBlackBoxModel(String dynamicModelId, String staticId, String parameterSetId) {
         this.dynamicModelId = Objects.requireNonNull(dynamicModelId);
@@ -101,5 +104,10 @@ public abstract class AbstractBlackBoxModel implements BlackBoxModel {
     protected void writePureDynamicBlackBoxModel(XMLStreamWriter writer, DynaWaltzContext context) throws XMLStreamException {
         writer.writeEmptyElement(DYN_URI, "blackBoxModel");
         writeDynamicAttributes(writer, context);
+    }
+
+    @Override
+    public MacroStaticReference getMacroStaticReference() {
+        return MACRO_STATIC_REFERENCE_PER_CLASS.computeIfAbsent(this.getClass(), k -> new MacroStaticReference(getLib(), getVarsMapping()));
     }
 }

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/BlackBoxModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/BlackBoxModel.java
@@ -7,6 +7,7 @@
 package com.powsybl.dynawaltz.models;
 
 import com.powsybl.dynawaltz.DynaWaltzContext;
+import com.powsybl.dynawaltz.xml.MacroStaticReference;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -35,4 +36,6 @@ public interface BlackBoxModel extends Model {
     void writeParameters(XMLStreamWriter writer, DynaWaltzContext context) throws XMLStreamException;
 
     void writeMacroConnect(XMLStreamWriter writer, DynaWaltzContext context, MacroConnector macroConnector, Model connected) throws XMLStreamException;
+
+    MacroStaticReference getMacroStaticReference();
 }


### PR DESCRIPTION
By design, all instances of one class derived from AbstractBlackBoxModelWithStaticRef implements getMacroStaticReference, and gives a unique MacroStaticReference according to the implementation of the target class.

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
fixes #112 
