### PR TITLE
Use Dynawo 1.4.0 and fix DynaFlow integration

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -30,6 +30,10 @@
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-iidm-xml-converter</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>
@@ -80,11 +84,6 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-iidm-xml-converter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/commons/src/main/java/com/powsybl/dynawo/commons/DynawoConstants.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/DynawoConstants.java
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 package com.powsybl.dynawo.commons;
 

--- a/commons/src/main/java/com/powsybl/dynawo/commons/DynawoConstants.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/DynawoConstants.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.dynawo.commons;
+
+import com.powsybl.iidm.xml.IidmXmlVersion;
+
+import java.util.List;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public final class DynawoConstants {
+
+    private DynawoConstants() {
+    }
+
+    /**
+     * write the network to XIIDM v1.4 because currently Dynawo does not support versions above
+     */
+    public static final String IIDM_VERSION = IidmXmlVersion.V_1_4.toString(".");
+
+    public static final List<String> IIDM_EXTENSIONS = List.of(
+            "activePowerControl",
+            "slackTerminal",
+            "coordinatedReactiveControl");
+}

--- a/commons/src/main/java/com/powsybl/dynawo/commons/DynawoUtil.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/DynawoUtil.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.dynawo.commons;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.xml.XMLExporter;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Properties;
+
+import static com.powsybl.dynawo.commons.DynawoConstants.IIDM_EXTENSIONS;
+import static com.powsybl.dynawo.commons.DynawoConstants.IIDM_VERSION;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public final class DynawoUtil {
+
+    private DynawoUtil() {
+    }
+
+    public static void writeIidm(Network network, Path file) {
+        Objects.requireNonNull(network);
+        Objects.requireNonNull(file);
+        Properties params = new Properties();
+        params.setProperty(XMLExporter.VERSION, IIDM_VERSION);
+        params.setProperty(XMLExporter.EXTENSIONS_LIST, String.join(",", IIDM_EXTENSIONS));
+        network.write("XIIDM", params, file);
+    }
+}

