### PR TITLE
Skip empty automatons

### DIFF
--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzContext.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzContext.java
@@ -19,6 +19,8 @@ import com.powsybl.dynawaltz.models.frequencysynchronizers.SetPoint;
 import com.powsybl.dynawaltz.xml.MacroStaticReference;
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.function.Function;
@@ -31,7 +33,9 @@ import java.util.stream.Stream;
  */
 public class DynaWaltzContext {
 
+    protected static final Logger LOGGER = LoggerFactory.getLogger(DynaWaltzContext.class);
     private static final String MODEL_ID_EXCEPTION = "The model identified by the static id %s does not match the expected model (%s)";
+    private static final String MODEL_ID_LOG = "The model identified by the static id {} does not match the expected model ({})";
 
     private final Network network;
     private final String workingVariantId;
@@ -111,27 +115,46 @@ public class DynaWaltzContext {
     }
 
     public <T extends Model> T getDynamicModel(Identifiable<?> equipment, Class<T> connectableClass) {
-        BlackBoxModel bbm = staticIdBlackBoxModelMap.get(equipment.getId());
-        if (bbm == null) {
-            return defaultModelsHandler.getDefaultModel(equipment, connectableClass);
-        }
-        if (connectableClass.isInstance(bbm)) {
-            return connectableClass.cast(bbm);
-        }
-        throw new PowsyblException(String.format(MODEL_ID_EXCEPTION, equipment.getId(), connectableClass.getSimpleName()));
+        return getDynamicModel(equipment, connectableClass, true);
     }
 
-    public <T extends Model> T getPureDynamicModel(String dynamicId, Class<T> connectableClass) {
-        BlackBoxModel bbm = dynamicModels.stream()
-                .filter(dm -> dynamicId.equals(dm.getDynamicModelId()))
-                .findFirst()
-                .orElseThrow(() -> {
-                    throw new PowsyblException("Pure dynamic model " + dynamicId + " not found");
-                });
+    public <T extends Model> T getDynamicModel(Identifiable<?> equipment, Class<T> connectableClass, boolean throwException) {
+        BlackBoxModel bbm = staticIdBlackBoxModelMap.get(equipment.getId());
+        if (bbm == null) {
+            return defaultModelsHandler.getDefaultModel(equipment, connectableClass, throwException);
+        }
         if (connectableClass.isInstance(bbm)) {
             return connectableClass.cast(bbm);
         }
-        throw new PowsyblException(String.format(MODEL_ID_EXCEPTION, dynamicId, connectableClass.getSimpleName()));
+        if (throwException) {
+            throw new PowsyblException(String.format(MODEL_ID_EXCEPTION, equipment.getId(), connectableClass.getSimpleName()));
+        } else {
+            LOGGER.warn(MODEL_ID_LOG, equipment.getId(), connectableClass.getSimpleName());
+            return null;
+        }
+    }
+
+    public <T extends Model> T getPureDynamicModel(String dynamicId, Class<T> connectableClass, boolean throwException) {
+        BlackBoxModel bbm = dynamicModels.stream()
+                .filter(dm -> dynamicId.equals(dm.getDynamicModelId()))
+                .findFirst().orElse(null);
+        if (bbm == null) {
+            if (throwException) {
+                throw new PowsyblException("Pure dynamic model " + dynamicId + " not found");
+            } else {
+                LOGGER.warn("Pure dynamic model {} not found", dynamicId);
+                return null;
+            }
+        }
+        if (connectableClass.isInstance(bbm)) {
+            return connectableClass.cast(bbm);
+        }
+        if (throwException) {
+            throw new PowsyblException(String.format(MODEL_ID_EXCEPTION, dynamicId, connectableClass.getSimpleName()));
+        } else {
+            LOGGER.warn(MODEL_ID_LOG, dynamicId, connectableClass.getSimpleName());
+            return null;
+        }
     }
 
     private EquipmentBlackBoxModel mergeDuplicateStaticId(EquipmentBlackBoxModel bbm1, EquipmentBlackBoxModel bbm2) {

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/AbstractBlackBoxModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/AbstractBlackBoxModel.java
@@ -101,10 +101,29 @@ public abstract class AbstractBlackBoxModel implements BlackBoxModel {
         createMacroConnections(connectedModel, varConnectionsSupplier.apply(connectedModel), context, connectFromAttributes);
     }
 
+    protected final <T extends Model> boolean createMacroConnectionsOrSkip(Identifiable<?> equipment, Class<T> modelClass, Function<T, List<VarConnection>> varConnectionsSupplier, DynaWaltzContext context, MacroConnectAttribute... connectFromAttributes) {
+        T connectedModel = context.getDynamicModel(equipment, modelClass, false);
+        if (connectedModel != null) {
+            createMacroConnections(connectedModel, varConnectionsSupplier.apply(connectedModel), context, connectFromAttributes);
+            return false;
+        }
+        return true;
+    }
+
     protected <T extends Model> void createMacroConnections(Identifiable<?> equipment, Class<T> modelClass, Function<T, List<VarConnection>> varConnectionsSupplier, DynaWaltzContext context) {
         T connectedModel = context.getDynamicModel(equipment, modelClass);
         String macroConnectorId = context.addMacroConnector(getName(), connectedModel.getName(), varConnectionsSupplier.apply(connectedModel));
         context.addMacroConnect(macroConnectorId, getMacroConnectFromAttributes(), connectedModel.getMacroConnectToAttributes());
+    }
+
+    protected <T extends Model> boolean createMacroConnectionsOrSkip(Identifiable<?> equipment, Class<T> modelClass, Function<T, List<VarConnection>> varConnectionsSupplier, DynaWaltzContext context) {
+        T connectedModel = context.getDynamicModel(equipment, modelClass, false);
+        if (connectedModel != null) {
+            String macroConnectorId = context.addMacroConnector(getName(), connectedModel.getName(), varConnectionsSupplier.apply(connectedModel));
+            context.addMacroConnect(macroConnectorId, getMacroConnectFromAttributes(), connectedModel.getMacroConnectToAttributes());
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -134,12 +153,6 @@ public abstract class AbstractBlackBoxModel implements BlackBoxModel {
     protected <T extends Model> void createMacroConnections(Identifiable<?> equipment, Class<T> modelClass, BiFunction<T, String, List<VarConnection>> varConnectionsSupplier, DynaWaltzContext context, MacroConnectionSuffix suffix) {
         T connectedModel = context.getDynamicModel(equipment, modelClass);
         String macroConnectorId = context.addMacroConnector(getName(), connectedModel.getName(), suffix.getIdSuffix(), varConnectionsSupplier.apply(connectedModel, suffix.getConnectionSuffix()));
-        context.addMacroConnect(macroConnectorId, getMacroConnectFromAttributes(), connectedModel.getMacroConnectToAttributes());
-    }
-
-    protected <T extends Model> void createPureDynamicMacroConnections(String dynamicId, Class<T> modelClass, Function<T, List<VarConnection>> varConnectionsSupplier, DynaWaltzContext context) {
-        T connectedModel = context.getPureDynamicModel(dynamicId, modelClass);
-        String macroConnectorId = context.addMacroConnector(getName(), connectedModel.getName(), varConnectionsSupplier.apply(connectedModel));
         context.addMacroConnect(macroConnectorId, getMacroConnectFromAttributes(), connectedModel.getMacroConnectToAttributes());
     }
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/EmptyTapChangerAutomatonXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/EmptyTapChangerAutomatonXmlTest.java
@@ -8,7 +8,7 @@
 package com.powsybl.dynawaltz.xml;
 
 import com.powsybl.dynawaltz.models.automatons.TapChangerAutomaton;
-import com.powsybl.dynawaltz.models.loads.LoadAlphaBeta;
+import com.powsybl.dynawaltz.models.loads.BaseLoad;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
@@ -28,7 +28,7 @@ class EmptyTapChangerAutomatonXmlTest extends AbstractDynamicModelXmlTest {
 
     @Override
     protected void addDynamicModels() {
-        dynamicModels.add(new LoadAlphaBeta("BBM_LOAD", network.getLoad("LOAD"), "LAB", "LoadAlphaBeta"));
+        dynamicModels.add(new BaseLoad("BBM_LOAD", network.getLoad("LOAD"), "LAB", "LoadAlphaBeta"));
         dynamicModels.add(new TapChangerAutomaton("BBM_TC", "tc", network.getLoad("LOAD")));
     }
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/EmptyTapChangerAutomatonXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/EmptyTapChangerAutomatonXmlTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com/)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.dynawaltz.xml;
+
+import com.powsybl.dynawaltz.models.automatons.TapChangerAutomaton;
+import com.powsybl.dynawaltz.models.loads.LoadAlphaBeta;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.IOException;
+
+/**
+ * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ */
+class EmptyTapChangerAutomatonXmlTest extends AbstractDynamicModelXmlTest {
+
+    @Override
+    protected void setupNetwork() {
+        network = EurostagTutorialExample1Factory.create();
+    }
+
+    @Override
+    protected void addDynamicModels() {
+        dynamicModels.add(new LoadAlphaBeta("BBM_LOAD", network.getLoad("LOAD"), "LAB", "LoadAlphaBeta"));
+        dynamicModels.add(new TapChangerAutomaton("BBM_TC", "tc", network.getLoad("LOAD")));
+    }
+
+    @Test
+    void writeModel() throws SAXException, IOException, XMLStreamException {
+        DydXml.write(tmpDir, context);
+        ParametersXml.write(tmpDir, context);
+        validate("dyd.xsd", "tap_changer_empty_dyd.xml", tmpDir.resolve(DynaWaltzConstants.DYD_FILENAME));
+    }
+}

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/EmptyTapChangerBlockingAutomatonXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/EmptyTapChangerBlockingAutomatonXmlTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com/)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.dynawaltz.xml;
+
+import com.powsybl.dynawaltz.models.automatons.TapChangerAutomaton;
+import com.powsybl.dynawaltz.models.automatons.TapChangerBlockingAutomaton;
+import com.powsybl.dynawaltz.models.loads.LoadOneTransformer;
+import com.powsybl.iidm.network.Bus;
+import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ */
+class EmptyTapChangerBlockingAutomatonXmlTest extends AbstractDynamicModelXmlTest {
+
+    @Override
+    protected void setupNetwork() {
+        network = EurostagTutorialExample1Factory.create();
+        VoltageLevel vlload = network.getVoltageLevel("VLLOAD");
+        Bus nload = network.getBusBreakerView().getBus("NLOAD");
+        vlload.newLoad().setId("LOAD2").setBus(nload.getId()).setConnectableBus(nload.getId()).setP0(600.0).setQ0(200.0).add();
+    }
+
+    @Override
+    protected void addDynamicModels() {
+        dynamicModels.add(new LoadOneTransformer("BBM_LOAD", network.getLoad("LOAD"), "lot"));
+        dynamicModels.add(new TapChangerBlockingAutomaton("BBM_TapChangerBlocking", "TapChangerPar",
+                Collections.emptyList(),
+                List.of(network.getLoad("LOAD")),
+                List.of("GEN", "LOAD", "BBM_TC"),
+                List.of(network.getBusBreakerView().getBus("NHV1"))));
+        dynamicModels.add(new TapChangerAutomaton("BBM_TC", "tc", network.getLoad("LOAD2")));
+    }
+
+    @Test
+    void writeModel() throws SAXException, IOException, XMLStreamException {
+        DydXml.write(tmpDir, context);
+        ParametersXml.write(tmpDir, context);
+        validate("dyd.xsd", "tap_changer_blocking_empty_dyd.xml", tmpDir.resolve(DynaWaltzConstants.DYD_FILENAME));
+    }
+}

--- a/dynawaltz/src/test/resources/tap_changer_blocking_empty_dyd.xml
+++ b/dynawaltz/src/test/resources/tap_changer_blocking_empty_dyd.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dyn:dynamicModelsArchitecture xmlns:dyn="http://www.rte-france.com/dynawo">
+    <dyn:blackBoxModel id="BBM_LOAD" lib="LoadOneTransformer" parFile="models.par" parId="lot" staticId="LOAD">
+        <dyn:macroStaticRef id="MSR_LoadOneTransformer"/>
+    </dyn:blackBoxModel>
+    <dyn:macroConnector id="MC_LoadOneTransformer-DefaultBus">
+        <dyn:connect var1="transformer_terminal" var2="@NAME@_ACPIN"/>
+        <dyn:connect var1="transformer_switchOffSignal1" var2="@NAME@_switchOff"/>
+        <dyn:connect var1="load_switchOffSignal1" var2="@NAME@_switchOff"/>
+    </dyn:macroConnector>
+    <dyn:macroStaticReference id="MSR_LoadOneTransformer">
+        <dyn:staticRef var="transformer_P1Pu_value" staticVar="p"/>
+        <dyn:staticRef var="transformer_Q1Pu_value" staticVar="q"/>
+        <dyn:staticRef var="transformer_state" staticVar="state"/>
+    </dyn:macroStaticReference>
+    <dyn:macroConnect connector="MC_LoadOneTransformer-DefaultBus" id1="BBM_LOAD" id2="NETWORK" name2="NLOAD"/>
+</dyn:dynamicModelsArchitecture>

--- a/dynawaltz/src/test/resources/tap_changer_blocking_empty_dyd.xml
+++ b/dynawaltz/src/test/resources/tap_changer_blocking_empty_dyd.xml
@@ -4,7 +4,7 @@
         <dyn:macroStaticRef id="MSR_LoadOneTransformer"/>
     </dyn:blackBoxModel>
     <dyn:macroConnector id="MC_LoadOneTransformer-DefaultBus">
-        <dyn:connect var1="transformer_terminal" var2="@NAME@_ACPIN"/>
+        <dyn:connect var1="transformer_terminal1" var2="@NAME@_ACPIN"/>
         <dyn:connect var1="transformer_switchOffSignal1" var2="@NAME@_switchOff"/>
         <dyn:connect var1="load_switchOffSignal1" var2="@NAME@_switchOff"/>
     </dyn:macroConnector>

--- a/dynawaltz/src/test/resources/tap_changer_empty_dyd.xml
+++ b/dynawaltz/src/test/resources/tap_changer_empty_dyd.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dyn:dynamicModelsArchitecture xmlns:dyn="http://www.rte-france.com/dynawo">
+    <dyn:blackBoxModel id="BBM_LOAD" lib="LoadAlphaBeta" parFile="models.par" parId="LAB" staticId="LOAD">
+        <dyn:macroStaticRef id="MSR_LoadAlphaBeta"/>
+    </dyn:blackBoxModel>
+    <dyn:macroConnector id="MC_LoadAlphaBeta-DefaultBus">
+        <dyn:connect var1="load_terminal" var2="@NAME@_ACPIN"/>
+        <dyn:connect var1="load_switchOffSignal1" var2="@NAME@_switchOff"/>
+    </dyn:macroConnector>
+    <dyn:macroStaticReference id="MSR_LoadAlphaBeta">
+        <dyn:staticRef var="load_PPu" staticVar="p"/>
+        <dyn:staticRef var="load_QPu" staticVar="q"/>
+        <dyn:staticRef var="load_state" staticVar="state"/>
+    </dyn:macroStaticReference>
+    <dyn:macroConnect connector="MC_LoadAlphaBeta-DefaultBus" id1="BBM_LOAD" id2="NETWORK" name2="NLOAD"/>
+</dyn:dynamicModelsArchitecture>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the new behavior (if this is a feature change)?**
For TapChanger and TapChangerBlocking automatons : skip the automaton if none of equipments linked to it have the expected properties

