### PR TITLE
Consistant provider name between AS and LF

### DIFF
--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysisProvider.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysisProvider.java
@@ -22,6 +22,8 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import static com.powsybl.dynaflow.DynaFlowConstants.*;
+
 /**
  * @author Marcos de Miguel <demiguelm at aia.es>
  */
@@ -29,9 +31,6 @@ import java.util.concurrent.CompletableFuture;
 public class DynaFlowSecurityAnalysisProvider implements SecurityAnalysisProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(DynaFlowSecurityAnalysisProvider.class);
-
-    private static final String PROVIDER_NAME = "DynawoSecurityAnalysis";
-    private static final String PROVIDER_VERSION = "1.0";
 
     @Override
     public CompletableFuture<SecurityAnalysisReport> run(Network network,
@@ -65,11 +64,11 @@ public class DynaFlowSecurityAnalysisProvider implements SecurityAnalysisProvide
 
     @Override
     public String getName() {
-        return PROVIDER_NAME;
+        return DYNAFLOW_NAME;
     }
 
     @Override
     public String getVersion() {
-        return PROVIDER_VERSION;
+        return VERSION.toString();
     }
 }

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysisTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysisTest.java
@@ -61,7 +61,6 @@ import static org.junit.Assert.*;
 public class DynaFlowSecurityAnalysisTest {
 
     private static final String SECURITY_ANALISIS_RESULTS_FILENAME = "securityAnalysisResults.json";
-    private static final String DYNAWO_PROVIDER_NAME = "DynawoSecurityAnalysis";
 
     private FileSystem fileSystem;
     private PlatformConfig platformConfig;
@@ -118,8 +117,8 @@ public class DynaFlowSecurityAnalysisTest {
     @Test
     public void testDefaultProvider() {
         SecurityAnalysis.Runner dynawoSecurityAnalysisRunner = SecurityAnalysis.find();
-        assertEquals(DYNAWO_PROVIDER_NAME, dynawoSecurityAnalysisRunner.getName());
-        assertEquals("1.0", dynawoSecurityAnalysisRunner.getVersion());
+        assertEquals(DYNAFLOW_NAME, dynawoSecurityAnalysisRunner.getName());
+        assertEquals(VERSION.toString(), dynawoSecurityAnalysisRunner.getVersion());
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Provider names and version are not the same for DynaFlow, in LF mode or AS mode. 


**What is the new behavior (if this is a feature change)?**
Is is now the same.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
