### PR TITLE
Fix network state update performance issue with IIDM network store im…

### DIFF
--- a/commons/src/main/java/com/powsybl/dynawo/commons/NetworkResultsUpdater.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/NetworkResultsUpdater.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -91,8 +92,10 @@ public final class NetworkResultsUpdater {
         // We choose to iterate over BusBreakerView buses instead of BusView buses because they are more stable:
         // a use-case when we need to export a node/breaker network to bus/breaker to Dynawo exists,
         // and reading the results from Dynawo-exported bus/breaker will end up with different ids at BusView level
+        Map<String, Bus> targetNetworkBusBreakerViewBusById = targetNetwork.getBusBreakerView().getBusStream()
+                .collect(Collectors.toMap(Identifiable::getId, Function.identity())); // it is needed to pre-index into a map as in network store n.getBusBreakerView().getBus(id) is slow
         for (Bus sourceBus : sourceNetwork.getBusBreakerView().getBuses()) {
-            Bus targetBus = targetNetwork.getBusBreakerView().getBus(sourceBus.getId());
+            Bus targetBus = targetNetworkBusBreakerViewBusById.get(sourceBus.getId());
             if (targetBus == null) {
                 LOG.error("Source bus {} not found in target network. Voltage not updated ({}, {})", sourceBus.getId(), sourceBus.getV(), sourceBus.getAngle());
             } else {


### PR DESCRIPTION
…plementation

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Performance issue


**What is the current behavior?**
<!-- You can also link to an open issue here -->
With network store implementation of IIDM, the `network.getBusBreakerView().getBus(id)` is quite slow because nothing is indexed (sequential loop).


**What is the new behavior (if this is a feature change)?**
We pre-index target network buses by ID in a map to speed up update.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
