### PR TITLE
Easier access to curves in DynamicSimulationResult

### DIFF
--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzCurve.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzCurve.java
@@ -31,4 +31,11 @@ public class DynaWaltzCurve implements Curve {
     public String getVariable() {
         return variable;
     }
+
+    /**
+     * @return the id given by dynawaltz to this curve
+     */
+    public String getDynaWaltzCurveId() {
+        return getModelId() + "_" + getVariable();
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Simple feature to interface the id of the curve that dynawaltz will create after the simulation.

**What is the current behavior?** *(You can also link to an open issue here)*
You must hardcode the naming convention of dynawaltz when you want to fetch a curve in `DynamicSimulationResult`.

**What is the new behavior (if this is a feature change)?**
If you have access to the Dynawaltz Curve, you can use : `result.getCurve(myCurve.getDynaWaltzCurveId())`

**Use case**
A user must know the convention of Dynawo to be able to fetch their curves.
Other APIs - such as pypowsybl - that use powsybl-dynawo should not have to hardcode this convention themselves.