### PR TITLE
Fix merging loads

### DIFF
--- a/commons/src/main/java/com/powsybl/dynawo/commons/NetworkResultsUpdater.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/NetworkResultsUpdater.java
@@ -9,7 +9,7 @@ package com.powsybl.dynawo.commons;
 
 import com.google.common.collect.Iterables;
 import com.powsybl.commons.PowsyblException;
-import com.powsybl.dynawo.commons.loadmerge.LoadPowers;
+import com.powsybl.dynawo.commons.loadmerge.LoadPowersSigns;
 import com.powsybl.dynawo.commons.loadmerge.LoadsMerger;
 import com.powsybl.iidm.network.*;
 import org.slf4j.Logger;
@@ -158,10 +158,10 @@ public final class NetworkResultsUpdater {
         if (nbLoads == 0) {
             return;
         }
-        Map<LoadPowers, Terminal> mergedLoadsTerminal = busSource.getLoadStream()
+        Map<LoadPowersSigns, Terminal> mergedLoadsTerminal = busSource.getLoadStream()
                 .collect(Collectors.toMap(LoadsMerger::getLoadPowers, Load::getTerminal));
-        LoadsMerger.getLoadPowersGrouping(busTarget).forEach((loadPowers, loadsGroup) -> {
-            Terminal mergedLoadTerminal = Optional.ofNullable(mergedLoadsTerminal.get(loadPowers))
+        LoadsMerger.getLoadPowersGrouping(busTarget).forEach((loadPowersSigns, loadsGroup) -> {
+            Terminal mergedLoadTerminal = Optional.ofNullable(mergedLoadsTerminal.get(loadPowersSigns))
                     .orElseThrow(() -> new PowsyblException("Missing merged load in bus " + busTarget.getId()));
             if (loadsGroup.size() == 1) {
                 update(loadsGroup.get(0).getTerminal(), mergedLoadTerminal);

--- a/commons/src/main/java/com/powsybl/dynawo/commons/NetworkResultsUpdater.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/NetworkResultsUpdater.java
@@ -159,8 +159,8 @@ public final class NetworkResultsUpdater {
             return;
         }
         Map<LoadPowersSigns, Terminal> mergedLoadsTerminal = busSource.getLoadStream()
-                .collect(Collectors.toMap(LoadsMerger::getLoadPowers, Load::getTerminal));
-        LoadsMerger.getLoadPowersGrouping(busTarget).forEach((loadPowersSigns, loadsGroup) -> {
+                .collect(Collectors.toMap(LoadsMerger::getLoadPowersSigns, Load::getTerminal));
+        LoadsMerger.getLoadPowersSignsGrouping(busTarget).forEach((loadPowersSigns, loadsGroup) -> {
             Terminal mergedLoadTerminal = Optional.ofNullable(mergedLoadsTerminal.get(loadPowersSigns))
                     .orElseThrow(() -> new PowsyblException("Missing merged load in bus " + busTarget.getId()));
             if (loadsGroup.size() == 1) {

--- a/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadPowersSigns.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadPowersSigns.java
@@ -10,7 +10,7 @@ package com.powsybl.dynawo.commons.loadmerge;
 /**
  * @author Laurent Isertial <laurent.issertial at rte-france.com>
  */
-public enum LoadPowers {
+public enum LoadPowersSigns {
     P_POS_Q_POS(".pppq"),
     P_POS_Q_NEG(".ppnq"),
     P_NEG_Q_POS(".nppq"),
@@ -18,7 +18,7 @@ public enum LoadPowers {
 
     private final String mergeLoadSuffixId;
 
-    LoadPowers(String suffix) {
+    LoadPowersSigns(String suffix) {
         mergeLoadSuffixId = suffix;
     }
 

--- a/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsMerger.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsMerger.java
@@ -39,20 +39,14 @@ public final class LoadsMerger {
     }
 
     private static void mergeLoadsInVoltageLevel(VoltageLevel vl) {
+        // we need to build the list of loads to merge beforehand as the buses of this voltage level
+        // will be invalidated once a load is removed
         List<LoadsToMerge> loadsToMergeList = vl.getBusBreakerView().getBusStream()
                 .filter(bus -> bus.getLoadStream().count() > 1)
                 .flatMap(LoadsMerger::getLoadsToMergeStream)
                 .collect(Collectors.toList());
 
-        for (LoadsToMerge loadsToMerge : loadsToMergeList) {
-            loadsToMerge.removeLoads();
-            Load load = loadsToMerge.getLoadAdder()
-                    .setP0(loadsToMerge.getMergedP0())
-                    .setQ0(loadsToMerge.getMergedQ0())
-                    .add();
-            load.getTerminal().setP(loadsToMerge.getMergedP());
-            load.getTerminal().setQ(loadsToMerge.getMergedQ());
-        }
+        loadsToMergeList.forEach(LoadsToMerge::merge);
     }
 
     private static Stream<LoadsToMerge> getLoadsToMergeStream(Bus bus) {

--- a/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsMerger.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsMerger.java
@@ -10,11 +10,10 @@ package com.powsybl.dynawo.commons.loadmerge;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.xml.NetworkXml;
+import org.apache.commons.lang3.tuple.Pair;
 
-import java.util.ArrayList;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.powsybl.dynawo.commons.loadmerge.LoadPowersSigns.*;
@@ -26,59 +25,33 @@ import static com.powsybl.dynawo.commons.loadmerge.LoadPowersSigns.*;
  */
 public final class LoadsMerger {
 
-    private static final String MERGE_LOAD_PREFIX_ID = "merged_load_.";
-
     private LoadsMerger() {
     }
 
     public static Network mergeLoads(Network network) throws PowsyblException {
         Network mergedLoadsNetwork = NetworkXml.copy(network);
 
-        List<LoadsToMerge> loadsToMergeList = mergedLoadsNetwork.getBusBreakerView().getBusStream()
+        mergedLoadsNetwork.getBusBreakerView().getBusStream()
                 .filter(bus -> bus.getLoadStream().count() > 1)
-                .map(LoadsMerger::mergeLoads)
-                .flatMap(List::stream)
-                .collect(Collectors.toList());
-
-        for (LoadsToMerge loadsToMerge : loadsToMergeList) {
-            loadsToMerge.getLoads().forEach(Connectable::remove);
-            loadsToMerge.getLoadAdder().setP0(loadsToMerge.getMergedP0());
-            loadsToMerge.getLoadAdder().setQ0(loadsToMerge.getMergedQ0());
-            Load load = loadsToMerge.getLoadAdder().add();
-            load.getTerminal().setP(loadsToMerge.getMergedP());
-            load.getTerminal().setQ(loadsToMerge.getMergedQ());
-        }
+                .flatMap(bus -> getLoadsToMergeList(bus).stream())
+                .forEach(loadsToMerge  -> {
+                    loadsToMerge.removeLoads();
+                    Load load = loadsToMerge.getLoadAdder()
+                            .setP0(loadsToMerge.getMergedP0())
+                            .setQ0(loadsToMerge.getMergedQ0())
+                            .add();
+                    load.getTerminal().setP(loadsToMerge.getMergedP());
+                    load.getTerminal().setQ(loadsToMerge.getMergedQ());
+                });
 
         return mergedLoadsNetwork;
-    }
-
-    private static List<LoadsToMerge> mergeLoads(Bus bus) {
-        return getLoadsToMergeList(bus).stream()
-                .map(loadsToMerge -> mergeLoads(bus, loadsToMerge))
-                .collect(Collectors.toList());
-    }
-
-    private static LoadsToMerge mergeLoads(Bus bus, LoadsToMerge loadsToMerge) {
-        LoadAdder loadAdder = loadsToMerge.getLoadAdder();
-        loadAdder.setId(MERGE_LOAD_PREFIX_ID + bus.getId() + loadsToMerge.getLoadPowers().getMergeLoadSuffixId());
-        loadAdder.setLoadType(LoadType.UNDEFINED);
-
-        TopologyKind topologyKind = bus.getVoltageLevel().getTopologyKind();
-        if (TopologyKind.BUS_BREAKER.equals(topologyKind)) {
-            loadAdder.setBus(bus.getId());
-            loadAdder.setConnectableBus(bus.getId());
-        } else if (TopologyKind.NODE_BREAKER.equals(topologyKind)) {
-            loadAdder.setNode(loadsToMerge.getLoads().get(0).getTerminal().getNodeBreakerView().getNode());
-        }
-
-        return loadsToMerge;
     }
 
     public static List<LoadsToMerge> getLoadsToMergeList(Bus bus) {
         List<LoadsToMerge> loadsToMerge = new ArrayList<>();
         getLoadPowersGrouping(bus).forEach((loadPowersSigns, loads) -> {
             if (loads.size() > 1) {
-                loadsToMerge.add(new LoadsToMerge(loadPowersSigns, loads, bus.getVoltageLevel().newLoad()));
+                loadsToMerge.add(new LoadsToMerge(loadPowersSigns, loads, bus));
             }
         });
         return loadsToMerge;

--- a/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsMerger.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsMerger.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static com.powsybl.dynawo.commons.loadmerge.LoadPowers.*;
+import static com.powsybl.dynawo.commons.loadmerge.LoadPowersSigns.*;
 
 /**
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
@@ -76,23 +76,23 @@ public final class LoadsMerger {
 
     public static List<LoadsToMerge> getLoadsToMergeList(Bus bus) {
         List<LoadsToMerge> loadsToMerge = new ArrayList<>();
-        getLoadPowersGrouping(bus).forEach((loadPowers, loads) -> {
+        getLoadPowersGrouping(bus).forEach((loadPowersSigns, loads) -> {
             if (loads.size() > 1) {
-                loadsToMerge.add(new LoadsToMerge(loadPowers, loads, bus.getVoltageLevel().newLoad()));
+                loadsToMerge.add(new LoadsToMerge(loadPowersSigns, loads, bus.getVoltageLevel().newLoad()));
             }
         });
         return loadsToMerge;
     }
 
-    public static Map<LoadPowers, List<Load>> getLoadPowersGrouping(Bus bus) {
-        EnumMap<LoadPowers, List<Load>> loadsGrouping = new EnumMap<>(LoadPowers.class);
+    public static Map<LoadPowersSigns, List<Load>> getLoadPowersGrouping(Bus bus) {
+        EnumMap<LoadPowersSigns, List<Load>> loadsGrouping = new EnumMap<>(LoadPowersSigns.class);
         for (Load load : bus.getLoads()) {
             loadsGrouping.computeIfAbsent(getLoadPowers(load), k -> new ArrayList<>()).add(load);
         }
         return loadsGrouping;
     }
 
-    public static LoadPowers getLoadPowers(Load load) {
+    public static LoadPowersSigns getLoadPowers(Load load) {
         if (load.getP0() >= 0) {
             return load.getQ0() >= 0 ? P_POS_Q_POS : P_POS_Q_NEG;
         } else {

--- a/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsMerger.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsMerger.java
@@ -10,10 +10,8 @@ package com.powsybl.dynawo.commons.loadmerge;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.xml.NetworkXml;
-import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -55,7 +53,7 @@ public final class LoadsMerger {
 
     public static List<LoadsToMerge> getLoadsToMergeList(Bus bus) {
         List<LoadsToMerge> loadsToMerge = new ArrayList<>();
-        getLoadPowersGrouping(bus).forEach((loadPowersSigns, loads) -> {
+        getLoadPowersSignsGrouping(bus).forEach((loadPowersSigns, loads) -> {
             if (loads.size() > 1) {
                 loadsToMerge.add(new LoadsToMerge(loadPowersSigns, loads, bus));
             }
@@ -63,15 +61,15 @@ public final class LoadsMerger {
         return loadsToMerge;
     }
 
-    public static Map<LoadPowersSigns, List<Load>> getLoadPowersGrouping(Bus bus) {
+    public static Map<LoadPowersSigns, List<Load>> getLoadPowersSignsGrouping(Bus bus) {
         EnumMap<LoadPowersSigns, List<Load>> loadsGrouping = new EnumMap<>(LoadPowersSigns.class);
         for (Load load : bus.getLoads()) {
-            loadsGrouping.computeIfAbsent(getLoadPowers(load), k -> new ArrayList<>()).add(load);
+            loadsGrouping.computeIfAbsent(getLoadPowersSigns(load), k -> new ArrayList<>()).add(load);
         }
         return loadsGrouping;
     }
 
-    public static LoadPowersSigns getLoadPowers(Load load) {
+    public static LoadPowersSigns getLoadPowersSigns(Load load) {
         if (load.getP0() >= 0) {
             return load.getQ0() >= 0 ? P_POS_Q_POS : P_POS_Q_NEG;
         } else {

--- a/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsToMerge.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsToMerge.java
@@ -7,9 +7,7 @@
  */
 package com.powsybl.dynawo.commons.loadmerge;
 
-import com.powsybl.iidm.network.Load;
-import com.powsybl.iidm.network.LoadAdder;
-import com.powsybl.iidm.network.Terminal;
+import com.powsybl.iidm.network.*;
 
 import java.util.List;
 
@@ -17,7 +15,7 @@ import java.util.List;
  * @author Laurent Isertial <laurent.issertial at rte-france.com>
  */
 public class LoadsToMerge {
-    private final LoadPowersSigns loadPowersSigns;
+    private static final String MERGE_LOAD_PREFIX_ID = "merged_load_.";
     private final List<Load> loads;
     private final LoadAdder loadAdder;
     private final double mergedP;
@@ -25,18 +23,29 @@ public class LoadsToMerge {
     private final double mergedP0;
     private final double mergedQ0;
 
-    public LoadsToMerge(LoadPowersSigns loadPowersSigns, List<Load> loads, LoadAdder loadAdder) {
-        this.loadPowersSigns = loadPowersSigns;
+    public LoadsToMerge(LoadPowersSigns loadPowersSigns, List<Load> loads, Bus bus) {
         this.loads = loads;
-        this.loadAdder = loadAdder;
+        this.loadAdder = createLoadAdder(loads, loadPowersSigns, bus);
         this.mergedP = loads.stream().map(Load::getTerminal).mapToDouble(Terminal::getP).sum();
         this.mergedQ = loads.stream().map(Load::getTerminal).mapToDouble(Terminal::getQ).sum();
         this.mergedP0 = loads.stream().mapToDouble(Load::getP0).sum();
         this.mergedQ0 = loads.stream().mapToDouble(Load::getQ0).sum();
     }
 
-    public LoadPowersSigns getLoadPowers() {
-        return loadPowersSigns;
+    private static LoadAdder createLoadAdder(List<Load> loads, LoadPowersSigns loadPowersSigns, Bus bus) {
+        LoadAdder loadAdder = bus.getVoltageLevel().newLoad();
+        loadAdder.setId(MERGE_LOAD_PREFIX_ID + bus.getId() + loadPowersSigns.getMergeLoadSuffixId());
+        loadAdder.setLoadType(LoadType.UNDEFINED);
+
+        TopologyKind topologyKind = bus.getVoltageLevel().getTopologyKind();
+        if (TopologyKind.BUS_BREAKER.equals(topologyKind)) {
+            loadAdder.setBus(bus.getId());
+            loadAdder.setConnectableBus(bus.getId());
+        } else if (TopologyKind.NODE_BREAKER.equals(topologyKind)) {
+            loadAdder.setNode(loads.get(0).getTerminal().getNodeBreakerView().getNode());
+        }
+
+        return loadAdder;
     }
 
     public double getMergedP0() {
@@ -55,11 +64,11 @@ public class LoadsToMerge {
         return mergedQ;
     }
 
-    public List<Load> getLoads() {
-        return loads;
-    }
-
     public LoadAdder getLoadAdder() {
         return loadAdder;
+    }
+
+    public void removeLoads() {
+        loads.forEach(Connectable::remove);
     }
 }

--- a/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsToMerge.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsToMerge.java
@@ -22,6 +22,8 @@ public class LoadsToMerge {
     private final LoadAdder loadAdder;
     private final double mergedP;
     private final double mergedQ;
+    private final double mergedP0;
+    private final double mergedQ0;
 
     public LoadsToMerge(LoadPowers loadPowers, List<Load> loads, LoadAdder loadAdder) {
         this.loadPowers = loadPowers;
@@ -29,6 +31,8 @@ public class LoadsToMerge {
         this.loadAdder = loadAdder;
         this.mergedP = loads.stream().map(Load::getTerminal).mapToDouble(Terminal::getP).sum();
         this.mergedQ = loads.stream().map(Load::getTerminal).mapToDouble(Terminal::getQ).sum();
+        this.mergedP0 = loads.stream().mapToDouble(Load::getP0).sum();
+        this.mergedQ0 = loads.stream().mapToDouble(Load::getQ0).sum();
     }
 
     public LoadPowers getLoadPowers() {
@@ -36,11 +40,11 @@ public class LoadsToMerge {
     }
 
     public double getMergedP0() {
-        return loads.stream().mapToDouble(Load::getP0).sum();
+        return mergedP0;
     }
 
     public double getMergedQ0() {
-        return loads.stream().mapToDouble(Load::getQ0).sum();
+        return mergedQ0;
     }
 
     public double getMergedP() {

--- a/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsToMerge.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsToMerge.java
@@ -48,27 +48,14 @@ public class LoadsToMerge {
         return loadAdder;
     }
 
-    public double getMergedP0() {
-        return mergedP0;
-    }
-
-    public double getMergedQ0() {
-        return mergedQ0;
-    }
-
-    public double getMergedP() {
-        return mergedP;
-    }
-
-    public double getMergedQ() {
-        return mergedQ;
-    }
-
-    public LoadAdder getLoadAdder() {
-        return loadAdder;
-    }
-
-    public void removeLoads() {
+    public void merge() {
         loads.forEach(Connectable::remove);
+        loads.clear();
+        Load load = loadAdder
+                .setP0(mergedP0)
+                .setQ0(mergedQ0)
+                .add();
+        load.getTerminal().setP(mergedP);
+        load.getTerminal().setQ(mergedQ);
     }
 }

--- a/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsToMerge.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsToMerge.java
@@ -17,7 +17,7 @@ import java.util.List;
  * @author Laurent Isertial <laurent.issertial at rte-france.com>
  */
 public class LoadsToMerge {
-    private final LoadPowers loadPowers;
+    private final LoadPowersSigns loadPowersSigns;
     private final List<Load> loads;
     private final LoadAdder loadAdder;
     private final double mergedP;
@@ -25,8 +25,8 @@ public class LoadsToMerge {
     private final double mergedP0;
     private final double mergedQ0;
 
-    public LoadsToMerge(LoadPowers loadPowers, List<Load> loads, LoadAdder loadAdder) {
-        this.loadPowers = loadPowers;
+    public LoadsToMerge(LoadPowersSigns loadPowersSigns, List<Load> loads, LoadAdder loadAdder) {
+        this.loadPowersSigns = loadPowersSigns;
         this.loads = loads;
         this.loadAdder = loadAdder;
         this.mergedP = loads.stream().map(Load::getTerminal).mapToDouble(Terminal::getP).sum();
@@ -35,8 +35,8 @@ public class LoadsToMerge {
         this.mergedQ0 = loads.stream().mapToDouble(Load::getQ0).sum();
     }
 
-    public LoadPowers getLoadPowers() {
-        return loadPowers;
+    public LoadPowersSigns getLoadPowers() {
+        return loadPowersSigns;
     }
 
     public double getMergedP0() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix + refactor 


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Loads are accessed after being removed, which leads in some implementations to a crash


**What is the new behavior (if this is a feature change)?**
Loads are not accessed once removed, and cannot be accessed in LoadsToMerge object anymore


**Does this PR introduce a breaking change or deprecate an API?**
No