### PR TITLE
Back to iidm v1.0 for input network file

### DIFF
--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzProvider.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzProvider.java
@@ -48,7 +48,7 @@ public class DynaWaltzProvider implements DynamicSimulationProvider {
     private static final String DYNAWO_CMD_NAME = "dynawo";
     private static final String WORKING_DIR_PREFIX = "powsybl_dynawaltz_";
     private static final String OUTPUT_IIDM_FILENAME = "outputIIDM.xml";
-    private static final String IIDM_VERSION = IidmXmlVersion.V_1_4.toString(".");
+    private static final String IIDM_VERSION = IidmXmlVersion.V_1_0.toString(".");
 
     private final DynaWaltzConfig dynaWaltzConfig;
 
@@ -158,7 +158,7 @@ public class DynaWaltzProvider implements DynamicSimulationProvider {
 
         private void writeInputFiles(Path workingDir) {
             try {
-                // Write the network to XIIDM v1.4 because currently Dynawo does not support versions above
+                // Write the network to XIIDM v1.0 because currently Dynawo does not support versions above
                 Properties params = new Properties();
                 params.setProperty(XMLExporter.VERSION, IIDM_VERSION);
                 context.getNetwork().write("XIIDM", params, workingDir.resolve(NETWORK_FILENAME));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
Dynawo cannot be launched as the v1.4 iidm file written as input cannot be read. Following error is returned:
```
Initialization failed: error while parsing file network.xiidm : Attribute Terminal does not exists ( DYNDataInterfaceIIDM.cpp:139 )
```



**What is the new behavior (if this is a feature change)?**
Dynawo can be launched as the iidm network file is written in v1.0 like it was in previous release.


**Does this PR introduce a breaking change or deprecate an API?**
No