--- a/commons/src/main/java/com/powsybl/dynawo/commons/DynawoUtil.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/DynawoUtil.java
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 package com.powsybl.dynawo.commons;
 

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowConstants.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowConstants.java
@@ -9,8 +9,6 @@ package com.powsybl.dynaflow;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import com.powsybl.iidm.xml.IidmXmlVersion;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -34,8 +32,6 @@ public final class DynaFlowConstants {
     public static final String OUTPUT_IIDM_FILENAME = "outputIIDM.xml";
 
     public static final String OUTPUT_RESULTS_FILENAME = "results.json";
-
-    public static final String IIDM_VERSION = IidmXmlVersion.V_1_4.toString(".");
 
     public enum DynaFlowVersion {
         V_1_3_0(List.of(1, 3, 0)),

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowConstants.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowConstants.java
@@ -25,9 +25,9 @@ public final class DynaFlowConstants {
 
     public static final String IIDM_FILENAME = "network.xiidm";
 
-    public static final DynaFlowVersion VERSION_MIN = DynaFlowVersion.V_1_3_0;
+    public static final DynaFlowVersion VERSION_MIN = DynaFlowVersion.V_1_4_0;
 
-    public static final DynaFlowVersion VERSION = DynaFlowVersion.V_1_3_1;
+    public static final DynaFlowVersion VERSION = DynaFlowVersion.V_1_4_0;
 
     public static final String OUTPUT_IIDM_FILENAME = "outputIIDM.xml";
 
@@ -35,7 +35,8 @@ public final class DynaFlowConstants {
 
     public enum DynaFlowVersion {
         V_1_3_0(List.of(1, 3, 0)),
-        V_1_3_1(List.of(1, 3, 1));
+        V_1_3_1(List.of(1, 3, 1)),
+        V_1_4_0(List.of(1, 4, 0));
 
         private final List<Integer> versionArray;
         private static final String DEFAULT_DELIMITER = ".";

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowProvider.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowProvider.java
@@ -17,9 +17,9 @@ import com.powsybl.computation.*;
 import com.powsybl.dynaflow.json.DynaFlowConfigSerializer;
 import com.powsybl.dynaflow.json.JsonDynaFlowParametersSerializer;
 import com.powsybl.dynawo.commons.DynawoResultsNetworkUpdate;
+import com.powsybl.dynawo.commons.DynawoUtil;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.xml.NetworkXml;
-import com.powsybl.iidm.xml.XMLExporter;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.LoadFlowProvider;
 import com.powsybl.loadflow.LoadFlowResult;
@@ -53,12 +53,6 @@ public class DynaFlowProvider implements LoadFlowProvider {
 
     public DynaFlowProvider(Supplier<DynaFlowConfig> configSupplier) {
         this.configSupplier = Suppliers.memoize(Objects.requireNonNull(configSupplier, "Config supplier is null"));
-    }
-
-    private static void writeIIDM(Path workingDir, Network network) {
-        Properties params = new Properties();
-        params.setProperty(XMLExporter.VERSION, IIDM_VERSION);
-        network.write("XIIDM", params, workingDir.resolve(IIDM_FILENAME));
     }
 
     private static String getProgram(DynaFlowConfig config) {
@@ -129,7 +123,7 @@ public class DynaFlowProvider implements LoadFlowProvider {
                     Files.delete(outputNetworkFile);
                 }
                 network.getVariantManager().setWorkingVariant(workingStateId);
-                writeIIDM(workingDir, network);
+                DynawoUtil.writeIidm(network, workingDir.resolve(IIDM_FILENAME));
                 DynaFlowConfigSerializer.serialize(loadFlowParameters, dynaFlowParameters, workingDir, workingDir.resolve(CONFIG_FILENAME));
                 return Collections.singletonList(createCommandExecution(config));
             }

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowProvider.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowProvider.java
@@ -66,6 +66,10 @@ public class DynaFlowProvider implements LoadFlowProvider {
                 .id("dynaflow_lf")
                 .program(getProgram(config))
                 .args(args)
+                .inputFiles(new InputFile(IIDM_FILENAME),
+                            new InputFile(CONFIG_FILENAME))
+                .outputFiles(new OutputFile(OUTPUT_RESULTS_FILENAME),
+                             new OutputFile("outputs/finalState/" + OUTPUT_IIDM_FILENAME))
                 .build();
     }
 
@@ -114,17 +118,13 @@ public class DynaFlowProvider implements LoadFlowProvider {
         if (!DynaFlowUtil.checkDynaFlowVersion(env, computationManager, versionCmd)) {
             throw new PowsyblException("DynaFlow version not supported. Must be " + VERSION_MIN + " <= version <= " + VERSION);
         }
-        return computationManager.execute(env, new AbstractExecutionHandler<LoadFlowResult>() {
+        return computationManager.execute(env, new AbstractExecutionHandler<>() {
 
             @Override
             public List<CommandExecution> before(Path workingDir) throws IOException {
-                Path outputNetworkFile = workingDir.resolve("outputs").resolve("finalState").resolve(OUTPUT_IIDM_FILENAME);
-                if (Files.exists(outputNetworkFile)) {
-                    Files.delete(outputNetworkFile);
-                }
                 network.getVariantManager().setWorkingVariant(workingStateId);
                 DynawoUtil.writeIidm(network, workingDir.resolve(IIDM_FILENAME));
-                DynaFlowConfigSerializer.serialize(loadFlowParameters, dynaFlowParameters, workingDir, workingDir.resolve(CONFIG_FILENAME));
+                DynaFlowConfigSerializer.serialize(loadFlowParameters, dynaFlowParameters, Path.of("."), workingDir.resolve(CONFIG_FILENAME));
                 return Collections.singletonList(createCommandExecution(config));
             }
 

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysis.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysis.java
@@ -126,7 +126,7 @@ public class DynaFlowSecurityAnalysis {
         // TODO(Luma) Take into account also Security Analysis parameters
         LoadFlowParameters loadFlowParameters = securityAnalysisParameters.getLoadFlowParameters();
         DynaFlowParameters dynaFlowParameters = getParametersExt(loadFlowParameters);
-        DynaFlowConfigSerializer.serialize(loadFlowParameters, dynaFlowParameters, workingDir, workingDir.resolve(CONFIG_FILENAME));
+        DynaFlowConfigSerializer.serialize(loadFlowParameters, dynaFlowParameters, Path.of("."), workingDir.resolve(CONFIG_FILENAME));
     }
 
     public void addInterceptor(SecurityAnalysisInterceptor interceptor) {

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/json/DynaFlowConfigSerializer.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/json/DynaFlowConfigSerializer.java
@@ -90,7 +90,7 @@ public final class DynaFlowConfigSerializer {
             if (dynaFlowParameters.getStartingPointMode() != null) {
                 jsonGenerator.writeStringField("StartingPointMode", dynaFlowParameters.getStartingPointMode().getName());
             }
-            jsonGenerator.writeStringField("OutputDir", workingDir.toAbsolutePath().toString());
+            jsonGenerator.writeStringField("OutputDir", workingDir.toString());
             jsonGenerator.writeEndObject();
             jsonGenerator.writeEndObject();
         } catch (IOException e) {

--- a/dynaflow/src/test/resources/SmallBusBranch.xiidm
+++ b/dynaflow/src/test/resources/SmallBusBranch.xiidm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_2" id="urn:uuid:2399cbd2-9a39-11e0-aa80-0800200c9a66_EU" caseDate="2030-01-02T09:00:00.000Z" forecastDistance="7993438" sourceFormat="CGMES">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_4" id="urn:uuid:2399cbd2-9a39-11e0-aa80-0800200c9a66_EU" caseDate="2030-01-02T09:00:00.000Z" forecastDistance="7993438" sourceFormat="CGMES">
     <iidm:property name="CGMESModelDetail" value="bus-branch"/>
     <iidm:substation id="_047c929a-c766-11e1-8775-005056c00008" name="Godrics Hollow" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_0460f448-c766-11e1-8775-005056c00008" name="GOD132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
@@ -61,8 +61,9 @@
                 <iidm:bus id="_0486f2d6-c766-11e1-8775-005056c00008" name="Bellefnt" v="126.403" angle="-8.388306"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68.0" q0="27.0" bus="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus="_0486f2d6-c766-11e1-8775-005056c00008" p="68.0" q="27.0"></iidm:load>
-            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" bPerSection="1.378E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="126.403" targetDeadband="1.0" bus="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus="_0486f2d6-c766-11e1-8775-005056c00008" q="-11.0086479">
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.403" targetDeadband="1.0" bus="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus="_0486f2d6-c766-11e1-8775-005056c00008" q="-11.0086479">
                 <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
+                <iidm:shuntLinearModel bPerSection="1.378E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -72,8 +73,9 @@
                 <iidm:bus id="_04550d63-c766-11e1-8775-005056c00008" name="Fieldale" v="126.066" angle="-11.6781759"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39.0" q0="30.0" bus="_04550d63-c766-11e1-8775-005056c00008" connectableBus="_04550d63-c766-11e1-8775-005056c00008" p="39.0" q="30.0"></iidm:load>
-            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" bPerSection="6.88E-5" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1.0" bus="_04550d63-c766-11e1-8775-005056c00008" connectableBus="_04550d63-c766-11e1-8775-005056c00008" q="-5.46706724">
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1.0" bus="_04550d63-c766-11e1-8775-005056c00008" connectableBus="_04550d63-c766-11e1-8775-005056c00008" q="-5.46706724">
                 <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
+                <iidm:shuntLinearModel bPerSection="6.88E-5" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -152,8 +154,9 @@
                 <iidm:bus id="_04725962-c766-11e1-8775-005056c00008" name="N.Newark" v="130.323" angle="-14.23693"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53.0" q0="22.0" bus="_04725962-c766-11e1-8775-005056c00008" connectableBus="_04725962-c766-11e1-8775-005056c00008" p="53.0" q="22.0"></iidm:load>
-            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.323" targetDeadband="1.0" bus="_04725962-c766-11e1-8775-005056c00008" connectableBus="_04725962-c766-11e1-8775-005056c00008" q="-9.748864">
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.323" targetDeadband="1.0" bus="_04725962-c766-11e1-8775-005056c00008" connectableBus="_04725962-c766-11e1-8775-005056c00008" q="-9.748864">
                 <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
+                <iidm:shuntLinearModel bPerSection="1.148E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -335,8 +338,9 @@
                 <iidm:bus id="_047c4478-c766-11e1-8775-005056c00008" name="WMVernon" v="130.212" angle="-16.10395"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16.0" q0="8.0" bus="_047c4478-c766-11e1-8775-005056c00008" connectableBus="_047c4478-c766-11e1-8775-005056c00008" p="16.0" q="8.0"></iidm:load>
-            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.212" targetDeadband="1.0" bus="_047c4478-c766-11e1-8775-005056c00008" connectableBus="_047c4478-c766-11e1-8775-005056c00008" q="-9.732265">
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.212" targetDeadband="1.0" bus="_047c4478-c766-11e1-8775-005056c00008" connectableBus="_047c4478-c766-11e1-8775-005056c00008" q="-9.732265">
                 <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
+                <iidm:shuntLinearModel bPerSection="1.148E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -508,8 +512,9 @@
                 <iidm:bus id="_04876809-c766-11e1-8775-005056c00008" name="Roanoke" v="127.423" angle="-9.429042"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31.0" q0="26.0" bus="_04876809-c766-11e1-8775-005056c00008" connectableBus="_04876809-c766-11e1-8775-005056c00008" p="31.0" q="26.0"></iidm:load>
-            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" bPerSection="2.296E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1.0" bus="_04876809-c766-11e1-8775-005056c00008" connectableBus="_04876809-c766-11e1-8775-005056c00008" q="-18.63964">
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1.0" bus="_04876809-c766-11e1-8775-005056c00008" connectableBus="_04876809-c766-11e1-8775-005056c00008" q="-18.63964">
                 <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
+                <iidm:shuntLinearModel bPerSection="2.296E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -575,8 +580,9 @@
                 <iidm:bus id="_044b7072-c766-11e1-8775-005056c00008" name="Zanesvll" v="134.723" angle="-9.946326"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20.0" q0="11.0" bus="_044b7072-c766-11e1-8775-005056c00008" connectableBus="_044b7072-c766-11e1-8775-005056c00008" p="20.0" q="11.0"></iidm:load>
-            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" bPerSection="1.722E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="134.723" targetDeadband="1.0" bus="_044b7072-c766-11e1-8775-005056c00008" connectableBus="_044b7072-c766-11e1-8775-005056c00008" q="-15.6273985">
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.723" targetDeadband="1.0" bus="_044b7072-c766-11e1-8775-005056c00008" connectableBus="_044b7072-c766-11e1-8775-005056c00008" q="-15.6273985">
                 <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
+                <iidm:shuntLinearModel bPerSection="1.722E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -640,8 +646,9 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="_047147f0-c766-11e1-8775-005056c00008" name="Olive2" v="133.676" angle="-14.1409559"/>
             </iidm:busBreakerTopology>
-            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" bPerSection="4.592E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="133.676" targetDeadband="1.0" bus="_047147f0-c766-11e1-8775-005056c00008" connectableBus="_047147f0-c766-11e1-8775-005056c00008" q="-41.0278473">
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.676" targetDeadband="1.0" bus="_047147f0-c766-11e1-8775-005056c00008" connectableBus="_047147f0-c766-11e1-8775-005056c00008" q="-41.0278473">
                 <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
+                <iidm:shuntLinearModel bPerSection="4.592E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0.0" x="4.652208" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_045163e5-c766-11e1-8775-005056c00008" connectableBus1="_045163e5-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" bus2="_047147f0-c766-11e1-8775-005056c00008" connectableBus2="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008">
@@ -747,8 +754,9 @@
             </iidm:busBreakerTopology>
             <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22.0" q0="0.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" p="22.0" q="0.0"></iidm:load>
             <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28.0" q0="12.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" p="28.0" q="12.0"></iidm:load>
-            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" bPerSection="6.88E-5" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="124.763" targetDeadband="1.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" q="-5.354637">
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.763" targetDeadband="1.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" q="-5.354637">
                 <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
+                <iidm:shuntLinearModel bPerSection="6.88E-5" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -775,8 +783,9 @@
                 <iidm:bus id="_0447ee09-c766-11e1-8775-005056c00008" name="CapitlHl" v="133.002" angle="-3.25421"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39.0" q0="32.0" bus="_0447ee09-c766-11e1-8775-005056c00008" connectableBus="_0447ee09-c766-11e1-8775-005056c00008" p="39.0" q="32.0"></iidm:load>
-            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" bPerSection="2.296E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="133.002" targetDeadband="1.0" bus="_0447ee09-c766-11e1-8775-005056c00008" connectableBus="_0447ee09-c766-11e1-8775-005056c00008" q="-20.3075829">
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.002" targetDeadband="1.0" bus="_0447ee09-c766-11e1-8775-005056c00008" connectableBus="_0447ee09-c766-11e1-8775-005056c00008" q="-20.3075829">
                 <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
+                <iidm:shuntLinearModel bPerSection="2.296E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -935,8 +944,9 @@
                 <iidm:bus id="_044ea4c4-c766-11e1-8775-005056c00008" name="Logan" v="130.419" angle="-2.74680519"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54.0" q0="27.0" bus="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus="_044ea4c4-c766-11e1-8775-005056c00008" p="54.0" q="27.0"></iidm:load>
-            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" bPerSection="2.296E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.419" targetDeadband="1.0" bus="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus="_044ea4c4-c766-11e1-8775-005056c00008" q="-19.5264664">
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.419" targetDeadband="1.0" bus="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus="_044ea4c4-c766-11e1-8775-005056c00008" q="-19.5264664">
                 <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
+                <iidm:shuntLinearModel bPerSection="2.296E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -951,8 +961,9 @@
                 <iidm:minMaxReactiveLimits minQ="-15.0" maxQ="45.0"/>
             </iidm:generator>
             <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28.0" q0="10.0" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" p="28.0" q="10.0"></iidm:load>
-            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1.0" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" q="-10.1016407">
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1.0" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" q="-10.1016407">
                 <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
+                <iidm:shuntLinearModel bPerSection="1.148E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -1057,8 +1068,9 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="_048b86b5-c766-11e1-8775-005056c00008" name="EastLima1" v="131.565" angle="-18.24901"/>
             </iidm:busBreakerTopology>
-            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" bPerSection="2.87E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1.0" bus="_048b86b5-c766-11e1-8775-005056c00008" connectableBus="_048b86b5-c766-11e1-8775-005056c00008" q="-24.8389168">
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1.0" bus="_048b86b5-c766-11e1-8775-005056c00008" connectableBus="_048b86b5-c766-11e1-8775-005056c00008" q="-24.8389168">
                 <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
+                <iidm:shuntLinearModel bPerSection="2.87E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_04742e21-c766-11e1-8775-005056c00008" name="QAR220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
@@ -1227,8 +1239,9 @@
                 <iidm:bus id="_044e56a4-c766-11e1-8775-005056c00008" name="Rockhill" v="130.814" angle="-18.7122536"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59.0" q0="26.0" bus="_044e56a4-c766-11e1-8775-005056c00008" connectableBus="_044e56a4-c766-11e1-8775-005056c00008" p="59.0" q="26.0"></iidm:load>
-            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" bPerSection="1.606E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.814" targetDeadband="1.0" bus="_044e56a4-c766-11e1-8775-005056c00008" connectableBus="_044e56a4-c766-11e1-8775-005056c00008" q="-13.7411785">
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.814" targetDeadband="1.0" bus="_044e56a4-c766-11e1-8775-005056c00008" connectableBus="_044e56a4-c766-11e1-8775-005056c00008" q="-13.7411785">
                 <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
+                <iidm:shuntLinearModel bPerSection="1.606E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -1238,8 +1251,9 @@
                 <iidm:bus id="_046a9133-c766-11e1-8775-005056c00008" name="Sprigg" v="129.935" angle="-1.56099224"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20.0" q0="10.0" bus="_046a9133-c766-11e1-8775-005056c00008" connectableBus="_046a9133-c766-11e1-8775-005056c00008" p="20.0" q="10.0"></iidm:load>
-            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1.0" bus="_046a9133-c766-11e1-8775-005056c00008" connectableBus="_046a9133-c766-11e1-8775-005056c00008" q="-9.690902">
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1.0" bus="_046a9133-c766-11e1-8775-005056c00008" connectableBus="_046a9133-c766-11e1-8775-005056c00008" q="-9.690902">
                 <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
+                <iidm:shuntLinearModel bPerSection="1.148E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>

--- a/dynaflow/src/test/resources/SmallBusBranch/dynaflow-inputs/powsybl_dynaflow.xiidm
+++ b/dynaflow/src/test/resources/SmallBusBranch/dynaflow-inputs/powsybl_dynaflow.xiidm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_2" id="urn:uuid:2399cbd2-9a39-11e0-aa80-0800200c9a66_EU" caseDate="2030-01-02T09:00:00.000Z" forecastDistance="7993438" sourceFormat="CGMES">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_4" id="urn:uuid:2399cbd2-9a39-11e0-aa80-0800200c9a66_EU" caseDate="2030-01-02T09:00:00.000Z" forecastDistance="7993438" sourceFormat="CGMES">
     <iidm:property name="CGMESModelDetail" value="bus-branch"/>
     <iidm:substation id="_047c929a-c766-11e1-8775-005056c00008" name="Godrics Hollow" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_0460f448-c766-11e1-8775-005056c00008" name="GOD132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
@@ -61,8 +61,9 @@
                 <iidm:bus id="_0486f2d6-c766-11e1-8775-005056c00008" name="Bellefnt" v="126.403" angle="-8.388306"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68.0" q0="27.0" bus="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus="_0486f2d6-c766-11e1-8775-005056c00008" p="68.0" q="27.0"></iidm:load>
-            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" bPerSection="1.378E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="126.403" targetDeadband="1.0" bus="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus="_0486f2d6-c766-11e1-8775-005056c00008" q="-11.0086479">
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.403" targetDeadband="1.0" bus="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus="_0486f2d6-c766-11e1-8775-005056c00008" q="-11.0086479">
                 <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
+                <iidm:shuntLinearModel bPerSection="1.378E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -72,8 +73,9 @@
                 <iidm:bus id="_04550d63-c766-11e1-8775-005056c00008" name="Fieldale" v="126.066" angle="-11.6781759"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39.0" q0="30.0" bus="_04550d63-c766-11e1-8775-005056c00008" connectableBus="_04550d63-c766-11e1-8775-005056c00008" p="39.0" q="30.0"></iidm:load>
-            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" bPerSection="6.88E-5" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1.0" bus="_04550d63-c766-11e1-8775-005056c00008" connectableBus="_04550d63-c766-11e1-8775-005056c00008" q="-5.46706724">
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1.0" bus="_04550d63-c766-11e1-8775-005056c00008" connectableBus="_04550d63-c766-11e1-8775-005056c00008" q="-5.46706724">
                 <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
+                <iidm:shuntLinearModel bPerSection="6.88E-5" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -152,8 +154,9 @@
                 <iidm:bus id="_04725962-c766-11e1-8775-005056c00008" name="N.Newark" v="130.323" angle="-14.23693"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53.0" q0="22.0" bus="_04725962-c766-11e1-8775-005056c00008" connectableBus="_04725962-c766-11e1-8775-005056c00008" p="53.0" q="22.0"></iidm:load>
-            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.323" targetDeadband="1.0" bus="_04725962-c766-11e1-8775-005056c00008" connectableBus="_04725962-c766-11e1-8775-005056c00008" q="-9.748864">
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.323" targetDeadband="1.0" bus="_04725962-c766-11e1-8775-005056c00008" connectableBus="_04725962-c766-11e1-8775-005056c00008" q="-9.748864">
                 <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
+                <iidm:shuntLinearModel bPerSection="1.148E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -335,8 +338,9 @@
                 <iidm:bus id="_047c4478-c766-11e1-8775-005056c00008" name="WMVernon" v="130.212" angle="-16.10395"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16.0" q0="8.0" bus="_047c4478-c766-11e1-8775-005056c00008" connectableBus="_047c4478-c766-11e1-8775-005056c00008" p="16.0" q="8.0"></iidm:load>
-            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.212" targetDeadband="1.0" bus="_047c4478-c766-11e1-8775-005056c00008" connectableBus="_047c4478-c766-11e1-8775-005056c00008" q="-9.732265">
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.212" targetDeadband="1.0" bus="_047c4478-c766-11e1-8775-005056c00008" connectableBus="_047c4478-c766-11e1-8775-005056c00008" q="-9.732265">
                 <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
+                <iidm:shuntLinearModel bPerSection="1.148E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -508,8 +512,9 @@
                 <iidm:bus id="_04876809-c766-11e1-8775-005056c00008" name="Roanoke" v="127.423" angle="-9.429042"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31.0" q0="26.0" bus="_04876809-c766-11e1-8775-005056c00008" connectableBus="_04876809-c766-11e1-8775-005056c00008" p="31.0" q="26.0"></iidm:load>
-            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" bPerSection="2.296E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1.0" bus="_04876809-c766-11e1-8775-005056c00008" connectableBus="_04876809-c766-11e1-8775-005056c00008" q="-18.63964">
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1.0" bus="_04876809-c766-11e1-8775-005056c00008" connectableBus="_04876809-c766-11e1-8775-005056c00008" q="-18.63964">
                 <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
+                <iidm:shuntLinearModel bPerSection="2.296E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -575,8 +580,9 @@
                 <iidm:bus id="_044b7072-c766-11e1-8775-005056c00008" name="Zanesvll" v="134.723" angle="-9.946326"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20.0" q0="11.0" bus="_044b7072-c766-11e1-8775-005056c00008" connectableBus="_044b7072-c766-11e1-8775-005056c00008" p="20.0" q="11.0"></iidm:load>
-            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" bPerSection="1.722E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="134.723" targetDeadband="1.0" bus="_044b7072-c766-11e1-8775-005056c00008" connectableBus="_044b7072-c766-11e1-8775-005056c00008" q="-15.6273985">
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.723" targetDeadband="1.0" bus="_044b7072-c766-11e1-8775-005056c00008" connectableBus="_044b7072-c766-11e1-8775-005056c00008" q="-15.6273985">
                 <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
+                <iidm:shuntLinearModel bPerSection="1.722E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -640,8 +646,9 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="_047147f0-c766-11e1-8775-005056c00008" name="Olive2" v="133.676" angle="-14.1409559"/>
             </iidm:busBreakerTopology>
-            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" bPerSection="4.592E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="133.676" targetDeadband="1.0" bus="_047147f0-c766-11e1-8775-005056c00008" connectableBus="_047147f0-c766-11e1-8775-005056c00008" q="-41.0278473">
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.676" targetDeadband="1.0" bus="_047147f0-c766-11e1-8775-005056c00008" connectableBus="_047147f0-c766-11e1-8775-005056c00008" q="-41.0278473">
                 <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
+                <iidm:shuntLinearModel bPerSection="4.592E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0.0" x="4.652208" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_045163e5-c766-11e1-8775-005056c00008" connectableBus1="_045163e5-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" bus2="_047147f0-c766-11e1-8775-005056c00008" connectableBus2="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008">
@@ -747,8 +754,9 @@
             </iidm:busBreakerTopology>
             <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22.0" q0="0.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" p="22.0" q="0.0"></iidm:load>
             <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28.0" q0="12.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" p="28.0" q="12.0"></iidm:load>
-            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" bPerSection="6.88E-5" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="124.763" targetDeadband="1.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" q="-5.354637">
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.763" targetDeadband="1.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" q="-5.354637">
                 <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
+                <iidm:shuntLinearModel bPerSection="6.88E-5" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -775,8 +783,9 @@
                 <iidm:bus id="_0447ee09-c766-11e1-8775-005056c00008" name="CapitlHl" v="133.002" angle="-3.25421"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39.0" q0="32.0" bus="_0447ee09-c766-11e1-8775-005056c00008" connectableBus="_0447ee09-c766-11e1-8775-005056c00008" p="39.0" q="32.0"></iidm:load>
-            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" bPerSection="2.296E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="133.002" targetDeadband="1.0" bus="_0447ee09-c766-11e1-8775-005056c00008" connectableBus="_0447ee09-c766-11e1-8775-005056c00008" q="-20.3075829">
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.002" targetDeadband="1.0" bus="_0447ee09-c766-11e1-8775-005056c00008" connectableBus="_0447ee09-c766-11e1-8775-005056c00008" q="-20.3075829">
                 <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
+                <iidm:shuntLinearModel bPerSection="2.296E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -935,8 +944,9 @@
                 <iidm:bus id="_044ea4c4-c766-11e1-8775-005056c00008" name="Logan" v="130.419" angle="-2.74680519"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54.0" q0="27.0" bus="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus="_044ea4c4-c766-11e1-8775-005056c00008" p="54.0" q="27.0"></iidm:load>
-            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" bPerSection="2.296E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.419" targetDeadband="1.0" bus="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus="_044ea4c4-c766-11e1-8775-005056c00008" q="-19.5264664">
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.419" targetDeadband="1.0" bus="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus="_044ea4c4-c766-11e1-8775-005056c00008" q="-19.5264664">
                 <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
+                <iidm:shuntLinearModel bPerSection="2.296E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -951,8 +961,9 @@
                 <iidm:minMaxReactiveLimits minQ="-15.0" maxQ="45.0"/>
             </iidm:generator>
             <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28.0" q0="10.0" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" p="28.0" q="10.0"></iidm:load>
-            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1.0" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" q="-10.1016407">
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1.0" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" q="-10.1016407">
                 <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
+                <iidm:shuntLinearModel bPerSection="1.148E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -1057,8 +1068,9 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="_048b86b5-c766-11e1-8775-005056c00008" name="EastLima1" v="131.565" angle="-18.24901"/>
             </iidm:busBreakerTopology>
-            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" bPerSection="2.87E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1.0" bus="_048b86b5-c766-11e1-8775-005056c00008" connectableBus="_048b86b5-c766-11e1-8775-005056c00008" q="-24.8389168">
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1.0" bus="_048b86b5-c766-11e1-8775-005056c00008" connectableBus="_048b86b5-c766-11e1-8775-005056c00008" q="-24.8389168">
                 <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
+                <iidm:shuntLinearModel bPerSection="2.87E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_04742e21-c766-11e1-8775-005056c00008" name="QAR220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
@@ -1227,8 +1239,9 @@
                 <iidm:bus id="_044e56a4-c766-11e1-8775-005056c00008" name="Rockhill" v="130.814" angle="-18.7122536"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59.0" q0="26.0" bus="_044e56a4-c766-11e1-8775-005056c00008" connectableBus="_044e56a4-c766-11e1-8775-005056c00008" p="59.0" q="26.0"></iidm:load>
-            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" bPerSection="1.606E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.814" targetDeadband="1.0" bus="_044e56a4-c766-11e1-8775-005056c00008" connectableBus="_044e56a4-c766-11e1-8775-005056c00008" q="-13.7411785">
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.814" targetDeadband="1.0" bus="_044e56a4-c766-11e1-8775-005056c00008" connectableBus="_044e56a4-c766-11e1-8775-005056c00008" q="-13.7411785">
                 <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
+                <iidm:shuntLinearModel bPerSection="1.606E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -1238,8 +1251,9 @@
                 <iidm:bus id="_046a9133-c766-11e1-8775-005056c00008" name="Sprigg" v="129.935" angle="-1.56099224"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20.0" q0="10.0" bus="_046a9133-c766-11e1-8775-005056c00008" connectableBus="_046a9133-c766-11e1-8775-005056c00008" p="20.0" q="10.0"></iidm:load>
-            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1.0" bus="_046a9133-c766-11e1-8775-005056c00008" connectableBus="_046a9133-c766-11e1-8775-005056c00008" q="-9.690902">
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1.0" bus="_046a9133-c766-11e1-8775-005056c00008" connectableBus="_046a9133-c766-11e1-8775-005056c00008" q="-9.690902">
                 <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
+                <iidm:shuntLinearModel bPerSection="1.148E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>

--- a/dynaflow/src/test/resources/SmallBusBranch/powsybl-inputs/SmallBusBranch.xiidm
+++ b/dynaflow/src/test/resources/SmallBusBranch/powsybl-inputs/SmallBusBranch.xiidm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_2" id="urn:uuid:2399cbd2-9a39-11e0-aa80-0800200c9a66_EU" caseDate="2030-01-02T09:00:00.000Z" forecastDistance="7993438" sourceFormat="CGMES">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_4" id="urn:uuid:2399cbd2-9a39-11e0-aa80-0800200c9a66_EU" caseDate="2030-01-02T09:00:00.000Z" forecastDistance="7993438" sourceFormat="CGMES">
     <iidm:property name="CGMESModelDetail" value="bus-branch"/>
     <iidm:substation id="_047c929a-c766-11e1-8775-005056c00008" name="Godrics Hollow" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_0460f448-c766-11e1-8775-005056c00008" name="GOD132KV" nominalV="132.0" topologyKind="BUS_BREAKER">
@@ -61,8 +61,9 @@
                 <iidm:bus id="_0486f2d6-c766-11e1-8775-005056c00008" name="Bellefnt" v="126.403" angle="-8.388306"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68.0" q0="27.0" bus="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus="_0486f2d6-c766-11e1-8775-005056c00008" p="68.0" q="27.0"></iidm:load>
-            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" bPerSection="1.378E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="126.403" targetDeadband="1.0" bus="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus="_0486f2d6-c766-11e1-8775-005056c00008" q="-11.0086479">
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.403" targetDeadband="1.0" bus="_0486f2d6-c766-11e1-8775-005056c00008" connectableBus="_0486f2d6-c766-11e1-8775-005056c00008" q="-11.0086479">
                 <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
+                <iidm:shuntLinearModel bPerSection="1.378E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -72,8 +73,9 @@
                 <iidm:bus id="_04550d63-c766-11e1-8775-005056c00008" name="Fieldale" v="126.066" angle="-11.6781759"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39.0" q0="30.0" bus="_04550d63-c766-11e1-8775-005056c00008" connectableBus="_04550d63-c766-11e1-8775-005056c00008" p="39.0" q="30.0"></iidm:load>
-            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" bPerSection="6.88E-5" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1.0" bus="_04550d63-c766-11e1-8775-005056c00008" connectableBus="_04550d63-c766-11e1-8775-005056c00008" q="-5.46706724">
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" bPerSection="6.88E-5" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1.0" bus="_04550d63-c766-11e1-8775-005056c00008" connectableBus="_04550d63-c766-11e1-8775-005056c00008" q="-5.46706724">
                 <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
+                <iidm:shuntLinearModel bPerSection="6.88E-5" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -152,8 +154,9 @@
                 <iidm:bus id="_04725962-c766-11e1-8775-005056c00008" name="N.Newark" v="130.323" angle="-14.23693"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53.0" q0="22.0" bus="_04725962-c766-11e1-8775-005056c00008" connectableBus="_04725962-c766-11e1-8775-005056c00008" p="53.0" q="22.0"></iidm:load>
-            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.323" targetDeadband="1.0" bus="_04725962-c766-11e1-8775-005056c00008" connectableBus="_04725962-c766-11e1-8775-005056c00008" q="-9.748864">
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.323" targetDeadband="1.0" bus="_04725962-c766-11e1-8775-005056c00008" connectableBus="_04725962-c766-11e1-8775-005056c00008" q="-9.748864">
                 <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
+                <iidm:shuntLinearModel bPerSection="1.148E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -335,8 +338,9 @@
                 <iidm:bus id="_047c4478-c766-11e1-8775-005056c00008" name="WMVernon" v="130.212" angle="-16.10395"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16.0" q0="8.0" bus="_047c4478-c766-11e1-8775-005056c00008" connectableBus="_047c4478-c766-11e1-8775-005056c00008" p="16.0" q="8.0"></iidm:load>
-            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.212" targetDeadband="1.0" bus="_047c4478-c766-11e1-8775-005056c00008" connectableBus="_047c4478-c766-11e1-8775-005056c00008" q="-9.732265">
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.212" targetDeadband="1.0" bus="_047c4478-c766-11e1-8775-005056c00008" connectableBus="_047c4478-c766-11e1-8775-005056c00008" q="-9.732265">
                 <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
+                <iidm:shuntLinearModel bPerSection="1.148E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -508,8 +512,9 @@
                 <iidm:bus id="_04876809-c766-11e1-8775-005056c00008" name="Roanoke" v="127.423" angle="-9.429042"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31.0" q0="26.0" bus="_04876809-c766-11e1-8775-005056c00008" connectableBus="_04876809-c766-11e1-8775-005056c00008" p="31.0" q="26.0"></iidm:load>
-            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" bPerSection="2.296E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1.0" bus="_04876809-c766-11e1-8775-005056c00008" connectableBus="_04876809-c766-11e1-8775-005056c00008" q="-18.63964">
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1.0" bus="_04876809-c766-11e1-8775-005056c00008" connectableBus="_04876809-c766-11e1-8775-005056c00008" q="-18.63964">
                 <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
+                <iidm:shuntLinearModel bPerSection="2.296E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -575,8 +580,9 @@
                 <iidm:bus id="_044b7072-c766-11e1-8775-005056c00008" name="Zanesvll" v="134.723" angle="-9.946326"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20.0" q0="11.0" bus="_044b7072-c766-11e1-8775-005056c00008" connectableBus="_044b7072-c766-11e1-8775-005056c00008" p="20.0" q="11.0"></iidm:load>
-            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" bPerSection="1.722E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="134.723" targetDeadband="1.0" bus="_044b7072-c766-11e1-8775-005056c00008" connectableBus="_044b7072-c766-11e1-8775-005056c00008" q="-15.6273985">
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.723" targetDeadband="1.0" bus="_044b7072-c766-11e1-8775-005056c00008" connectableBus="_044b7072-c766-11e1-8775-005056c00008" q="-15.6273985">
                 <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
+                <iidm:shuntLinearModel bPerSection="1.722E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -640,8 +646,9 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="_047147f0-c766-11e1-8775-005056c00008" name="Olive2" v="133.676" angle="-14.1409559"/>
             </iidm:busBreakerTopology>
-            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" bPerSection="4.592E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="133.676" targetDeadband="1.0" bus="_047147f0-c766-11e1-8775-005056c00008" connectableBus="_047147f0-c766-11e1-8775-005056c00008" q="-41.0278473">
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.676" targetDeadband="1.0" bus="_047147f0-c766-11e1-8775-005056c00008" connectableBus="_047147f0-c766-11e1-8775-005056c00008" q="-41.0278473">
                 <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
+                <iidm:shuntLinearModel bPerSection="4.592E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0.0" x="4.652208" g="0.0" b="0.0" ratedU1="220.0" ratedU2="132.0" bus1="_045163e5-c766-11e1-8775-005056c00008" connectableBus1="_045163e5-c766-11e1-8775-005056c00008" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" bus2="_047147f0-c766-11e1-8775-005056c00008" connectableBus2="_047147f0-c766-11e1-8775-005056c00008" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008">
@@ -747,8 +754,9 @@
             </iidm:busBreakerTopology>
             <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22.0" q0="0.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" p="22.0" q="0.0"></iidm:load>
             <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28.0" q0="12.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" p="28.0" q="12.0"></iidm:load>
-            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" bPerSection="6.88E-5" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="124.763" targetDeadband="1.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" q="-5.354637">
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.763" targetDeadband="1.0" bus="_0483be8a-c766-11e1-8775-005056c00008" connectableBus="_0483be8a-c766-11e1-8775-005056c00008" q="-5.354637">
                 <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
+                <iidm:shuntLinearModel bPerSection="6.88E-5" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -775,8 +783,9 @@
                 <iidm:bus id="_0447ee09-c766-11e1-8775-005056c00008" name="CapitlHl" v="133.002" angle="-3.25421"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39.0" q0="32.0" bus="_0447ee09-c766-11e1-8775-005056c00008" connectableBus="_0447ee09-c766-11e1-8775-005056c00008" p="39.0" q="32.0"></iidm:load>
-            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" bPerSection="2.296E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="133.002" targetDeadband="1.0" bus="_0447ee09-c766-11e1-8775-005056c00008" connectableBus="_0447ee09-c766-11e1-8775-005056c00008" q="-20.3075829">
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.002" targetDeadband="1.0" bus="_0447ee09-c766-11e1-8775-005056c00008" connectableBus="_0447ee09-c766-11e1-8775-005056c00008" q="-20.3075829">
                 <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
+                <iidm:shuntLinearModel bPerSection="2.296E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -935,8 +944,9 @@
                 <iidm:bus id="_044ea4c4-c766-11e1-8775-005056c00008" name="Logan" v="130.419" angle="-2.74680519"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54.0" q0="27.0" bus="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus="_044ea4c4-c766-11e1-8775-005056c00008" p="54.0" q="27.0"></iidm:load>
-            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" bPerSection="2.296E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.419" targetDeadband="1.0" bus="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus="_044ea4c4-c766-11e1-8775-005056c00008" q="-19.5264664">
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.419" targetDeadband="1.0" bus="_044ea4c4-c766-11e1-8775-005056c00008" connectableBus="_044ea4c4-c766-11e1-8775-005056c00008" q="-19.5264664">
                 <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
+                <iidm:shuntLinearModel bPerSection="2.296E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -951,8 +961,9 @@
                 <iidm:minMaxReactiveLimits minQ="-15.0" maxQ="45.0"/>
             </iidm:generator>
             <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28.0" q0="10.0" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" p="28.0" q="10.0"></iidm:load>
-            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1.0" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" q="-10.1016407">
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1.0" bus="_0462a1f3-c766-11e1-8775-005056c00008" connectableBus="_0462a1f3-c766-11e1-8775-005056c00008" q="-10.1016407">
                 <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
+                <iidm:shuntLinearModel bPerSection="1.148E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -1057,8 +1068,9 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="_048b86b5-c766-11e1-8775-005056c00008" name="EastLima1" v="131.565" angle="-18.24901"/>
             </iidm:busBreakerTopology>
-            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" bPerSection="2.87E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1.0" bus="_048b86b5-c766-11e1-8775-005056c00008" connectableBus="_048b86b5-c766-11e1-8775-005056c00008" q="-24.8389168">
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1.0" bus="_048b86b5-c766-11e1-8775-005056c00008" connectableBus="_048b86b5-c766-11e1-8775-005056c00008" q="-24.8389168">
                 <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
+                <iidm:shuntLinearModel bPerSection="2.87E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_04742e21-c766-11e1-8775-005056c00008" name="QAR220KV" nominalV="220.0" topologyKind="BUS_BREAKER">
@@ -1227,8 +1239,9 @@
                 <iidm:bus id="_044e56a4-c766-11e1-8775-005056c00008" name="Rockhill" v="130.814" angle="-18.7122536"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59.0" q0="26.0" bus="_044e56a4-c766-11e1-8775-005056c00008" connectableBus="_044e56a4-c766-11e1-8775-005056c00008" p="59.0" q="26.0"></iidm:load>
-            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" bPerSection="1.606E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="130.814" targetDeadband="1.0" bus="_044e56a4-c766-11e1-8775-005056c00008" connectableBus="_044e56a4-c766-11e1-8775-005056c00008" q="-13.7411785">
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.814" targetDeadband="1.0" bus="_044e56a4-c766-11e1-8775-005056c00008" connectableBus="_044e56a4-c766-11e1-8775-005056c00008" q="-13.7411785">
                 <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
+                <iidm:shuntLinearModel bPerSection="0.0001606" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -1238,8 +1251,9 @@
                 <iidm:bus id="_046a9133-c766-11e1-8775-005056c00008" name="Sprigg" v="129.935" angle="-1.56099224"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20.0" q0="10.0" bus="_046a9133-c766-11e1-8775-005056c00008" connectableBus="_046a9133-c766-11e1-8775-005056c00008" p="20.0" q="10.0"></iidm:load>
-            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" bPerSection="1.148E-4" maximumSectionCount="10" currentSectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1.0" bus="_046a9133-c766-11e1-8775-005056c00008" connectableBus="_046a9133-c766-11e1-8775-005056c00008" q="-9.690902">
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1.0" bus="_046a9133-c766-11e1-8775-005056c00008" connectableBus="_046a9133-c766-11e1-8775-005056c00008" q="-9.690902">
                 <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
+                <iidm:shuntLinearModel bPerSection="1.148E-4" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>

--- a/dynaflow/src/test/resources/dynaflow_version.out
+++ b/dynaflow/src/test/resources/dynaflow_version.out
@@ -1,1 +1,1 @@
-1.3.1 (rev:party-123abcd)
+1.4.0 (rev:HEAD-70c5c8e)

--- a/dynaflow/src/test/resources/params.json
+++ b/dynaflow/src/test/resources/params.json
@@ -17,6 +17,6 @@
     "ChosenOutputs" : [ "STEADYSTATE" ],
     "TimeStep" : 2.6,
     "StartingPointMode" : "warm",
-    "OutputDir" : "/work/dynaflow/workingDir"
+    "OutputDir" : "dynaflow/workingDir"
   }
 }

--- a/dynaflow/src/test/resources/params_default.json
+++ b/dynaflow/src/test/resources/params_default.json
@@ -1,6 +1,6 @@
 {
   "dfl-config" : {
     "InfiniteReactiveLimits" : true,
-    "OutputDir" : "/work/dynaflow/workingDir"
+    "OutputDir" : "dynaflow/workingDir"
   }
 }

--- a/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/ieee/AbstractIeeeTest.java
+++ b/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/ieee/AbstractIeeeTest.java
@@ -115,7 +115,7 @@ public abstract class AbstractIeeeTest {
         ComputationManager computationManager = new LocalComputationManager(new LocalComputationConfig(workingDir, 1), commandExecutor, ForkJoinPool.commonPool());
         DynamicSimulation.Runner dynawoSimulation = DynamicSimulation.find();
         assertEquals(DynaWaltzProvider.NAME, dynawoSimulation.getName());
-        assertEquals("1.2.0", dynawoSimulation.getVersion());
+        assertEquals(DynaWaltzProvider.VERSION, dynawoSimulation.getVersion());
         return dynawoSimulation.run(network, dynamicModelsSupplier, eventModelsSupplier,
             curvesSupplier, network.getVariantManager().getWorkingVariantId(),
             computationManager, parameters);

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzProvider.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzProvider.java
@@ -45,7 +45,7 @@ import static com.powsybl.dynawaltz.xml.DynaWaltzConstants.*;
 public class DynaWaltzProvider implements DynamicSimulationProvider {
 
     public static final String NAME = "DynaWaltz";
-    public static final String VERSION = "1.3.1";
+    public static final String VERSION = "1.4.0";
     private static final String DYNAWO_CMD_NAME = "dynawo";
     private static final String WORKING_DIR_PREFIX = "powsybl_dynawaltz_";
     private static final String OUTPUT_IIDM_FILENAME = "outputIIDM.xml";

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzProvider.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzProvider.java
@@ -17,10 +17,9 @@ import com.powsybl.dynawaltz.xml.DydXml;
 import com.powsybl.dynawaltz.xml.JobsXml;
 import com.powsybl.dynawaltz.xml.ParametersXml;
 import com.powsybl.dynawo.commons.DynawoResultsNetworkUpdate;
+import com.powsybl.dynawo.commons.DynawoUtil;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.xml.IidmXmlVersion;
 import com.powsybl.iidm.xml.NetworkXml;
-import com.powsybl.iidm.xml.XMLExporter;
 import com.powsybl.timeseries.TimeSeries;
 import com.powsybl.timeseries.TimeSeries.TimeFormat;
 import com.powsybl.timeseries.TimeSeriesConstants;
@@ -46,10 +45,10 @@ import static com.powsybl.dynawaltz.xml.DynaWaltzConstants.*;
 public class DynaWaltzProvider implements DynamicSimulationProvider {
 
     public static final String NAME = "DynaWaltz";
+    public static final String VERSION = "1.3.1";
     private static final String DYNAWO_CMD_NAME = "dynawo";
     private static final String WORKING_DIR_PREFIX = "powsybl_dynawaltz_";
     private static final String OUTPUT_IIDM_FILENAME = "outputIIDM.xml";
-    private static final String IIDM_VERSION = IidmXmlVersion.V_1_4.toString(".");
 
     private final PlatformConfig platformConfig;
 
@@ -75,7 +74,7 @@ public class DynaWaltzProvider implements DynamicSimulationProvider {
 
     @Override
     public String getVersion() {
-        return "1.2.0";
+        return VERSION;
     }
 
     @Override
@@ -166,10 +165,7 @@ public class DynaWaltzProvider implements DynamicSimulationProvider {
 
         private void writeInputFiles(Path workingDir) {
             try {
-                // Write the network to XIIDM v1.4 because currently Dynawo does not support versions above
-                Properties params = new Properties();
-                params.setProperty(XMLExporter.VERSION, IIDM_VERSION);
-                context.getNetwork().write("XIIDM", params, workingDir.resolve(NETWORK_FILENAME));
+                DynawoUtil.writeIidm(context.getNetwork(), workingDir.resolve(NETWORK_FILENAME));
 
                 JobsXml.write(workingDir, context);
                 DydXml.write(workingDir, context);

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzProviderTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzProviderTest.java
@@ -110,7 +110,7 @@ public class DynaWaltzProviderTest {
             ComputationManager computationManager = new LocalComputationManager(new LocalComputationConfig(localDir, 1));
             DynamicSimulation.Runner dynawoSimulation = DynamicSimulation.find();
             assertEquals(DynaWaltzProvider.NAME, dynawoSimulation.getName());
-            assertEquals("1.2.0", dynawoSimulation.getVersion());
+            assertEquals(DynaWaltzProvider.VERSION, dynawoSimulation.getVersion());
             DynamicSimulationResult result = dynawoSimulation.run(network, DynamicModelsSupplierMock.empty(), EventModelsSupplierMock.empty(),
                                                                   CurvesSupplier.empty(), network.getVariantManager().getWorkingVariantId(),
                                                                   computationManager, DynamicSimulationParameters.load());
@@ -128,7 +128,7 @@ public class DynaWaltzProviderTest {
             ComputationManager computationManager = new LocalComputationManager(new LocalComputationConfig(localDir, 1), commandExecutor, ForkJoinPool.commonPool());
             DynamicSimulation.Runner dynawoSimulation = DynamicSimulation.find();
             assertEquals(DynaWaltzProvider.NAME, dynawoSimulation.getName());
-            assertEquals("1.2.0", dynawoSimulation.getVersion());
+            assertEquals(DynaWaltzProvider.VERSION, dynawoSimulation.getVersion());
             DynamicSimulationResult result = dynawoSimulation.run(network, DynamicModelsSupplierMock.empty(), EventModelsSupplierMock.empty(),
                     CurvesSupplier.empty(), network.getVariantManager().getWorkingVariantId(),
                     computationManager, DynamicSimulationParameters.load());
@@ -147,7 +147,7 @@ public class DynaWaltzProviderTest {
             ComputationManager computationManager = new LocalComputationManager(new LocalComputationConfig(localDir, 1), commandExecutor, ForkJoinPool.commonPool());
             DynamicSimulation.Runner dynawoSimulation = DynamicSimulation.find();
             assertEquals(DynaWaltzProvider.NAME, dynawoSimulation.getName());
-            assertEquals("1.2.0", dynawoSimulation.getVersion());
+            assertEquals(DynaWaltzProvider.VERSION, dynawoSimulation.getVersion());
             DynamicSimulationResult result = dynawoSimulation.run(network, DynamicModelsSupplierMock.empty(), EventModelsSupplierMock.empty(),
                     new CurvesSupplierMock(), network.getVariantManager().getWorkingVariantId(),
                     computationManager, DynamicSimulationParameters.load());

--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/AbstractDynawoTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/AbstractDynawoTest.java
@@ -23,7 +23,7 @@ import java.util.Objects;
  */
 public abstract class AbstractDynawoTest {
 
-    private static final String DYNAWO_VERSION = "1.3.1";
+    private static final String DYNAWO_VERSION = "1.4.0";
 
     private static final String DOCKER_IMAGE_ID = "powsybl/java-dynawo:" + DYNAWO_VERSION;
 

--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynaFlowTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynaFlowTest.java
@@ -29,8 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -65,10 +64,11 @@ public class DynaFlowTest extends AbstractDynawoTest {
         Network network = IeeeCdfNetworkFactory.create14();
         LoadFlowResult result = loadFlowProvider.run(network, computationManager, VariantManagerConstants.INITIAL_VARIANT_ID, loadFlowParameters)
                 .join();
-        assertFalse(result.isOk()); // FIXME
+        assertTrue(result.isOk());
         assertEquals(1, result.getComponentResults().size());
         LoadFlowResult.ComponentResult componentResult = result.getComponentResults().get(0);
-        assertEquals(LoadFlowResult.ComponentResult.Status.FAILED, componentResult.getStatus()); // FIXME
+        assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, componentResult.getStatus());
+        assertEquals("B4", componentResult.getSlackBusId());
     }
 
     @Test

--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynaWaltzTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynaWaltzTest.java
@@ -91,7 +91,7 @@ public class DynaWaltzTest extends AbstractDynawoTest {
         assertEquals(41, result.getCurves().size());
         DoubleTimeSeries ts1 = (DoubleTimeSeries) result.getCurve("_GEN____1_SM_generator_UStatorPu");
         assertEquals("_GEN____1_SM_generator_UStatorPu", ts1.getMetadata().getName());
-        assertEquals(589, ts1.toArray().length);
+        assertEquals(586, ts1.toArray().length);
         StringTimeSeries timeLine = result.getTimeLine();
         assertEquals(1, timeLine.toArray().length);
         assertNull(timeLine.toArray()[0]); // FIXME why null????

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
         <groovy.version>3.0.9</groovy.version> <!-- used for groovydoc (dynawaltz-dsl) -->
 
-        <powsyblcore.version>5.1.0-RC1</powsyblcore.version>
+        <powsyblcore.version>5.2.0-SNAPSHOT</powsyblcore.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
         <groovy.version>3.0.9</groovy.version> <!-- used for groovydoc (dynawaltz-dsl) -->
 
-        <powsyblcore.version>5.2.0-SNAPSHOT</powsyblcore.version>
+        <powsyblcore.version>5.1.0-RC1</powsyblcore.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix



**What is the new behavior (if this is a feature change)?**
This PR fixes many issues:
 - Dynawo side SlackTerminal extension parsing fixed in 1.4.0 (1.3.1 is buggy)
 - IIDM XML is exported with unsupported (from IIDM C++ side) extensions => now we explicitely defined list of written extensions.
 - IIDM export version and extensions should be common to DynaFlow and DynaWaltz (because provided by Dynawo platform) 
 - Dynaflow security analysis was still exporting IIDM XML to 1.2 => now 1.4, many reference files have been updated
 - DynaFlow output files were written in the wrong directory, local one instead of remote one. The bug is not visible using the local computation manager but is when using Docker/Slurm/Mpi ones where the 2 directories are not the same.
 - DynaWaltz version is wrong.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
