### PR TITLE
Add dynawaltz parameter options : dump file export and use as input

### DIFF
--- a/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/ieee/AbstractIeeeTest.java
+++ b/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/ieee/AbstractIeeeTest.java
@@ -98,7 +98,8 @@ public abstract class AbstractIeeeTest {
         dynaWaltzParameters.setModelsParameters(ParametersXml.load(getClass().getResourceAsStream(parametersFile)))
                 .setNetworkParameters(ParametersXml.load(getClass().getResourceAsStream(networkParametersFile), networkParametersId))
                 .setSolverParameters(ParametersXml.load(getClass().getResourceAsStream(solverParametersFile), solverParametersId))
-                .setSolverType(DynaWaltzParameters.SolverType.IDA);
+                .setSolverType(DynaWaltzParameters.SolverType.IDA)
+                .setDefaultDumpFileParameters();
     }
 
     protected DynaWaltzParameters getDynaWaltzSimulationParameters(DynamicSimulationParameters parameters) {

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DumpFileParameters.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DumpFileParameters.java
@@ -36,6 +36,18 @@ public record DumpFileParameters(boolean exportDumpFile, boolean useDumpFile, Pa
         return new DumpFileParameters(DEFAULT_EXPORT_DUMP, DEFAULT_USE_DUMP, null, DEFAULT_DUMP_NAME);
     }
 
+    public static DumpFileParameters createExportDumpFileParameters(Path dumpFileFolder) {
+        return new DumpFileParameters(true, false, dumpFileFolder, null);
+    }
+
+    public static DumpFileParameters createImportDumpFileParameters(Path dumpFileFolder, String dumpFile) {
+        return new DumpFileParameters(false, true, dumpFileFolder, dumpFile);
+    }
+
+    public static DumpFileParameters createImportExportDumpFileParameters(Path dumpFileFolder, String dumpFile) {
+        return new DumpFileParameters(true, true, dumpFileFolder, dumpFile);
+    }
+
     public Path getDumpFilePath() {
         return dumpFileFolder != null ?
                 dumpFileFolder.resolve(dumpFile)

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DumpFileParameters.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DumpFileParameters.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com/)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.dynawaltz;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ */
+@JsonIgnoreProperties(value = { "dumpFilePath" })
+public record DumpFileParameters(boolean exportDumpFile, boolean useDumpFile, Path exportDumpFileFolder, String dumpFile) {
+
+    public static final boolean DEFAULT_EXPORT_DUMP = false;
+    public static final boolean DEFAULT_USE_DUMP = false;
+    public static final String DEFAULT_DUMP_FOLDER = null;
+    public static final String DEFAULT_DUMP_NAME = null;
+
+    public DumpFileParameters {
+        if (useDumpFile) {
+            Objects.requireNonNull(exportDumpFileFolder);
+            Objects.requireNonNull(dumpFile);
+        } else if (exportDumpFile) {
+            Objects.requireNonNull(exportDumpFileFolder);
+        }
+    }
+
+    public static DumpFileParameters createDefaultDumpFileParameters() {
+        return new DumpFileParameters(DEFAULT_EXPORT_DUMP, DEFAULT_USE_DUMP, null, DEFAULT_DUMP_NAME);
+    }
+
+    public Path getDumpFilePath() {
+        return exportDumpFileFolder != null ?
+                exportDumpFileFolder.resolve(dumpFile)
+                : null;
+    }
+}

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DumpFileParameters.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DumpFileParameters.java
@@ -13,7 +13,7 @@ import java.nio.file.Path;
 import java.util.Objects;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @JsonIgnoreProperties(value = { "dumpFilePath" })
 public record DumpFileParameters(boolean exportDumpFile, boolean useDumpFile, Path dumpFileFolder, String dumpFile) {

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DumpFileParameters.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DumpFileParameters.java
@@ -16,7 +16,7 @@ import java.util.Objects;
  * @author Laurent Issertial <laurent.issertial at rte-france.com>
  */
 @JsonIgnoreProperties(value = { "dumpFilePath" })
-public record DumpFileParameters(boolean exportDumpFile, boolean useDumpFile, Path exportDumpFileFolder, String dumpFile) {
+public record DumpFileParameters(boolean exportDumpFile, boolean useDumpFile, Path dumpFileFolder, String dumpFile) {
 
     public static final boolean DEFAULT_EXPORT_DUMP = false;
     public static final boolean DEFAULT_USE_DUMP = false;
@@ -25,10 +25,10 @@ public record DumpFileParameters(boolean exportDumpFile, boolean useDumpFile, Pa
 
     public DumpFileParameters {
         if (useDumpFile) {
-            Objects.requireNonNull(exportDumpFileFolder);
+            Objects.requireNonNull(dumpFileFolder);
             Objects.requireNonNull(dumpFile);
         } else if (exportDumpFile) {
-            Objects.requireNonNull(exportDumpFileFolder);
+            Objects.requireNonNull(dumpFileFolder);
         }
     }
 
@@ -37,8 +37,8 @@ public record DumpFileParameters(boolean exportDumpFile, boolean useDumpFile, Pa
     }
 
     public Path getDumpFilePath() {
-        return exportDumpFileFolder != null ?
-                exportDumpFileFolder.resolve(dumpFile)
+        return dumpFileFolder != null ?
+                dumpFileFolder.resolve(dumpFile)
                 : null;
     }
 }

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzParameters.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzParameters.java
@@ -8,14 +8,13 @@ package com.powsybl.dynawaltz;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.config.ModuleConfig;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.dynamicsimulation.DynamicSimulationParameters;
 import com.powsybl.dynawaltz.parameters.ParametersSet;
 import com.powsybl.dynawaltz.xml.ParametersXml;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -40,8 +39,6 @@ public class DynaWaltzParameters extends AbstractExtension<DynamicSimulationPara
     public static final String NETWORK_OUTPUT_PARAMETERS_FILE = "network.par";
     public static final String SOLVER_OUTPUT_PARAMETERS_FILE = "solvers.par";
     private static final boolean DEFAULT_WRITE_FINAL_STATE = true;
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(DynaWaltzParameters.class);
 
     public enum SolverType {
         SIM,
@@ -111,14 +108,12 @@ public class DynaWaltzParameters extends AbstractExtension<DynamicSimulationPara
         Path exportDumpFileFolderPath = exportDumpFileFolder != null ? fileSystem.getPath(exportDumpFileFolder) : null;
         boolean exportFolderNotFound = exportDumpFileFolderPath == null || !Files.exists(exportDumpFileFolderPath);
         if (exportDumpFile && exportFolderNotFound) {
-            LOGGER.warn("Folder {} set in 'exportDumpFileFolder' property cannot be found, exportDumpFile property will be set to false ", exportDumpFileFolder);
-            exportDumpFile = false;
+            throw new PowsyblException("Folder " + exportDumpFileFolder + " set in 'exportDumpFileFolder' property not be found");
         }
         boolean useDumpFile = config.flatMap(c -> c.getOptionalBooleanProperty("dump.useAsInput")).orElse(DumpFileParameters.DEFAULT_USE_DUMP);
         String dumpFile = config.flatMap(c -> c.getOptionalStringProperty("dump.fileName")).orElse(DumpFileParameters.DEFAULT_DUMP_NAME);
         if (useDumpFile && (exportFolderNotFound || dumpFile == null || !Files.exists(exportDumpFileFolderPath.resolve(dumpFile)))) {
-            LOGGER.warn("File {} set in 'dumpFile' property cannot be found, useDumpFile property will be set to false ", dumpFile);
-            useDumpFile = false;
+            throw new PowsyblException("File " + dumpFile + " set in 'dumpFile' property not be found");
         }
 
         DumpFileParameters dumpFileParameters = new DumpFileParameters(exportDumpFile, useDumpFile, exportDumpFileFolderPath, dumpFile);

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzParameters.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzParameters.java
@@ -108,12 +108,12 @@ public class DynaWaltzParameters extends AbstractExtension<DynamicSimulationPara
         Path exportDumpFileFolderPath = exportDumpFileFolder != null ? fileSystem.getPath(exportDumpFileFolder) : null;
         boolean exportFolderNotFound = exportDumpFileFolderPath == null || !Files.exists(exportDumpFileFolderPath);
         if (exportDumpFile && exportFolderNotFound) {
-            throw new PowsyblException("Folder " + exportDumpFileFolder + " set in 'exportDumpFileFolder' property not be found");
+            throw new PowsyblException("Folder " + exportDumpFileFolder + " set in 'dumpFileFolder' property cannot be found");
         }
         boolean useDumpFile = config.flatMap(c -> c.getOptionalBooleanProperty("dump.useAsInput")).orElse(DumpFileParameters.DEFAULT_USE_DUMP);
         String dumpFile = config.flatMap(c -> c.getOptionalStringProperty("dump.fileName")).orElse(DumpFileParameters.DEFAULT_DUMP_NAME);
         if (useDumpFile && (exportFolderNotFound || dumpFile == null || !Files.exists(exportDumpFileFolderPath.resolve(dumpFile)))) {
-            throw new PowsyblException("File " + dumpFile + " set in 'dumpFile' property not be found");
+            throw new PowsyblException("File " + dumpFile + " set in 'dumpFile' property cannot be found");
         }
 
         DumpFileParameters dumpFileParameters = new DumpFileParameters(exportDumpFile, useDumpFile, exportDumpFileFolderPath, dumpFile);

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzProvider.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzProvider.java
@@ -223,7 +223,7 @@ public class DynaWaltzProvider implements DynamicSimulationProvider {
                 DumpFileParameters dumpFileParameters = context.getDynaWaltzParameters().getDumpFileParameters();
                 if (dumpFileParameters.useDumpFile()) {
                     Path dumpFilePath = dumpFileParameters.getDumpFilePath();
-                    if(dumpFilePath != null) {
+                    if (dumpFilePath != null) {
                         Files.copy(dumpFilePath, workingDir.resolve(dumpFileParameters.dumpFile()), StandardCopyOption.REPLACE_EXISTING);
                     }
                 }

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzProvider.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzProvider.java
@@ -193,7 +193,7 @@ public class DynaWaltzProvider implements DynamicSimulationProvider {
             if (dumpFileParameters.exportDumpFile()) {
                 Path outputDumpFile = workingDir.resolve(OUTPUTS_FOLDER).resolve(FINAL_STATE_FOLDER).resolve(OUTPUT_DUMP_FILENAME);
                 if (Files.exists(outputDumpFile)) {
-                    Files.copy(outputDumpFile, dumpFileParameters.exportDumpFileFolder().resolve(workingDir.getFileName() + "_" + OUTPUT_DUMP_FILENAME), StandardCopyOption.REPLACE_EXISTING);
+                    Files.copy(outputDumpFile, dumpFileParameters.dumpFileFolder().resolve(workingDir.getFileName() + "_" + OUTPUT_DUMP_FILENAME), StandardCopyOption.REPLACE_EXISTING);
                 } else {
                     LOGGER.warn("Dump file {} not found, export will be skipped", OUTPUT_DUMP_FILENAME);
                 }

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/JobsXml.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/JobsXml.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.dynawaltz.xml;
 
+import com.powsybl.dynawaltz.DumpFileParameters;
 import com.powsybl.dynawaltz.DynaWaltzContext;
 import com.powsybl.dynawaltz.DynaWaltzParameters;
 import com.powsybl.dynawaltz.DynaWaltzParameters.SolverType;
@@ -65,6 +66,12 @@ public final class JobsXml {
         writer.writeEmptyElement(DYN_URI, "dynModels");
         writer.writeAttribute("dydFile", DYD_FILENAME);
 
+        DumpFileParameters dumpFileParameters = parameters.getDumpFileParameters();
+        if (dumpFileParameters.useDumpFile()) {
+            writer.writeEmptyElement(DYN_URI, "initialState");
+            writer.writeAttribute("file", dumpFileParameters.dumpFile());
+        }
+
         writer.writeEmptyElement(DYN_URI, "precompiledModels");
         writer.writeAttribute("useStandardModels", "true");
 
@@ -93,7 +100,7 @@ public final class JobsXml {
 
         writer.writeEmptyElement(DYN_URI, "finalState");
         writer.writeAttribute("exportIIDMFile", Boolean.toString(context.getDynaWaltzParameters().isWriteFinalState()));
-        writer.writeAttribute("exportDumpFile", "false");
+        writer.writeAttribute("exportDumpFile", Boolean.toString(context.getDynaWaltzParameters().getDumpFileParameters().exportDumpFile()));
 
         if (context.withCurves()) {
             writer.writeEmptyElement(DYN_URI, "curves");

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzParametersTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzParametersTest.java
@@ -217,13 +217,8 @@ class DynaWaltzParametersTest extends AbstractConverterTest {
         String folderProperty = USER_HOME + "wrongFolder";
         String fileProperty = "dumpFile.dmp";
         initDumpFilePlatformConfig(folderProperty, fileProperty);
-        DynaWaltzParameters parameters = DynaWaltzParameters.load(platformConfig, fileSystem);
-        DumpFileParameters dumpFileParameters = parameters.getDumpFileParameters();
-
-        assertFalse(dumpFileParameters.exportDumpFile());
-        assertFalse(dumpFileParameters.useDumpFile());
-        assertEquals(folderProperty, dumpFileParameters.exportDumpFileFolder().toString());
-        assertEquals(fileProperty, dumpFileParameters.dumpFile());
+        PowsyblException e = assertThrows(PowsyblException.class, () -> DynaWaltzParameters.load(platformConfig, fileSystem));
+        assertEquals("Folder /home/user/wrongFolder set in 'exportDumpFileFolder' property not be found", e.getMessage());
     }
 
     @Test
@@ -231,13 +226,8 @@ class DynaWaltzParametersTest extends AbstractConverterTest {
         String folderProperty = USER_HOME + "dumpFiles";
         String fileProperty = "wrongFile.dmp";
         initDumpFilePlatformConfig(folderProperty, fileProperty);
-        DynaWaltzParameters parameters = DynaWaltzParameters.load(platformConfig, fileSystem);
-        DumpFileParameters dumpFileParameters = parameters.getDumpFileParameters();
-
-        assertTrue(dumpFileParameters.exportDumpFile());
-        assertFalse(dumpFileParameters.useDumpFile());
-        assertEquals(folderProperty, dumpFileParameters.exportDumpFileFolder().toString());
-        assertEquals(fileProperty, dumpFileParameters.dumpFile());
+        PowsyblException e = assertThrows(PowsyblException.class, () -> DynaWaltzParameters.load(platformConfig, fileSystem));
+        assertEquals("File wrongFile.dmp set in 'dumpFile' property not be found", e.getMessage());
     }
 
     private static void checkModelParameters(DynaWaltzParameters dynaWaltzParameters) {

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzParametersTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzParametersTest.java
@@ -99,7 +99,7 @@ class DynaWaltzParametersTest extends AbstractConverterTest {
 
         assertTrue(dumpFileParameters.exportDumpFile());
         assertTrue(dumpFileParameters.useDumpFile());
-        assertEquals(folderProperty, dumpFileParameters.exportDumpFileFolder().toString());
+        assertEquals(folderProperty, dumpFileParameters.dumpFileFolder().toString());
         assertEquals(fileProperty, dumpFileParameters.dumpFile());
     }
 
@@ -192,7 +192,7 @@ class DynaWaltzParametersTest extends AbstractConverterTest {
         DumpFileParameters dumpFileParameters = parameters.getDumpFileParameters();
         assertEquals(DumpFileParameters.DEFAULT_EXPORT_DUMP, dumpFileParameters.exportDumpFile());
         assertEquals(DumpFileParameters.DEFAULT_USE_DUMP, dumpFileParameters.useDumpFile());
-        assertNull(dumpFileParameters.exportDumpFileFolder());
+        assertNull(dumpFileParameters.dumpFileFolder());
         assertEquals(DumpFileParameters.DEFAULT_DUMP_NAME, dumpFileParameters.dumpFile());
     }
 
@@ -218,7 +218,7 @@ class DynaWaltzParametersTest extends AbstractConverterTest {
         String fileProperty = "dumpFile.dmp";
         initDumpFilePlatformConfig(folderProperty, fileProperty);
         PowsyblException e = assertThrows(PowsyblException.class, () -> DynaWaltzParameters.load(platformConfig, fileSystem));
-        assertEquals("Folder /home/user/wrongFolder set in 'exportDumpFileFolder' property not be found", e.getMessage());
+        assertEquals("Folder /home/user/wrongFolder set in 'dumpFileFolder' property cannot be found", e.getMessage());
     }
 
     @Test
@@ -227,7 +227,7 @@ class DynaWaltzParametersTest extends AbstractConverterTest {
         String fileProperty = "wrongFile.dmp";
         initDumpFilePlatformConfig(folderProperty, fileProperty);
         PowsyblException e = assertThrows(PowsyblException.class, () -> DynaWaltzParameters.load(platformConfig, fileSystem));
-        assertEquals("File wrongFile.dmp set in 'dumpFile' property not be found", e.getMessage());
+        assertEquals("File wrongFile.dmp set in 'dumpFile' property cannot be found", e.getMessage());
     }
 
     private static void checkModelParameters(DynaWaltzParameters dynaWaltzParameters) {

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzProviderTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzProviderTest.java
@@ -110,6 +110,30 @@ class DynaWaltzProviderTest extends AbstractConverterTest {
     }
 
     @Test
+    void testWithDump() throws Exception {
+        Path folderPath = tmpDir.resolve("dumpFiles");
+        Files.createDirectory(folderPath);
+        String fileProperty = "dumpFile.dmp";
+        Files.createFile(folderPath.resolve(fileProperty));
+
+        Network network = createTestNetwork();
+        LocalCommandExecutor commandExecutor = new LocalCommandExecutorMock("/dynawo_version.out", "/noMergedLoads.xiidm");
+        ComputationManager computationManager = new LocalComputationManager(new LocalComputationConfig(tmpDir, 1), commandExecutor, ForkJoinPool.commonPool());
+        DynamicSimulation.Runner dynawoSimulation = DynamicSimulation.find();
+        DynamicSimulationParameters dynamicSimulationParameters = DynamicSimulationParameters.load();
+        DynaWaltzParameters dynaWaltzParameters = DynaWaltzParameters.load()
+                .setMergeLoads(false)
+                .setDumpFileParameters(new DumpFileParameters(true, true, folderPath, fileProperty));
+        dynamicSimulationParameters.addExtension(DynaWaltzParameters.class, dynaWaltzParameters);
+
+        assertEquals(DynaWaltzProvider.NAME, dynawoSimulation.getName());
+        DynamicSimulationResult result = dynawoSimulation.run(network, n -> Collections.emptyList(), EventModelsSupplier.empty(),
+                CurvesSupplier.empty(), network.getVariantManager().getWorkingVariantId(),
+                computationManager, dynamicSimulationParameters);
+        assertNotNull(result);
+    }
+
+    @Test
     void testFail() throws Exception {
         Network network = createTestNetwork();
         LocalCommandExecutor commandExecutor = new LocalCommandExecutorMock("/dynawo_version.out", null);

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzProviderTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzProviderTest.java
@@ -124,7 +124,7 @@ class DynaWaltzProviderTest extends AbstractConverterTest {
         DynamicSimulationParameters dynamicSimulationParameters = DynamicSimulationParameters.load();
         DynaWaltzParameters dynaWaltzParameters = DynaWaltzParameters.load()
                 .setMergeLoads(false)
-                .setDumpFileParameters(new DumpFileParameters(true, true, folderPath, fileProperty));
+                .setDumpFileParameters(DumpFileParameters.createImportExportDumpFileParameters(folderPath, fileProperty));
         dynamicSimulationParameters.addExtension(DynaWaltzParameters.class, dynaWaltzParameters);
 
         assertEquals(DynaWaltzProvider.NAME, dynawoSimulation.getName());

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/JobsXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/JobsXmlTest.java
@@ -36,7 +36,7 @@ class JobsXmlTest extends DynaWaltzTestUtil {
     void writeJobWithDumpFile() throws SAXException, IOException, XMLStreamException {
         DynamicSimulationParameters parameters = DynamicSimulationParameters.load();
         DynaWaltzParameters dynawoParameters = DynaWaltzParameters.load()
-                .setDumpFileParameters(new DumpFileParameters(true, true, Path.of("/dumpFiles"), "dump.dmp"));
+                .setDumpFileParameters(DumpFileParameters.createImportExportDumpFileParameters(Path.of("/dumpFiles"), "dump.dmp"));
         DynaWaltzContext context = new DynaWaltzContext(network, network.getVariantManager().getWorkingVariantId(), dynamicModels, eventModels, curves, parameters, dynawoParameters);
 
         JobsXml.write(tmpDir, context);

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/JobsXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/JobsXmlTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.dynawaltz.xml;
 
 import com.powsybl.dynamicsimulation.DynamicSimulationParameters;
+import com.powsybl.dynawaltz.DumpFileParameters;
 import com.powsybl.dynawaltz.DynaWaltzContext;
 import com.powsybl.dynawaltz.DynaWaltzParameters;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import org.xml.sax.SAXException;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * @author Marcos de Miguel <demiguelm at aia.es>
@@ -28,6 +30,17 @@ class JobsXmlTest extends DynaWaltzTestUtil {
 
         JobsXml.write(tmpDir, context);
         validate("jobs.xsd", "jobs.xml", tmpDir.resolve(DynaWaltzConstants.JOBS_FILENAME));
+    }
+
+    @Test
+    void writeJobWithDumpFile() throws SAXException, IOException, XMLStreamException {
+        DynamicSimulationParameters parameters = DynamicSimulationParameters.load();
+        DynaWaltzParameters dynawoParameters = DynaWaltzParameters.load()
+                .setDumpFileParameters(new DumpFileParameters(true, true, Path.of("/dumpFiles"), "dump.dmp"));
+        DynaWaltzContext context = new DynaWaltzContext(network, network.getVariantManager().getWorkingVariantId(), dynamicModels, eventModels, curves, parameters, dynawoParameters);
+
+        JobsXml.write(tmpDir, context);
+        validate("jobs.xsd", "jobsWithDump.xml", tmpDir.resolve(DynaWaltzConstants.JOBS_FILENAME));
     }
 
 }

--- a/dynawaltz/src/test/resources/DynaWaltzParameters.json
+++ b/dynawaltz/src/test/resources/DynaWaltzParameters.json
@@ -42,7 +42,7 @@
       "dumpFileParameters" : {
         "exportDumpFile" : false,
         "useDumpFile" : false,
-        "exportDumpFileFolder" : null,
+        "dumpFileFolder" : null,
         "dumpFile" : null
       },
       "modelsParameters" : [ {

--- a/dynawaltz/src/test/resources/DynaWaltzParameters.json
+++ b/dynawaltz/src/test/resources/DynaWaltzParameters.json
@@ -39,6 +39,12 @@
       "solverType" : "IDA",
       "mergeLoads" : false,
       "writeFinalState" : true,
+      "dumpFileParameters" : {
+        "exportDumpFile" : false,
+        "useDumpFile" : false,
+        "exportDumpFileFolder" : null,
+        "dumpFile" : null
+      },
       "modelsParameters" : [ {
         "id" : "test",
         "parameters" : {

--- a/dynawaltz/src/test/resources/jobsWithDump.xml
+++ b/dynawaltz/src/test/resources/jobsWithDump.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dyn:jobs xmlns:dyn="http://www.rte-france.com/dynawo">
+    <dyn:job name="Job">
+        <dyn:solver lib="dynawo_SolverIDA" parFile="solvers.par" parId="1"/>
+        <dyn:modeler compileDir="outputs/compilation">
+            <dyn:network iidmFile="powsybl_dynawaltz.xiidm" parFile="network.par" parId="1"/>
+            <dyn:dynModels dydFile="powsybl_dynawaltz.dyd"/>
+            <dyn:initialState file="dump.dmp"/>
+            <dyn:precompiledModels useStandardModels="true"/>
+            <dyn:modelicaModels useStandardModels="false"/>
+        </dyn:modeler>
+        <dyn:simulation startTime="1" stopTime="100"/>
+        <dyn:outputs directory="outputs">
+            <dyn:dumpInitValues local="false" global="false"/>
+            <dyn:timeline exportMode="TXT"/>
+            <dyn:finalState exportIIDMFile="true" exportDumpFile="true"/>
+            <dyn:curves inputFile="powsybl_dynawaltz.crv" exportMode="CSV"/>
+            <dyn:logs>
+                <dyn:appender tag="" file="dynawaltz.log" lvlFilter="DEBUG"/>
+            </dyn:logs>
+        </dyn:outputs>
+    </dyn:job>
+</dyn:jobs>

--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynaWaltzTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynaWaltzTest.java
@@ -133,7 +133,7 @@ class DynaWaltzTest extends AbstractDynawoTest {
         //Use exported dump as input
         parameters.setStartTime(30);
         parameters.setStopTime(100);
-        try(Stream<Path> stream = Files.list(dumpDir)) {
+        try (Stream<Path> stream = Files.list(dumpDir)) {
             dumpFile = stream.findFirst().orElseThrow();
         }
         dumpFileParameters = new DumpFileParameters(false, true, dumpDir, dumpFile.getFileName().toString());

--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynaWaltzTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynaWaltzTest.java
@@ -72,7 +72,8 @@ class DynaWaltzTest extends AbstractDynawoTest {
         dynaWaltzParameters.setModelsParameters(modelsParameters)
                 .setNetworkParameters(networkParameters)
                 .setSolverParameters(solverParameters)
-                .setSolverType(DynaWaltzParameters.SolverType.IDA);
+                .setSolverType(DynaWaltzParameters.SolverType.IDA)
+                .setDefaultDumpFileParameters();
 
         DynamicSimulationResult result = provider.run(network, dynamicModelsSupplier, eventModelsSupplier, curvesSupplier,
                         VariantManagerConstants.INITIAL_VARIANT_ID, computationManager, parameters)
@@ -102,7 +103,8 @@ class DynaWaltzTest extends AbstractDynawoTest {
         dynaWaltzParameters.setModelsParameters(modelsParameters)
                 .setNetworkParameters(networkParameters)
                 .setSolverParameters(solverParameters)
-                .setSolverType(DynaWaltzParameters.SolverType.IDA);
+                .setSolverType(DynaWaltzParameters.SolverType.IDA)
+                .setDefaultDumpFileParameters();
 
         DynamicSimulationResult result = provider.run(network, dynamicModelsSupplier, EventModelsSupplier.empty(), CurvesSupplier.empty(),
                         VariantManagerConstants.INITIAL_VARIANT_ID, computationManager, parameters)
@@ -129,7 +131,8 @@ class DynaWaltzTest extends AbstractDynawoTest {
         dynaWaltzParameters.setModelsParameters(modelsParameters)
                 .setNetworkParameters(networkParameters)
                 .setSolverParameters(solverParameters)
-                .setSolverType(DynaWaltzParameters.SolverType.IDA);
+                .setSolverType(DynaWaltzParameters.SolverType.IDA)
+                .setDefaultDumpFileParameters();
 
         DynamicSimulationResult result = provider.run(network, dynamicModelsSupplier, EventModelsSupplier.empty(), CurvesSupplier.empty(),
                         VariantManagerConstants.INITIAL_VARIANT_ID, computationManager, parameters)
@@ -165,7 +168,8 @@ class DynaWaltzTest extends AbstractDynawoTest {
                 .setNetworkParameters(networkParameters)
                 .setSolverParameters(solverParameters)
                 .setSolverType(DynaWaltzParameters.SolverType.IDA)
-                .setWriteFinalState(false);
+                .setWriteFinalState(false)
+                .setDefaultDumpFileParameters();
 
         DynamicSimulationResult result = provider.run(network, dynamicModelsSupplier, eventModelsSupplier, curvesSupplier,
                         VariantManagerConstants.INITIAL_VARIANT_ID, computationManager, parameters)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #253


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**
Add 4 dynawaltz parameters 
    dump.export: export the dump in the export folder at the end of a simulation  
    dump.exportFolder: the folder were the dumps are stored
    dump.useAsInput: use a dump stored in the export folder at the start of a simulation
    dump.fileName: dump used as input


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
