### PR TITLE
Add network parameter "hasShortCircuitCapabilities" for buses in node fault event

### DIFF
--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/events/NodeFaultEvent.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/events/NodeFaultEvent.java
@@ -18,6 +18,8 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import java.util.List;
 
+import static com.powsybl.dynawaltz.parameters.ParameterType.BOOL;
+
 /**
  * @author Laurent Issertial <laurent.issertial at rte-france.com>
  */
@@ -48,6 +50,12 @@ public class NodeFaultEvent extends AbstractEventModel {
 
     private List<VarConnection> getVarConnectionsWithBus(BusModel connected) {
         return List.of(new VarConnection("fault_terminal", connected.getTerminalVarName()));
+    }
+
+    @Override
+    public void writeParameters(XMLStreamWriter writer, DynaWaltzContext context) throws XMLStreamException {
+        super.writeParameters(writer, context);
+        context.getDynaWaltzParameters().getNetworkParameters().addParameter(getEquipment().getId() + "_hasShortCircuitCapabilities", BOOL, Boolean.toString(true));
     }
 
     @Override

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/NodeFaultEventXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/NodeFaultEventXmlTest.java
@@ -36,5 +36,6 @@ class NodeFaultEventXmlTest extends AbstractDynamicModelXmlTest {
         ParametersXml.write(tmpDir, context);
         validate("dyd.xsd", "node_fault_dyd.xml", tmpDir.resolve(DynaWaltzConstants.DYD_FILENAME));
         validate("parameters.xsd", "node_fault_par.xml", tmpDir.resolve(context.getSimulationParFile()));
+        validate("parameters.xsd", "node_network_par.xml", tmpDir.resolve("network.par"));
     }
 }

--- a/dynawaltz/src/test/resources/node_network_par.xml
+++ b/dynawaltz/src/test/resources/node_network_par.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parametersSet xmlns="http://www.rte-france.com/dynawo">
+    <set id="1">
+        <par type="BOOL" name="NGEN_hasShortCircuitCapabilities" value="true"/>
+    </set>
+</parametersSet>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
