### PR TITLE
Avoid throwing UncheckedXmlStreamException

### DIFF
--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/CurvesXml.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/CurvesXml.java
@@ -36,16 +36,12 @@ public final class CurvesXml {
         XmlUtil.write(file, context, "curvesInput", CurvesXml::write);
     }
 
-    private static void write(XMLStreamWriter writer, DynaWaltzContext context) {
-        try {
-            for (Curve curve : context.getCurves()) {
-                DynaWaltzCurve dynCurve = (DynaWaltzCurve) curve;
-                writer.writeEmptyElement(DYN_URI, "curve");
-                writer.writeAttribute("model", dynCurve.getModelId());
-                writer.writeAttribute("variable", dynCurve.getVariable());
-            }
-        } catch (XMLStreamException e) {
-            throw new UncheckedXmlStreamException(e);
+    private static void write(XMLStreamWriter writer, DynaWaltzContext context) throws XMLStreamException {
+        for (Curve curve : context.getCurves()) {
+            DynaWaltzCurve dynCurve = (DynaWaltzCurve) curve;
+            writer.writeEmptyElement(DYN_URI, "curve");
+            writer.writeAttribute("model", dynCurve.getModelId());
+            writer.writeAttribute("variable", dynCurve.getVariable());
         }
     }
 }

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/CurvesXml.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/CurvesXml.java
@@ -6,20 +6,18 @@
  */
 package com.powsybl.dynawaltz.xml;
 
-import com.powsybl.commons.exceptions.UncheckedXmlStreamException;
 import com.powsybl.dynamicsimulation.Curve;
 import com.powsybl.dynawaltz.DynaWaltzContext;
 import com.powsybl.dynawaltz.DynaWaltzCurve;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
-
-import static com.powsybl.dynawaltz.xml.DynaWaltzConstants.CRV_FILENAME;
-import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_URI;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Objects;
+
+import static com.powsybl.dynawaltz.xml.DynaWaltzConstants.CRV_FILENAME;
+import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_URI;
 
 /**
  * @author Marcos de Miguel <demiguelm at aia.es>

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/DydXml.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/DydXml.java
@@ -38,52 +38,42 @@ public final class DydXml {
         XmlUtil.write(file, context, "dynamicModelsArchitecture", DydXml::write);
     }
 
-    private static void write(XMLStreamWriter writer, DynaWaltzContext context) {
+    private static void write(XMLStreamWriter writer, DynaWaltzContext context) throws XMLStreamException {
         writeDynamicModels(writer, context);
         writeEvents(writer, context);
     }
 
-    private static void writeDynamicModels(XMLStreamWriter writer, DynaWaltzContext context) {
-
-        try {
-            // loop over the values of the map indexed by dynamicIds to write only once objects with the same dynamicId
-            for (BlackBoxModel model : context.getBlackBoxModels()) {
-                model.write(writer, context);
+    private static void writeDynamicModels(XMLStreamWriter writer, DynaWaltzContext context) throws XMLStreamException {
+        // loop over the values of the map indexed by dynamicIds to write only once objects with the same dynamicId
+        for (BlackBoxModel model : context.getBlackBoxModels()) {
+            model.write(writer, context);
+        }
+        for (MacroConnector macroConnector : context.getMacroConnectors()) {
+            macroConnector.write(writer);
+        }
+        for (MacroStaticReference macroStaticReference : context.getMacroStaticReferences()) {
+            macroStaticReference.write(writer);
+        }
+        for (Map.Entry<BlackBoxModel, List<Model>> bbmMapping : context.getModelsConnections().entrySet()) {
+            BlackBoxModel bbm = bbmMapping.getKey();
+            for (Model connected : bbmMapping.getValue()) {
+                bbm.writeMacroConnect(writer, context, context.getMacroConnector(bbm, connected), connected);
             }
-            for (MacroConnector macroConnector : context.getMacroConnectors()) {
-                macroConnector.write(writer);
-            }
-            for (MacroStaticReference macroStaticReference : context.getMacroStaticReferences()) {
-                macroStaticReference.write(writer);
-            }
-            for (Map.Entry<BlackBoxModel, List<Model>> bbmMapping : context.getModelsConnections().entrySet()) {
-                BlackBoxModel bbm = bbmMapping.getKey();
-                for (Model connected : bbmMapping.getValue()) {
-                    bbm.writeMacroConnect(writer, context, context.getMacroConnector(bbm, connected), connected);
-                }
-            }
-        } catch (XMLStreamException e) {
-            throw new UncheckedXmlStreamException(e);
         }
     }
 
-    private static void writeEvents(XMLStreamWriter writer, DynaWaltzContext context) {
-
-        try {
-            for (BlackBoxModel model : context.getBlackBoxEventModels()) {
-                model.write(writer, context);
+    private static void writeEvents(XMLStreamWriter writer, DynaWaltzContext context) throws XMLStreamException {
+        for (BlackBoxModel model : context.getBlackBoxEventModels()) {
+            model.write(writer, context);
+        }
+        for (MacroConnector macroConnector : context.getEventMacroConnectors()) {
+            macroConnector.write(writer);
+        }
+        for (Map.Entry<BlackBoxModel, List<Model>> bbmMapping : context.getEventModelsConnections().entrySet()) {
+            BlackBoxModel event = bbmMapping.getKey();
+            for (Model connected : bbmMapping.getValue()) {
+                event.writeMacroConnect(writer, context, context.getEventMacroConnector(event, connected), connected);
             }
-            for (MacroConnector macroConnector : context.getEventMacroConnectors()) {
-                macroConnector.write(writer);
-            }
-            for (Map.Entry<BlackBoxModel, List<Model>> bbmMapping : context.getEventModelsConnections().entrySet()) {
-                BlackBoxModel event = bbmMapping.getKey();
-                for (Model connected : bbmMapping.getValue()) {
-                    event.writeMacroConnect(writer, context, context.getEventMacroConnector(event, connected), connected);
-                }
-            }
-        } catch (XMLStreamException e) {
-            throw new UncheckedXmlStreamException(e);
         }
     }
 }

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/DydXml.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/DydXml.java
@@ -7,7 +7,6 @@
 
 package com.powsybl.dynawaltz.xml;
 
-import com.powsybl.commons.exceptions.UncheckedXmlStreamException;
 import com.powsybl.dynawaltz.DynaWaltzContext;
 import com.powsybl.dynawaltz.models.BlackBoxModel;
 import com.powsybl.dynawaltz.models.MacroConnector;

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/JobsXml.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/JobsXml.java
@@ -37,18 +37,14 @@ public final class JobsXml {
         XmlUtil.write(file, context, "jobs", JobsXml::write);
     }
 
-    private static void write(XMLStreamWriter writer, DynaWaltzContext context) {
-        try {
-            writer.writeStartElement(DYN_URI, "job");
-            writer.writeAttribute("name", "Job");
-            writeSolver(writer, context);
-            writeModeler(writer, context);
-            writeSimulation(writer, context);
-            writeOutput(writer, context);
-            writer.writeEndElement();
-        } catch (XMLStreamException e) {
-            throw new UncheckedXmlStreamException(e);
-        }
+    private static void write(XMLStreamWriter writer, DynaWaltzContext context) throws XMLStreamException {
+        writer.writeStartElement(DYN_URI, "job");
+        writer.writeAttribute("name", "Job");
+        writeSolver(writer, context);
+        writeModeler(writer, context);
+        writeSimulation(writer, context);
+        writeOutput(writer, context);
+        writer.writeEndElement();
     }
 
     private static void writeSolver(XMLStreamWriter writer, DynaWaltzContext context) throws XMLStreamException {

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/JobsXml.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/JobsXml.java
@@ -6,21 +6,19 @@
  */
 package com.powsybl.dynawaltz.xml;
 
-import com.powsybl.commons.exceptions.UncheckedXmlStreamException;
 import com.powsybl.dynawaltz.DynaWaltzContext;
 import com.powsybl.dynawaltz.DynaWaltzParameters;
 import com.powsybl.dynawaltz.DynaWaltzParameters.SolverType;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
-
-import static com.powsybl.dynawaltz.xml.DynaWaltzConstants.*;
-import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_URI;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
+
+import static com.powsybl.dynawaltz.xml.DynaWaltzConstants.*;
+import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_URI;
 
 /**
  * @author Marcos de Miguel <demiguelm at aia.es>

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/ParametersXml.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/ParametersXml.java
@@ -9,7 +9,6 @@ package com.powsybl.dynawaltz.xml;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.config.PlatformConfig;
-import com.powsybl.commons.exceptions.UncheckedXmlStreamException;
 import com.powsybl.dynawaltz.DynaWaltzContext;
 import com.powsybl.dynawaltz.DynaWaltzParameters;
 import com.powsybl.dynawaltz.DynaWaltzParametersDatabase;

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/ParametersXml.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/ParametersXml.java
@@ -59,14 +59,10 @@ public final class ParametersXml {
         Files.copy(source, workingDir.resolve(source.getFileName().toString()), StandardCopyOption.REPLACE_EXISTING);
     }
 
-    private static void write(XMLStreamWriter writer, DynaWaltzContext context) {
-        try {
-            // loop over the values of the map indexed by dynamicIds to write only once parameters of objects with the same dynamicId
-            for (BlackBoxModel model : context.getBlackBoxModels()) {
-                model.writeParameters(writer, context);
-            }
-        } catch (XMLStreamException e) {
-            throw new UncheckedXmlStreamException(e);
+    private static void write(XMLStreamWriter writer, DynaWaltzContext context) throws XMLStreamException {
+        // loop over the values of the map indexed by dynamicIds to write only once parameters of objects with the same dynamicId
+        for (BlackBoxModel model : context.getBlackBoxModels()) {
+            model.writeParameters(writer, context);
         }
     }
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/XmlUtil.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/XmlUtil.java
@@ -28,14 +28,19 @@ import java.util.function.BiConsumer;
  */
 public final class XmlUtil {
 
+    @FunctionalInterface
+    public interface XmlDynawaltzWriter {
+        void write(XMLStreamWriter writer, DynaWaltzContext dynaWaltzContext) throws XMLStreamException;
+    }
+
     private XmlUtil() {
     }
 
-    public static void write(Path file, DynaWaltzContext context, String elementName, BiConsumer<XMLStreamWriter, DynaWaltzContext> write) throws IOException, XMLStreamException {
+    public static void write(Path file, DynaWaltzContext context, String elementName, XmlDynawaltzWriter xmlDynawaltzWriter) throws IOException, XMLStreamException {
         Objects.requireNonNull(file);
         Objects.requireNonNull(context);
         Objects.requireNonNull(elementName);
-        Objects.requireNonNull(write);
+        Objects.requireNonNull(xmlDynawaltzWriter);
 
         try (Writer writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
             XMLStreamWriter xmlWriter = XmlStreamWriterFactory.newInstance(writer);
@@ -45,7 +50,7 @@ public final class XmlUtil {
                 xmlWriter.writeStartElement(DYN_URI, elementName);
                 xmlWriter.writeNamespace(DYN_PREFIX, DYN_URI);
 
-                write.accept(xmlWriter, context);
+                xmlDynawaltzWriter.write(xmlWriter, context);
 
                 xmlWriter.writeEndElement();
                 xmlWriter.writeEndDocument();

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/XmlUtil.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/XmlUtil.java
@@ -7,21 +7,19 @@
 
 package com.powsybl.dynawaltz.xml;
 
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
-
 import com.powsybl.dynawaltz.DynaWaltzContext;
 
-import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_PREFIX;
-import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_URI;
-
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
-import java.util.function.BiConsumer;
+
+import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_PREFIX;
+import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_URI;
 
 /**
  * @author Mathieu Bague <mathieu.bague@rte-france.com>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?** 
Design bug fix


**What is the current behavior?**
`XmlStreamException` are catched in write methods and an `UncheckedXmlStreamException` is thrown, because of the use of a `BiConsumer<XMLStreamWriter, DynaWaltzContext>` parameter



**What is the new behavior (if this is a feature change)?**
The `BiConsumer<XMLStreamWriter, DynaWaltzContext>` parameter is replaced by a `XmlDynawaltzWriter`  functional interface which is allowed to throw a `XmlStreamException`, removing the need of catching them.


**Does this PR introduce a breaking change or deprecate an API?** 
No