### PR TITLE
Replace deprecated calls to getModuleConfig

### DIFF
--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzConfig.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzConfig.java
@@ -6,10 +6,10 @@
  */
 package com.powsybl.dynawaltz;
 
-import java.util.Objects;
-
-import com.powsybl.commons.config.ModuleConfig;
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.config.PlatformConfig;
+
+import java.util.Objects;
 
 /**
  * @author Marcos de Miguel <demiguelm at aia.es>
@@ -21,11 +21,11 @@ public class DynaWaltzConfig {
     }
 
     public static DynaWaltzConfig load(PlatformConfig platformConfig) {
-        ModuleConfig config = platformConfig.getModuleConfig("dynawaltz");
-        String homeDir = config.getStringProperty("homeDir");
-        boolean debug = config.getBooleanProperty("debug", DEBUG_DEFAULT);
-
-        return new DynaWaltzConfig(homeDir, debug);
+        return platformConfig.getOptionalModuleConfig("dynawaltz")
+                .map(moduleConfig -> new DynaWaltzConfig(
+                        moduleConfig.getStringProperty("homeDir"),
+                        moduleConfig.getBooleanProperty("debug", DEBUG_DEFAULT)))
+                .orElseThrow(() -> new PowsyblException("PlatformConfig incomplete: Module dynawaltz not found"));
     }
 
     public DynaWaltzConfig(String homeDir, boolean debug) {

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzParameters.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzParameters.java
@@ -7,6 +7,7 @@
 package com.powsybl.dynawaltz;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import com.powsybl.commons.config.ModuleConfig;
 import com.powsybl.commons.config.PlatformConfig;
@@ -21,6 +22,9 @@ public class DynaWaltzParameters extends AbstractExtension<DynamicSimulationPara
     public static final SolverType DEFAULT_SOLVER_TYPE = SolverType.SIM;
     public static final String DEFAULT_NETWORK_PAR_ID = "1";
     public static final String DEFAULT_SOLVER_PAR_ID = "1";
+    private static final String DEFAULT_PARAMETERS_FILE = "models.par";
+    private static final String DEFAULT_NETWORK_PARAMETERS_FILE = "network.par";
+    private static final String DEFAULT_SOLVER_PARAMETERS_FILE = "solvers.par";
 
     public enum SolverType {
         SIM,
@@ -108,21 +112,27 @@ public class DynaWaltzParameters extends AbstractExtension<DynamicSimulationPara
      * Load parameters from a provided platform configuration.
      */
     public static DynaWaltzParameters load(PlatformConfig platformConfig) {
-        ModuleConfig config = platformConfig.getModuleConfig("dynawaltz-default-parameters");
+        Optional<ModuleConfig> config = platformConfig.getOptionalModuleConfig("dynawaltz-default-parameters");
+
         // File with all the dynamic models' parameters for the simulation
-        String parametersFile = config.getStringProperty("parametersFile");
+        String parametersFile = config.map(c -> c.getStringProperty("parametersFile")).orElse(DEFAULT_PARAMETERS_FILE);
+
         // File with all the network's parameters for the simulation
-        String networkParametersFile = config.getStringProperty("network.parametersFile");
+        String networkParametersFile = config.map(c -> c.getStringProperty("network.parametersFile")).orElse(DEFAULT_NETWORK_PARAMETERS_FILE);
+
         // Identifies the set of network parameters that will be used in the simulation.
-        String networkParametersId = config.getStringProperty("network.parametersId", DEFAULT_NETWORK_PAR_ID);
+        String networkParametersId = config.flatMap(c -> c.getOptionalStringProperty("network.parametersId")).orElse(DEFAULT_NETWORK_PAR_ID);
+
         // Information about the solver to use in the simulation, there are two options
         // the simplified solver
         // and the IDA solver
-        SolverType solverType = config.getEnumProperty("solver.type", SolverType.class, DEFAULT_SOLVER_TYPE);
+        SolverType solverType = config.flatMap(c -> c.getOptionalEnumProperty("solver.type", SolverType.class)).orElse(DEFAULT_SOLVER_TYPE);
+
         // File with all the solvers' parameters for the simulation
-        String solverParametersFile = config.getStringProperty("solver.parametersFile");
+        String solverParametersFile = config.flatMap(c -> c.getOptionalStringProperty("solver.parametersFile")).orElse(DEFAULT_SOLVER_PARAMETERS_FILE);
+
         // Identifies the set of solver parameters that will be used in the simulation
-        String solverParametersId = config.getStringProperty("solver.parametersId", DEFAULT_SOLVER_PAR_ID);
+        String solverParametersId = config.flatMap(c -> c.getOptionalStringProperty("solver.parametersId")).orElse(DEFAULT_SOLVER_PAR_ID);
 
         return new DynaWaltzParameters(parametersFile, networkParametersFile, networkParametersId, solverType, solverParametersFile, solverParametersId);
     }

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzParametersTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzParametersTest.java
@@ -10,7 +10,9 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.FileSystem;
+import java.util.Optional;
 
+import com.powsybl.commons.config.ModuleConfig;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,10 +56,12 @@ public class DynaWaltzParametersTest {
         SolverType solverType = SolverType.IDA;
         String solverParametersId = "solverParametersId";
 
-        MapModuleConfig moduleConfig = (MapModuleConfig) platformConfig.getModuleConfig("dynawaltz-default-parameters");
-        moduleConfig.setStringProperty("network.parametersId", networkParametersId);
-        moduleConfig.setStringProperty("solver.type", solverType.toString());
-        moduleConfig.setStringProperty("solver.parametersId", solverParametersId);
+        Optional<ModuleConfig> moduleConfig = platformConfig.getOptionalModuleConfig("dynawaltz-default-parameters");
+        moduleConfig.filter(MapModuleConfig.class::isInstance).map(MapModuleConfig.class::cast).ifPresent(c -> {
+            c.setStringProperty("network.parametersId", networkParametersId);
+            c.setStringProperty("solver.type", solverType.toString());
+            c.setStringProperty("solver.parametersId", solverParametersId);
+        });
 
         DynaWaltzParameters parameters = DynaWaltzParameters.load(platformConfig);
         assertEquals(parametersFile, parameters.getParametersFile());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Refactor


**What is the current behavior?**
calls to deprecated method `PlatformConfig::getModuleConfig()`


**What is the new behavior (if this is a feature change)?**
calls to method `PlatformConfig::getOptionalModuleConfig()`



**Does this PR introduce a breaking change or deprecate an API?**
No