### PR TITLE
Fix pre-contingency limit violations.

### DIFF
--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynaFlowTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynaFlowTest.java
@@ -82,6 +82,6 @@ public class DynaFlowTest extends AbstractDynawoTest {
                         Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Reporter.NO_OP)
                 .join()
                 .getResult();
-        assertEquals(LoadFlowResult.ComponentResult.Status.FAILED, result.getPreContingencyResult().getStatus()); // FIXME
+        assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getPreContingencyResult().getStatus());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
Pre-contingency limit violations are calculated based on a non-existing iidm file: dynawo does not run a loadflow for state N



**What is the new behavior (if this is a feature change)?**
Pre-contingency limit violations are deduced from the input network, assuming that a loadflow has already been launched prior to security analysis.


**Does this PR introduce a breaking change or deprecate an API?**
Yes