### PR TITLE
Rename remaining connectedToOmegaRef variables

### DIFF
--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/generators/OmegaRefGeneratorGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/generators/OmegaRefGeneratorGroovyExtension.groovy
@@ -21,23 +21,23 @@ import com.powsybl.dynawaltz.models.generators.OmegaRefGenerator
 @AutoService(DynamicModelGroovyExtension.class)
 class OmegaRefGeneratorGroovyExtension extends AbstractPowsyblDynawoGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {
 
-    private static final String CONNECTED_TO_OMEGA_REF_GENERATORS = "connectedToOmegaRefGenerators"
+    private static final String OMEGA_REF_GENERATORS = "omegaRefGenerators"
 
     OmegaRefGeneratorGroovyExtension() {
         ConfigSlurper config = new ConfigSlurper()
-        modelTags = config.parse(this.getClass().getClassLoader().getResource(MODELS_CONFIG)).get(CONNECTED_TO_OMEGA_REF_GENERATORS).keySet() as List
+        modelTags = config.parse(this.getClass().getClassLoader().getResource(MODELS_CONFIG)).get(OMEGA_REF_GENERATORS).keySet() as List
     }
 
     @Override
-    protected GeneratorConnectedToOmegaRefBuilder createBuilder(String currentTag) {
-        new GeneratorConnectedToOmegaRefBuilder(currentTag)
+    protected OmegaRefGeneratorBuilder createBuilder(String currentTag) {
+        new OmegaRefGeneratorBuilder(currentTag)
     }
 
-    static class GeneratorConnectedToOmegaRefBuilder extends AbstractDynamicModelBuilder {
+    static class OmegaRefGeneratorBuilder extends AbstractDynamicModelBuilder {
 
         String tag
 
-        GeneratorConnectedToOmegaRefBuilder(String tag) {
+        OmegaRefGeneratorBuilder(String tag) {
             this.tag = tag
         }
 

--- a/dynawaltz-dsl/src/main/resources/models.cfg
+++ b/dynawaltz-dsl/src/main/resources/models.cfg
@@ -20,6 +20,6 @@ synchronousGenerators {
      GeneratorSynchronousThreeWindingsProportionalRegulations
 }
 
-connectedToOmegaRefGenerators {
+omegaRefGenerators {
     GeneratorPQ
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
Some variables still have the old naming generatorConnectedToOmegaRef


**What is the new behavior (if this is a feature change)?**
Those variables are renamed into omegaRefGenerators


**Does this PR introduce a breaking change or deprecate an API?**
No