### PR TITLE
Add literal annotation in author's email address

### DIFF
--- a/commons/src/main/java-templates/PowsyblDynawoVersion.java
+++ b/commons/src/main/java-templates/PowsyblDynawoVersion.java
@@ -12,7 +12,7 @@ import com.powsybl.tools.AbstractVersion;
 import com.powsybl.tools.Version;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(Version.class)
 public class PowsyblDynawoVersion extends AbstractVersion {

--- a/commons/src/main/java/com/powsybl/dynawo/commons/DynawoConstants.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/DynawoConstants.java
@@ -12,7 +12,7 @@ import com.powsybl.iidm.xml.IidmXmlVersion;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class DynawoConstants {
 

--- a/commons/src/main/java/com/powsybl/dynawo/commons/DynawoUtil.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/DynawoUtil.java
@@ -24,7 +24,7 @@ import static com.powsybl.dynawo.commons.DynawoConstants.IIDM_EXTENSIONS;
 import static com.powsybl.dynawo.commons.DynawoConstants.IIDM_VERSION;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class DynawoUtil {
 

--- a/commons/src/main/java/com/powsybl/dynawo/commons/DynawoVersion.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/DynawoVersion.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class DynawoVersion implements Comparable<DynawoVersion> {
 

--- a/commons/src/main/java/com/powsybl/dynawo/commons/NetworkResultsUpdater.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/NetworkResultsUpdater.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * @author Guillem Jané Guasch <janeg at aia.es>
+ * @author Guillem Jané Guasch {@literal <janeg at aia.es>}
  */
 public final class NetworkResultsUpdater {
 

--- a/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadPowersSigns.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadPowersSigns.java
@@ -8,7 +8,7 @@
 package com.powsybl.dynawo.commons.loadmerge;
 
 /**
- * @author Laurent Isertial <laurent.issertial at rte-france.com>
+ * @author Laurent Isertial {@literal <laurent.issertial at rte-france.com>}
  */
 public enum LoadPowersSigns {
     P_POS_Q_POS(".pppq"),

--- a/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsMerger.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsMerger.java
@@ -23,9 +23,9 @@ import java.util.stream.Stream;
 import static com.powsybl.dynawo.commons.loadmerge.LoadPowersSigns.*;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Laurent Isertial <laurent.issertial at rte-france.com>
- * @author Dimitri Baudrier <dimitri.baudrier at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Laurent Isertial {@literal <laurent.issertial at rte-france.com>}
+ * @author Dimitri Baudrier {@literal <dimitri.baudrier at rte-france.com>}
  */
 public final class LoadsMerger {
 

--- a/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsToMerge.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/loadmerge/LoadsToMerge.java
@@ -12,7 +12,7 @@ import com.powsybl.iidm.network.*;
 import java.util.List;
 
 /**
- * @author Laurent Isertial <laurent.issertial at rte-france.com>
+ * @author Laurent Isertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class LoadsToMerge {
     private static final String MERGE_LOAD_PREFIX_ID = "merged_load_.";

--- a/commons/src/main/java/com/powsybl/dynawo/commons/timeline/CsvTimeLineParser.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/timeline/CsvTimeLineParser.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public final class CsvTimeLineParser implements TimeLineParser {
 

--- a/commons/src/main/java/com/powsybl/dynawo/commons/timeline/TimeLineParser.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/timeline/TimeLineParser.java
@@ -11,7 +11,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public interface TimeLineParser {
     List<TimelineEntry> parse(Path timeLineFile);

--- a/commons/src/main/java/com/powsybl/dynawo/commons/timeline/TimeLineUtil.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/timeline/TimeLineUtil.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Optional;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public final class TimeLineUtil {
 

--- a/commons/src/main/java/com/powsybl/dynawo/commons/timeline/TimelineEntry.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/timeline/TimelineEntry.java
@@ -8,8 +8,8 @@
 package com.powsybl.dynawo.commons.timeline;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public record TimelineEntry(double time, String modelName, String message) {
 

--- a/commons/src/main/java/com/powsybl/dynawo/commons/timeline/XmlTimeLineParser.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/timeline/XmlTimeLineParser.java
@@ -27,8 +27,8 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 public final class XmlTimeLineParser implements TimeLineParser {
 

--- a/commons/src/test/java/com/powsybl/dynawo/commons/AbstractDynawoCommonsTest.java
+++ b/commons/src/test/java/com/powsybl/dynawo/commons/AbstractDynawoCommonsTest.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 import static com.powsybl.commons.test.ComparisonUtils.compareTxt;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 abstract class AbstractDynawoCommonsTest extends AbstractConverterTest {
 

--- a/commons/src/test/java/com/powsybl/dynawo/commons/DynawoVersionTest.java
+++ b/commons/src/test/java/com/powsybl/dynawo/commons/DynawoVersionTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class DynawoVersionTest extends AbstractConverterTest {
 

--- a/commons/src/test/java/com/powsybl/dynawo/commons/LoadState.java
+++ b/commons/src/test/java/com/powsybl/dynawo/commons/LoadState.java
@@ -8,7 +8,7 @@
 package com.powsybl.dynawo.commons;
 
 /**
- * @author Laurent Isertial <laurent.issertial at rte-france.com>
+ * @author Laurent Isertial {@literal <laurent.issertial at rte-france.com>}
  */
 public record LoadState(double p, double q, double p0, double q0) {
 

--- a/commons/src/test/java/com/powsybl/dynawo/commons/LoadsMergerTest.java
+++ b/commons/src/test/java/com/powsybl/dynawo/commons/LoadsMergerTest.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class LoadsMergerTest extends AbstractDynawoCommonsTest {
 

--- a/commons/src/test/java/com/powsybl/dynawo/commons/NetworkResultsUpdaterTest.java
+++ b/commons/src/test/java/com/powsybl/dynawo/commons/NetworkResultsUpdaterTest.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 /**
- * @author Guillem Jané Guasch <janeg at aia.es>
+ * @author Guillem Jané Guasch {@literal <janeg at aia.es>}
  */
 class NetworkResultsUpdaterTest extends AbstractDynawoCommonsTest {
 

--- a/commons/src/test/java/com/powsybl/dynawo/commons/TestNetworkFactory.java
+++ b/commons/src/test/java/com/powsybl/dynawo/commons/TestNetworkFactory.java
@@ -13,7 +13,7 @@ import org.joda.time.DateTime;
 import java.util.List;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public final class TestNetworkFactory {
 

--- a/commons/src/test/java/com/powsybl/dynawo/commons/timeline/CsvTimeLineParserTest.java
+++ b/commons/src/test/java/com/powsybl/dynawo/commons/timeline/CsvTimeLineParserTest.java
@@ -21,8 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 class CsvTimeLineParserTest {
 

--- a/commons/src/test/java/com/powsybl/dynawo/commons/timeline/XmlTimeLineParserTest.java
+++ b/commons/src/test/java/com/powsybl/dynawo/commons/timeline/XmlTimeLineParserTest.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 class XmlTimeLineParserTest {
 

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowConfig.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowConfig.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Guillaume Pernin <guillaume.pernin at rte-france.com>
+ * @author Guillaume Pernin {@literal <guillaume.pernin at rte-france.com>}
  */
 public class DynaFlowConfig {
 

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowConstants.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowConstants.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
- * @author Guillaume Pernin <guillaume.pernin at rte-france.com>
+ * @author Guillaume Pernin {@literal <guillaume.pernin at rte-france.com>}
  */
 public final class DynaFlowConstants {
 

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowParameters.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowParameters.java
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
 import static com.powsybl.dynaflow.DynaFlowProvider.MODULE_SPECIFIC_PARAMETERS;
 
 /**
- * @author Guillaume Pernin <guillaume.pernin at rte-france.com>
+ * @author Guillaume Pernin {@literal <guillaume.pernin at rte-france.com>}
  */
 public class DynaFlowParameters extends AbstractExtension<LoadFlowParameters> {
 

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowProvider.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowProvider.java
@@ -41,7 +41,7 @@ import static com.powsybl.dynaflow.DynaFlowConstants.*;
 
 /**
  *
- * @author Guillaume Pernin <guillaume.pernin at rte-france.com>
+ * @author Guillaume Pernin {@literal <guillaume.pernin at rte-france.com>}
  */
 @AutoService(LoadFlowProvider.class)
 public class DynaFlowProvider implements LoadFlowProvider {

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysis.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysis.java
@@ -42,7 +42,7 @@ import static com.powsybl.dynaflow.DynaFlowConstants.CONFIG_FILENAME;
 import static com.powsybl.dynaflow.DynaFlowConstants.IIDM_FILENAME;
 
 /**
- * @author Luma Zamarreno <zamarrenolm at aia.es>
+ * @author Luma Zamarreno {@literal <zamarrenolm at aia.es>}
  */
 public class DynaFlowSecurityAnalysis {
 

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysisProvider.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysisProvider.java
@@ -28,7 +28,7 @@ import java.util.function.Supplier;
 import static com.powsybl.dynaflow.DynaFlowConstants.*;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 @AutoService(SecurityAnalysisProvider.class)
 public class DynaFlowSecurityAnalysisProvider implements SecurityAnalysisProvider {

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/Reports.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/Reports.java
@@ -13,7 +13,7 @@ import com.powsybl.commons.reporter.TypedValue;
 import com.powsybl.dynawo.commons.timeline.TimelineEntry;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public final class Reports {
     private static final String TIME_MS = "timeMsTypedValue";

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/json/DynaFlowConfigSerializer.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/json/DynaFlowConfigSerializer.java
@@ -21,7 +21,7 @@ import java.nio.file.Path;
 
 /**
  *
- * @author Guillaume Pernin <guillaume.pernin at rte-france.com>
+ * @author Guillaume Pernin {@literal <guillaume.pernin at rte-france.com>}
  */
 public final class DynaFlowConfigSerializer {
 

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/json/JsonDynaFlowParametersSerializer.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/json/JsonDynaFlowParametersSerializer.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 
 /**
  *
- * @author Guillaume Pernin <guillaume.pernin at rte-france.com>
+ * @author Guillaume Pernin {@literal <guillaume.pernin at rte-france.com>}
  */
 @AutoService(ExtensionJsonSerializer.class)
 public class JsonDynaFlowParametersSerializer implements ExtensionJsonSerializer<LoadFlowParameters, DynaFlowParameters> {

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/xml/ConstraintsReader.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/xml/ConstraintsReader.java
@@ -33,8 +33,8 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public final class ConstraintsReader {
 

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/AbstractLocalCommandExecutor.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/AbstractLocalCommandExecutor.java
@@ -16,7 +16,7 @@ import java.nio.file.StandardCopyOption;
 
 /**
  *
- * @author Guillaume Pernin <guillaume.pernin at rte-france.com>
+ * @author Guillaume Pernin {@literal <guillaume.pernin at rte-france.com>}
  */
 abstract class AbstractLocalCommandExecutor implements LocalCommandExecutor {
 

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/ConstraintsReaderTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/ConstraintsReaderTest.java
@@ -26,7 +26,7 @@ import static com.powsybl.commons.test.ComparisonUtils.compareTxt;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class ConstraintsReaderTest {
 

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowConfigTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowConfigTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  *
- * @author Guillaume Pernin <guillaume.pernin at rte-france.com>
+ * @author Guillaume Pernin {@literal <guillaume.pernin at rte-france.com>}
  */
 class DynaFlowConfigTest {
 

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowParametersTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowParametersTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
- * @author Guillaume Pernin <guillaume.pernin at rte-france.com>
+ * @author Guillaume Pernin {@literal <guillaume.pernin at rte-france.com>}
  */
 class DynaFlowParametersTest extends AbstractConverterTest {
 

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowProviderTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowProviderTest.java
@@ -36,7 +36,7 @@ import static com.powsybl.dynaflow.DynaFlowConstants.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Guillaume Pernin <guillaume.pernin at rte-france.com>
+ * @author Guillaume Pernin {@literal <guillaume.pernin at rte-france.com>}
  */
 class DynaFlowProviderTest extends AbstractConverterTest {
 

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysisTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysisTest.java
@@ -43,7 +43,7 @@ import static com.powsybl.dynaflow.DynaFlowConstants.IIDM_FILENAME;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 class DynaFlowSecurityAnalysisTest extends AbstractConverterTest {
 

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/DynawoVersionCheckTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/DynawoVersionCheckTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
- * @author Guillaume Pernin <guillaume.pernin at rte-france.com>
+ * @author Guillaume Pernin {@literal <guillaume.pernin at rte-france.com>}
  */
 class DynawoVersionCheckTest {
 

--- a/dynaflow/src/test/java/com/powsybl/dynaflow/json/JsonDynaFlowParametersSerializerTest.java
+++ b/dynaflow/src/test/java/com/powsybl/dynaflow/json/JsonDynaFlowParametersSerializerTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
- * @author Guillaume Pernin <guillaume.pernin at rte-france.com>
+ * @author Guillaume Pernin {@literal <guillaume.pernin at rte-france.com>}
  */
 class JsonDynaFlowParametersSerializerTest extends AbstractConverterTest {
 

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/AbstractEquipmentGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/AbstractEquipmentGroovyExtension.groovy
@@ -12,7 +12,7 @@ import com.powsybl.iidm.network.Network
 
 import java.util.function.Consumer
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 abstract class AbstractEquipmentGroovyExtension<T> {
 

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/AbstractPureDynamicGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/AbstractPureDynamicGroovyExtension.groovy
@@ -13,7 +13,7 @@ import com.powsybl.iidm.network.Network
 import java.util.function.Consumer
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 abstract class AbstractPureDynamicGroovyExtension<T> {
 

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/AbstractSimpleEquipmentGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/AbstractSimpleEquipmentGroovyExtension.groovy
@@ -13,7 +13,7 @@ import com.powsybl.iidm.network.Network
 import java.util.function.Consumer
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 abstract class AbstractSimpleEquipmentGroovyExtension<T> {
 

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/DslEquipment.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/DslEquipment.groovy
@@ -16,7 +16,7 @@ import java.util.function.Function
 /**
  * Represents an equipment field identified by a static ID in the groovy script
  * Verifies if the corresponding equipment with the specified type exists, log the error otherwise
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class DslEquipment<T extends Identifiable> {
 

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/DslFilteredEquipment.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/DslFilteredEquipment.groovy
@@ -16,7 +16,7 @@ import java.util.function.Predicate
 /**
  * Same as DslEquipment but the equipment type could be different subtypes of the specified T type
  * (for example a load OR a generator with T as an Injection)
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class DslFilteredEquipment<T extends Identifiable> extends DslEquipment<T> {
 

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/DynaWaltzCurveGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/DynaWaltzCurveGroovyExtension.groovy
@@ -19,7 +19,7 @@ import java.util.function.Consumer
 /**
  * An implementation of {@link CurveGroovyExtension} that adds the <pre>curve</pre> keyword to the DSL
  *
- * @author Mathieu Bague <mathieu.bague@rte-france.com>
+ * @author Mathieu Bague {@literal <mathieu.bague@rte-france.com>}
  */
 @AutoService(CurveGroovyExtension.class)
 class DynaWaltzCurveGroovyExtension implements CurveGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/EquipmentConfig.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/EquipmentConfig.groovy
@@ -8,7 +8,7 @@
 package com.powsybl.dynawaltz.dsl
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class EquipmentConfig {
 

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/ModelBuilder.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/ModelBuilder.groovy
@@ -8,7 +8,7 @@
 package com.powsybl.dynawaltz.dsl
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 interface ModelBuilder<T> {
 

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/ModelsSlurper.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/ModelsSlurper.groovy
@@ -11,7 +11,7 @@ import groovy.json.JsonSlurper
 import org.apache.groovy.json.internal.LazyMap
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @Singleton
 class ModelsSlurper {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/automatons/AbstractPhaseShifterModelBuilder.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/automatons/AbstractPhaseShifterModelBuilder.groovy
@@ -14,7 +14,7 @@ import com.powsybl.iidm.network.Network
 import com.powsybl.iidm.network.TwoWindingsTransformer
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 abstract class AbstractPhaseShifterModelBuilder extends AbstractPureDynamicModelBuilder {
 

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/automatons/CurrentLimitAutomatonGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/automatons/CurrentLimitAutomatonGroovyExtension.groovy
@@ -22,7 +22,7 @@ import com.powsybl.iidm.network.Network
 /**
  * An implementation of {@link DynamicModelGroovyExtension} that adds the <pre>CurrentLimitAutomaton</pre> keyword to the DSL
  *
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class CurrentLimitAutomatonGroovyExtension extends AbstractPureDynamicGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/automatons/CurrentLimitTwoLevelsAutomatonGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/automatons/CurrentLimitTwoLevelsAutomatonGroovyExtension.groovy
@@ -20,7 +20,7 @@ import com.powsybl.iidm.network.Branch
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class CurrentLimitTwoLevelsAutomatonGroovyExtension extends AbstractPureDynamicGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/automatons/PhaseShifterIAutomatonGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/automatons/PhaseShifterIAutomatonGroovyExtension.groovy
@@ -15,7 +15,7 @@ import com.powsybl.dynawaltz.models.automatons.phaseshifters.PhaseShifterIAutoma
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class PhaseShifterIAutomatonGroovyExtension extends AbstractPureDynamicGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/automatons/PhaseShifterPAutomatonGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/automatons/PhaseShifterPAutomatonGroovyExtension.groovy
@@ -15,7 +15,7 @@ import com.powsybl.dynawaltz.models.automatons.phaseshifters.PhaseShifterPAutoma
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class PhaseShifterPAutomatonGroovyExtension extends AbstractPureDynamicGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/automatons/TapChangerAutomatonGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/automatons/TapChangerAutomatonGroovyExtension.groovy
@@ -18,7 +18,7 @@ import com.powsybl.dynawaltz.models.automatons.TapChangerAutomaton
 import com.powsybl.iidm.network.*
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class TapChangerAutomatonGroovyExtension extends AbstractPureDynamicGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/automatons/TapChangerBlockingAutomatonGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/automatons/TapChangerBlockingAutomatonGroovyExtension.groovy
@@ -21,7 +21,7 @@ import com.powsybl.iidm.network.Network
 import com.powsybl.iidm.network.TwoWindingsTransformer
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class TapChangerBlockingAutomatonGroovyExtension extends AbstractPureDynamicGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/automatons/UnderVoltageAutomatonGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/automatons/UnderVoltageAutomatonGroovyExtension.groovy
@@ -19,7 +19,7 @@ import com.powsybl.iidm.network.IdentifiableType
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class UnderVoltageAutomatonGroovyExtension extends AbstractPureDynamicGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/builders/AbstractDynamicModelBuilder.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/builders/AbstractDynamicModelBuilder.groovy
@@ -12,7 +12,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 abstract class AbstractDynamicModelBuilder {
 

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/builders/AbstractEquipmentModelBuilder.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/builders/AbstractEquipmentModelBuilder.groovy
@@ -16,7 +16,7 @@ import com.powsybl.iidm.network.IdentifiableType
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 abstract class AbstractEquipmentModelBuilder<T extends Identifiable> extends AbstractDynamicModelBuilder implements ModelBuilder<DynamicModel> {
 

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/builders/AbstractEventModelBuilder.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/builders/AbstractEventModelBuilder.groovy
@@ -15,7 +15,7 @@ import com.powsybl.iidm.network.Identifiable
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 abstract class AbstractEventModelBuilder<T extends Identifiable> extends AbstractDynamicModelBuilder implements ModelBuilder<EventModel> {
 

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/builders/AbstractPureDynamicModelBuilder.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/builders/AbstractPureDynamicModelBuilder.groovy
@@ -12,7 +12,7 @@ import com.powsybl.dynawaltz.dsl.ModelBuilder
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 abstract class AbstractPureDynamicModelBuilder extends AbstractDynamicModelBuilder implements ModelBuilder<DynamicModel> {
 

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/events/EventActivePowerVariationGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/events/EventActivePowerVariationGroovyExtension.groovy
@@ -19,7 +19,7 @@ import com.powsybl.iidm.network.Injection
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(EventModelGroovyExtension.class)
 class EventActivePowerVariationGroovyExtension extends AbstractPureDynamicGroovyExtension<EventModel> implements EventModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/events/EventDisconnectionGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/events/EventDisconnectionGroovyExtension.groovy
@@ -24,7 +24,7 @@ import com.powsybl.iidm.network.IdentifiableType
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(EventModelGroovyExtension.class)
 class EventDisconnectionGroovyExtension extends AbstractPureDynamicGroovyExtension<EventModel> implements EventModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/events/NodeFaultEventGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/events/NodeFaultEventGroovyExtension.groovy
@@ -19,7 +19,7 @@ import com.powsybl.iidm.network.IdentifiableType
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(EventModelGroovyExtension.class)
 class NodeFaultEventGroovyExtension extends AbstractPureDynamicGroovyExtension<EventModel> implements EventModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/buses/AbstractBusBuilder.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/buses/AbstractBusBuilder.groovy
@@ -14,7 +14,7 @@ import com.powsybl.iidm.network.IdentifiableType
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 abstract class AbstractBusBuilder extends AbstractEquipmentModelBuilder<Bus> {
 

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/buses/BusGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/buses/BusGroovyExtension.groovy
@@ -18,7 +18,7 @@ import com.powsybl.iidm.network.Network
 /**
  * An implementation of {@link DynamicModelGroovyExtension} that adds the <pre>Bus</pre> keyword to the DSL
  *
- * @author Dimitri Baudrier <dimitri.baudrier at rte-france.com>
+ * @author Dimitri Baudrier {@literal <dimitri.baudrier at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class BusGroovyExtension extends AbstractSimpleEquipmentGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/buses/InfiniteBusGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/buses/InfiniteBusGroovyExtension.groovy
@@ -16,7 +16,7 @@ import com.powsybl.dynawaltz.models.buses.InfiniteBus
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class InfiniteBusGroovyExtension extends AbstractEquipmentGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/generators/AbstractGeneratorBuilder.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/generators/AbstractGeneratorBuilder.groovy
@@ -14,7 +14,7 @@ import com.powsybl.iidm.network.IdentifiableType
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 abstract class AbstractGeneratorBuilder extends AbstractEquipmentModelBuilder<Generator> {
 

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/generators/GeneratorFictitiousGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/generators/GeneratorFictitiousGroovyExtension.groovy
@@ -15,7 +15,7 @@ import com.powsybl.dynawaltz.models.generators.GeneratorFictitious
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Dimitri Baudrier <dimitri.baudrier at rte-france.com>
+ * @author Dimitri Baudrier {@literal <dimitri.baudrier at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class GeneratorFictitiousGroovyExtension extends AbstractSimpleEquipmentGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/generators/GridFormingConverterGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/generators/GridFormingConverterGroovyExtension.groovy
@@ -16,7 +16,7 @@ import com.powsybl.dynawaltz.models.generators.GridFormingConverter
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class GridFormingConverterGroovyExtension extends AbstractEquipmentGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/generators/SynchronizedGeneratorGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/generators/SynchronizedGeneratorGroovyExtension.groovy
@@ -17,8 +17,8 @@ import com.powsybl.dynawaltz.models.generators.SynchronizedGeneratorControllable
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Dimitri Baudrier <dimitri.baudrier at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Dimitri Baudrier {@literal <dimitri.baudrier at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class SynchronizedGeneratorGroovyExtension extends AbstractEquipmentGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/generators/SynchronousGeneratorGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/generators/SynchronousGeneratorGroovyExtension.groovy
@@ -18,7 +18,7 @@ import com.powsybl.dynawaltz.models.generators.SynchronousGeneratorControllable
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class SynchronousGeneratorGroovyExtension extends AbstractEquipmentGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/generators/WeccGenGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/generators/WeccGenGroovyExtension.groovy
@@ -17,7 +17,7 @@ import com.powsybl.dynawaltz.models.generators.WeccGen
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class WeccGenGroovyExtension extends AbstractEquipmentGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/hvdc/AbstractHvdcBuilder.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/hvdc/AbstractHvdcBuilder.groovy
@@ -17,7 +17,7 @@ import com.powsybl.iidm.network.IdentifiableType
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 abstract class AbstractHvdcBuilder extends AbstractEquipmentModelBuilder<HvdcLine> {
 

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/hvdc/HvdcPGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/hvdc/HvdcPGroovyExtension.groovy
@@ -17,7 +17,7 @@ import com.powsybl.dynawaltz.models.hvdc.HvdcPDangling
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class HvdcPGroovyExtension extends AbstractEquipmentGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/hvdc/HvdcVscGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/hvdc/HvdcVscGroovyExtension.groovy
@@ -17,7 +17,7 @@ import com.powsybl.dynawaltz.models.hvdc.HvdcVscDangling
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class HvdcVscGroovyExtension extends AbstractEquipmentGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/lines/LineGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/lines/LineGroovyExtension.groovy
@@ -21,7 +21,7 @@ import com.powsybl.iidm.network.Network
 /**
  * An implementation of {@link DynamicModelGroovyExtension} that adds the <pre>Line</pre> keyword to the DSL
  *
- * @author Dimitri Baudrier <dimitri.baudrier at rte-france.com>
+ * @author Dimitri Baudrier {@literal <dimitri.baudrier at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class LineGroovyExtension extends AbstractSimpleEquipmentGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/loads/AbstractLoadModelBuilder.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/loads/AbstractLoadModelBuilder.groovy
@@ -14,7 +14,7 @@ import com.powsybl.iidm.network.Load
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 abstract class AbstractLoadModelBuilder extends AbstractEquipmentModelBuilder<Load> {
 

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/loads/BaseLoadGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/loads/BaseLoadGroovyExtension.groovy
@@ -18,7 +18,7 @@ import com.powsybl.iidm.network.Network
 /**
  * An implementation of {@link DynamicModelGroovyExtension} that adds the <pre>LoadAlphaBeta</pre> keyword to the DSL
  *
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class BaseLoadGroovyExtension extends AbstractEquipmentGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/loads/LoadOneTransformerGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/loads/LoadOneTransformerGroovyExtension.groovy
@@ -17,7 +17,7 @@ import com.powsybl.iidm.network.Network
 /**
  * An implementation of {@link DynamicModelGroovyExtension} that adds the <pre>LoadOneTransformer</pre> keyword to the DSL
  *
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class LoadOneTransformerGroovyExtension extends AbstractSimpleEquipmentGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/loads/LoadOneTransformerTapChangerGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/loads/LoadOneTransformerTapChangerGroovyExtension.groovy
@@ -16,7 +16,7 @@ import com.powsybl.dynawaltz.models.loads.LoadOneTransformerTapChanger
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class LoadOneTransformerTapChangerGroovyExtension extends AbstractSimpleEquipmentGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/loads/LoadTwoTransformersGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/loads/LoadTwoTransformersGroovyExtension.groovy
@@ -16,7 +16,7 @@ import com.powsybl.dynawaltz.models.loads.LoadTwoTransformers
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class LoadTwoTransformersGroovyExtension extends AbstractSimpleEquipmentGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/loads/LoadTwoTransformersTapChangersGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/loads/LoadTwoTransformersTapChangersGroovyExtension.groovy
@@ -16,7 +16,7 @@ import com.powsybl.dynawaltz.models.loads.LoadTwoTransformersTapChangers
 import com.powsybl.iidm.network.Network
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class LoadTwoTransformersTapChangersGroovyExtension extends AbstractSimpleEquipmentGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/svarcs/SvarcGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/svarcs/SvarcGroovyExtension.groovy
@@ -19,7 +19,7 @@ import com.powsybl.iidm.network.Network
 import com.powsybl.iidm.network.StaticVarCompensator as StaticSvarc
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class SvarcGroovyExtension extends AbstractEquipmentGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/transformers/TransformerFixedRatioGroovyExtension.groovy
+++ b/dynawaltz-dsl/src/main/groovy/com/powsybl/dynawaltz/dsl/models/transformers/TransformerFixedRatioGroovyExtension.groovy
@@ -19,7 +19,7 @@ import com.powsybl.iidm.network.Network
 import com.powsybl.iidm.network.TwoWindingsTransformer
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @AutoService(DynamicModelGroovyExtension.class)
 class TransformerFixedRatioGroovyExtension extends AbstractEquipmentGroovyExtension<DynamicModel> implements DynamicModelGroovyExtension {

--- a/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/AbstractModelSupplierTest.java
+++ b/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/AbstractModelSupplierTest.java
@@ -11,7 +11,7 @@ import java.io.InputStream;
 import java.util.Objects;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 abstract class AbstractModelSupplierTest {
 

--- a/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/DynaWaltzGroovyCurvesSupplierTest.java
+++ b/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/DynaWaltzGroovyCurvesSupplierTest.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 class DynaWaltzGroovyCurvesSupplierTest {
 

--- a/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/DynamicModelsSupplierTest.java
+++ b/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/DynamicModelsSupplierTest.java
@@ -46,7 +46,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class DynamicModelsSupplierTest extends AbstractModelSupplierTest {
 

--- a/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/EventModelsSupplierTest.java
+++ b/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/EventModelsSupplierTest.java
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class EventModelsSupplierTest extends AbstractModelSupplierTest {
 

--- a/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/ieee/AbstractIeeeTest.java
+++ b/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/ieee/AbstractIeeeTest.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ForkJoinPool;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 public abstract class AbstractIeeeTest {
 

--- a/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/ieee/DynaWaltzLocalCommandExecutor.java
+++ b/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/ieee/DynaWaltzLocalCommandExecutor.java
@@ -29,8 +29,8 @@ import static com.powsybl.dynawaltz.xml.DynaWaltzConstants.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class DynaWaltzLocalCommandExecutor implements LocalCommandExecutor {
 

--- a/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/ieee14/Ieee14CurrentLimitAutomatonTest.java
+++ b/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/ieee14/Ieee14CurrentLimitAutomatonTest.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 class Ieee14CurrentLimitAutomatonTest extends AbstractIeeeTest {
 

--- a/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/ieee14/Ieee14DisconnectLineTest.java
+++ b/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/ieee14/Ieee14DisconnectLineTest.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 class Ieee14DisconnectLineTest extends AbstractIeeeTest {
 

--- a/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/ieee14/Ieee14MacroConnectsTest.java
+++ b/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/ieee14/Ieee14MacroConnectsTest.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 class Ieee14MacroConnectsTest extends AbstractIeeeTest {
 

--- a/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/ieee57/Ieee57DisconnectGeneratorTest.java
+++ b/dynawaltz-dsl/src/test/java/com/powsybl/dynawaltz/dsl/ieee57/Ieee57DisconnectGeneratorTest.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 class Ieee57DisconnectGeneratorTest extends AbstractIeeeTest {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzConfig.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzConfig.java
@@ -12,7 +12,7 @@ import com.powsybl.commons.config.PlatformConfig;
 import java.util.Objects;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 public class DynaWaltzConfig {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzContext.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzContext.java
@@ -35,8 +35,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class DynaWaltzContext {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzCurve.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzCurve.java
@@ -12,7 +12,7 @@ import com.powsybl.dynamicsimulation.Curve;
 import java.util.Objects;
 
 /**
- * @author Mathieu Bague <mathieu.bague@rte-france.com>
+ * @author Mathieu Bague {@literal <mathieu.bague@rte-france.com>}
  */
 public class DynaWaltzCurve implements Curve {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzParameters.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzParameters.java
@@ -21,8 +21,8 @@ import java.nio.file.Path;
 import java.util.*;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class DynaWaltzParameters extends AbstractExtension<DynamicSimulationParameters> {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzProvider.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/DynaWaltzProvider.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 import static com.powsybl.dynawaltz.xml.DynaWaltzConstants.*;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 @AutoService(DynamicSimulationProvider.class)
 public class DynaWaltzProvider implements DynamicSimulationProvider {

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/json/DynaWaltzSimulationParametersSerializer.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/json/DynaWaltzSimulationParametersSerializer.java
@@ -22,7 +22,7 @@ import com.powsybl.dynamicsimulation.json.JsonDynamicSimulationParameters.Extens
 import com.powsybl.dynawaltz.DynaWaltzParameters;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 @AutoService(ExtensionSerializer.class)
 public class DynaWaltzSimulationParametersSerializer implements JsonDynamicSimulationParameters.ExtensionSerializer<DynaWaltzParameters> {

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/AbstractBlackBoxModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/AbstractBlackBoxModel.java
@@ -30,8 +30,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * @author Luma Zamarreño <zamarrenolm at aia.es>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public abstract class AbstractBlackBoxModel implements BlackBoxModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/AbstractEquipmentBlackBoxModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/AbstractEquipmentBlackBoxModel.java
@@ -18,8 +18,8 @@ import java.util.Objects;
 import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_URI;
 
 /**
- * @author Luma Zamarreño <zamarrenolm at aia.es>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public abstract class AbstractEquipmentBlackBoxModel<T extends Identifiable<?>> extends AbstractBlackBoxModel implements EquipmentBlackBoxModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/AbstractPureDynamicBlackBoxModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/AbstractPureDynamicBlackBoxModel.java
@@ -16,8 +16,8 @@ import java.util.List;
 import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_URI;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public abstract class AbstractPureDynamicBlackBoxModel extends AbstractBlackBoxModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/BlackBoxModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/BlackBoxModel.java
@@ -15,8 +15,8 @@ import java.util.List;
 import java.util.function.Consumer;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public interface BlackBoxModel extends Model {
     String getDynamicModelId();

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/EquipmentBlackBoxModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/EquipmentBlackBoxModel.java
@@ -8,7 +8,7 @@
 package com.powsybl.dynawaltz.models;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public interface EquipmentBlackBoxModel extends BlackBoxModel {
     String getStaticId();

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/InjectionModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/InjectionModel.java
@@ -8,7 +8,7 @@
 package com.powsybl.dynawaltz.models;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public interface InjectionModel extends Model {
     String getSwitchOffSignalEventVarName();

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/MeasurementPointSuffix.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/MeasurementPointSuffix.java
@@ -10,7 +10,7 @@ package com.powsybl.dynawaltz.models;
 import com.powsybl.dynawaltz.models.macroconnections.MacroConnectionSuffix;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public final class MeasurementPointSuffix implements MacroConnectionSuffix {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/Model.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/Model.java
@@ -12,7 +12,7 @@ import com.powsybl.dynawaltz.models.macroconnections.MacroConnectAttribute;
 import java.util.List;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public interface Model extends DynamicModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/Side.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/Side.java
@@ -8,7 +8,7 @@
 package com.powsybl.dynawaltz.models;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public enum Side {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/TransformerSide.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/TransformerSide.java
@@ -8,7 +8,7 @@
 package com.powsybl.dynawaltz.models;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public enum TransformerSide {
     HIGH_VOLTAGE("T"),

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/VarConnection.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/VarConnection.java
@@ -7,8 +7,8 @@
 package com.powsybl.dynawaltz.models;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public record VarConnection(String var1, String var2) {
 }

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/VarMapping.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/VarMapping.java
@@ -7,8 +7,8 @@
 package com.powsybl.dynawaltz.models;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public record VarMapping(String dynamicVar, String staticVar) {
 }

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/CurrentLimitAutomaton.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/CurrentLimitAutomaton.java
@@ -17,8 +17,8 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class CurrentLimitAutomaton extends AbstractPureDynamicBlackBoxModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/CurrentLimitTwoLevelsAutomaton.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/CurrentLimitTwoLevelsAutomaton.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class CurrentLimitTwoLevelsAutomaton extends CurrentLimitAutomaton {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/QuadripoleModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/QuadripoleModel.java
@@ -11,7 +11,7 @@ import com.powsybl.dynawaltz.models.Model;
 import com.powsybl.dynawaltz.models.Side;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public interface QuadripoleModel extends Model {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/TapChangerAutomaton.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/TapChangerAutomaton.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class TapChangerAutomaton extends AbstractPureDynamicBlackBoxModel implements TapChangerModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/TapChangerBlockingAutomaton.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/TapChangerBlockingAutomaton.java
@@ -26,7 +26,7 @@ import javax.xml.stream.XMLStreamWriter;
 import java.util.*;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class TapChangerBlockingAutomaton extends AbstractPureDynamicBlackBoxModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/UnderVoltageAutomaton.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/UnderVoltageAutomaton.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class UnderVoltageAutomaton extends AbstractPureDynamicBlackBoxModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/phaseshifters/AbstractPhaseShifterAutomaton.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/phaseshifters/AbstractPhaseShifterAutomaton.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public abstract class AbstractPhaseShifterAutomaton extends AbstractPureDynamicBlackBoxModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/phaseshifters/PhaseShifterIAutomaton.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/phaseshifters/PhaseShifterIAutomaton.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class PhaseShifterIAutomaton extends AbstractPhaseShifterAutomaton {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/phaseshifters/PhaseShifterPAutomaton.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/automatons/phaseshifters/PhaseShifterPAutomaton.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class PhaseShifterPAutomaton extends AbstractPhaseShifterAutomaton {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/buses/AbstractBus.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/buses/AbstractBus.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public abstract class AbstractBus extends AbstractEquipmentBlackBoxModel<Bus> implements EquipmentConnectionPoint, ActionConnectionPoint {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/buses/ActionConnectionPoint.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/buses/ActionConnectionPoint.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 /**
  * Interface for buses used by automatons for measure or event for various actions
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public interface ActionConnectionPoint extends Model {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/buses/BusOfFrequencySynchronizedModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/buses/BusOfFrequencySynchronizedModel.java
@@ -12,7 +12,7 @@ import com.powsybl.dynawaltz.models.Model;
 /**
  * View of frequency synchronized equipment from the bus to which it is connected
  * Used by FrequencySynchronizer in order to get NummCC var name
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public interface BusOfFrequencySynchronizedModel extends Model {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/buses/DefaultActionConnectionPoint.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/buses/DefaultActionConnectionPoint.java
@@ -12,8 +12,8 @@ import com.powsybl.dynawaltz.models.defaultmodels.AbstractDefaultModel;
 import java.util.Optional;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class DefaultActionConnectionPoint extends AbstractDefaultModel implements ActionConnectionPoint {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/buses/DefaultEquipmentConnectionPoint.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/buses/DefaultEquipmentConnectionPoint.java
@@ -18,7 +18,7 @@ import java.util.Optional;
  * Used for the connection between an equipment and a bus.
  * Since the equipment static id (@STATIC_ID@ in varname) is the only information needed in order to create var connections,
  * DefaultBusModel is implemented as a singleton
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public final class DefaultEquipmentConnectionPoint implements EquipmentConnectionPoint {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/buses/EquipmentConnectionPoint.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/buses/EquipmentConnectionPoint.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 
 /**
  * Interface use for buses by equipments for connection with the network
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public interface EquipmentConnectionPoint extends Model {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/buses/InfiniteBus.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/buses/InfiniteBus.java
@@ -10,7 +10,7 @@ package com.powsybl.dynawaltz.models.buses;
 import com.powsybl.iidm.network.Bus;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class InfiniteBus extends AbstractBus {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/buses/StandardBus.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/buses/StandardBus.java
@@ -14,8 +14,8 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
 /**
- * @author Dimitri Baudrier <dimitri.baudrier at rte-france.com>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Dimitri Baudrier {@literal <dimitri.baudrier at rte-france.com>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class StandardBus extends AbstractBus {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/defaultmodels/AbstractInjectionDefaultModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/defaultmodels/AbstractInjectionDefaultModel.java
@@ -8,7 +8,7 @@
 package com.powsybl.dynawaltz.models.defaultmodels;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public abstract class AbstractInjectionDefaultModel extends AbstractDefaultModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/defaultmodels/DefaultModelFactory.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/defaultmodels/DefaultModelFactory.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class DefaultModelFactory<T> {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/defaultmodels/DefaultModelsHandler.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/defaultmodels/DefaultModelsHandler.java
@@ -33,8 +33,8 @@ import java.util.EnumMap;
 import java.util.Map;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class DefaultModelsHandler {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/events/AbstractDynamicLibEventDisconnection.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/events/AbstractDynamicLibEventDisconnection.java
@@ -19,7 +19,7 @@ import static com.powsybl.dynawaltz.parameters.ParameterType.BOOL;
 import static com.powsybl.dynawaltz.parameters.ParameterType.DOUBLE;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public abstract class AbstractDynamicLibEventDisconnection extends AbstractEvent {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/events/AbstractEvent.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/events/AbstractEvent.java
@@ -16,8 +16,8 @@ import com.powsybl.iidm.network.Identifiable;
 import java.util.function.Consumer;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public abstract class AbstractEvent extends AbstractPureDynamicBlackBoxModel implements EventModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/events/EventActivePowerVariation.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/events/EventActivePowerVariation.java
@@ -24,7 +24,7 @@ import static com.powsybl.dynawaltz.parameters.ParameterType.BOOL;
 import static com.powsybl.dynawaltz.parameters.ParameterType.DOUBLE;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class EventActivePowerVariation extends AbstractEvent {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/events/EventHvdcDisconnection.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/events/EventHvdcDisconnection.java
@@ -16,7 +16,7 @@ import com.powsybl.iidm.network.HvdcLine;
 import java.util.List;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class EventHvdcDisconnection extends AbstractDynamicLibEventDisconnection {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/events/EventInjectionDisconnection.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/events/EventInjectionDisconnection.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 /**
  * @author Mathieu BAGUE {@literal <mathieu.bague at rte-france.com>}
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class EventInjectionDisconnection extends AbstractDynamicLibEventDisconnection {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/events/EventQuadripoleDisconnection.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/events/EventQuadripoleDisconnection.java
@@ -18,8 +18,8 @@ import static com.powsybl.dynawaltz.parameters.ParameterType.BOOL;
 import static com.powsybl.dynawaltz.parameters.ParameterType.DOUBLE;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class EventQuadripoleDisconnection extends AbstractEvent {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/events/NodeFaultEvent.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/events/NodeFaultEvent.java
@@ -19,7 +19,7 @@ import static com.powsybl.dynawaltz.parameters.ParameterType.BOOL;
 import static com.powsybl.dynawaltz.parameters.ParameterType.DOUBLE;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class NodeFaultEvent extends AbstractEvent {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/frequencysynchronizers/AbstractFrequencySynchronizer.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/frequencysynchronizers/AbstractFrequencySynchronizer.java
@@ -13,7 +13,7 @@ import com.powsybl.dynawaltz.models.AbstractPureDynamicBlackBoxModel;
 import java.util.List;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public abstract class AbstractFrequencySynchronizer extends AbstractPureDynamicBlackBoxModel implements FrequencySynchronizerModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/frequencysynchronizers/FrequencySynchronizedModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/frequencysynchronizers/FrequencySynchronizedModel.java
@@ -14,7 +14,7 @@ import com.powsybl.dynawaltz.models.VarConnection;
 import java.util.List;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public interface FrequencySynchronizedModel extends Model {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/frequencysynchronizers/FrequencySynchronizerModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/frequencysynchronizers/FrequencySynchronizerModel.java
@@ -10,7 +10,7 @@ package com.powsybl.dynawaltz.models.frequencysynchronizers;
 import com.powsybl.dynawaltz.models.BlackBoxModel;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public interface FrequencySynchronizerModel extends BlackBoxModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/frequencysynchronizers/OmegaRef.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/frequencysynchronizers/OmegaRef.java
@@ -28,8 +28,8 @@ import static com.powsybl.dynawaltz.parameters.ParameterType.INT;
  * NETWORK dynamic model. There are thus two macroConnectors defined for OmegaRef: one to connect it to a generator's
  * dynamic model and one to connect it to the NETWORK model.
  *
- * @author Marcos de Miguel <demiguelm at aia.es>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class OmegaRef extends AbstractFrequencySynchronizer {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/frequencysynchronizers/SetPoint.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/frequencysynchronizers/SetPoint.java
@@ -20,7 +20,7 @@ import static com.powsybl.dynawaltz.parameters.ParameterType.DOUBLE;
 /**
  * Special generators' frequency synchronizer used when an Infinite Bus is present in the model.
  *
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class SetPoint extends AbstractFrequencySynchronizer {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/AbstractGenerator.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/AbstractGenerator.java
@@ -18,8 +18,8 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public abstract class AbstractGenerator extends AbstractEquipmentBlackBoxModel<Generator> implements GeneratorModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/DefaultGenerator.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/DefaultGenerator.java
@@ -11,7 +11,7 @@ import com.powsybl.dynawaltz.models.defaultmodels.AbstractInjectionDefaultModel;
 import com.powsybl.dynawaltz.models.events.ControllableEquipment;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class DefaultGenerator extends AbstractInjectionDefaultModel implements GeneratorModel, ControllableEquipment {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/EnumGeneratorComponent.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/EnumGeneratorComponent.java
@@ -8,7 +8,7 @@
 package com.powsybl.dynawaltz.models.generators;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public enum EnumGeneratorComponent {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/GeneratorFictitious.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/GeneratorFictitious.java
@@ -9,8 +9,8 @@ package com.powsybl.dynawaltz.models.generators;
 import com.powsybl.iidm.network.Generator;
 
 /**
- * @author Dimitri Baudrier <dimitri.baudrier at rte-france.com>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Dimitri Baudrier {@literal <dimitri.baudrier at rte-france.com>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class GeneratorFictitious extends AbstractGenerator {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/GeneratorModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/GeneratorModel.java
@@ -9,7 +9,7 @@ package com.powsybl.dynawaltz.models.generators;
 import com.powsybl.dynawaltz.models.InjectionModel;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public interface GeneratorModel extends InjectionModel {
     String getTerminalVarName();

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/GridFormingConverter.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/GridFormingConverter.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class GridFormingConverter extends AbstractEquipmentBlackBoxModel<Generator> implements FrequencySynchronizedModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/SynchronizedGenerator.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/SynchronizedGenerator.java
@@ -14,8 +14,8 @@ import com.powsybl.iidm.network.Generator;
 import java.util.List;
 
 /**
- * @author Dimitri Baudrier <dimitri.baudrier at rte-france.com>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Dimitri Baudrier {@literal <dimitri.baudrier at rte-france.com>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class SynchronizedGenerator extends AbstractGenerator implements FrequencySynchronizedModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/SynchronizedGeneratorControllable.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/SynchronizedGeneratorControllable.java
@@ -11,7 +11,7 @@ import com.powsybl.dynawaltz.models.events.ControllableEquipment;
 import com.powsybl.iidm.network.Generator;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class SynchronizedGeneratorControllable extends SynchronizedGenerator implements ControllableEquipment {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/SynchronizedWeccGen.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/SynchronizedWeccGen.java
@@ -11,7 +11,7 @@ import com.powsybl.dynawaltz.models.frequencysynchronizers.FrequencySynchronized
 import com.powsybl.iidm.network.Generator;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class SynchronizedWeccGen extends WeccGen implements FrequencySynchronizedModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/SynchronousGenerator.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/SynchronousGenerator.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class SynchronousGenerator extends SynchronizedGenerator {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/SynchronousGeneratorControllable.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/SynchronousGeneratorControllable.java
@@ -11,7 +11,7 @@ import com.powsybl.dynawaltz.models.events.ControllableEquipment;
 import com.powsybl.iidm.network.Generator;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class SynchronousGeneratorControllable extends SynchronousGenerator implements ControllableEquipment {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/WeccGen.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/generators/WeccGen.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class WeccGen extends AbstractEquipmentBlackBoxModel<Generator> {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/hvdc/AbstractHvdc.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/hvdc/AbstractHvdc.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public abstract class AbstractHvdc extends AbstractEquipmentBlackBoxModel<HvdcLine> implements HvdcModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/hvdc/DefaultHvdc.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/hvdc/DefaultHvdc.java
@@ -11,7 +11,7 @@ import com.powsybl.dynawaltz.models.defaultmodels.AbstractDefaultModel;
 import com.powsybl.dynawaltz.models.Side;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class DefaultHvdc extends AbstractDefaultModel implements HvdcModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/hvdc/HvdcModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/hvdc/HvdcModel.java
@@ -11,7 +11,7 @@ import com.powsybl.dynawaltz.models.Model;
 import com.powsybl.dynawaltz.models.Side;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public interface HvdcModel extends Model {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/hvdc/HvdcP.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/hvdc/HvdcP.java
@@ -11,7 +11,7 @@ import com.powsybl.dynawaltz.models.Side;
 import com.powsybl.iidm.network.HvdcLine;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class HvdcP extends AbstractHvdc {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/hvdc/HvdcPDangling.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/hvdc/HvdcPDangling.java
@@ -14,7 +14,7 @@ import com.powsybl.dynawaltz.models.utils.SideConverter;
 import com.powsybl.iidm.network.HvdcLine;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class HvdcPDangling extends HvdcP {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/hvdc/HvdcVsc.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/hvdc/HvdcVsc.java
@@ -11,7 +11,7 @@ import com.powsybl.dynawaltz.models.Side;
 import com.powsybl.iidm.network.HvdcLine;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class HvdcVsc extends AbstractHvdc {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/hvdc/HvdcVscDangling.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/hvdc/HvdcVscDangling.java
@@ -13,7 +13,7 @@ import com.powsybl.dynawaltz.models.Side;
 import com.powsybl.iidm.network.HvdcLine;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class HvdcVscDangling extends HvdcVsc {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/lines/DefaultLine.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/lines/DefaultLine.java
@@ -10,7 +10,7 @@ import com.powsybl.dynawaltz.models.defaultmodels.AbstractDefaultModel;
 import com.powsybl.dynawaltz.models.Side;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class DefaultLine extends AbstractDefaultModel implements LineModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/lines/LineModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/lines/LineModel.java
@@ -9,7 +9,7 @@ package com.powsybl.dynawaltz.models.lines;
 import com.powsybl.dynawaltz.models.automatons.QuadripoleModel;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public interface LineModel extends QuadripoleModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/lines/StandardLine.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/lines/StandardLine.java
@@ -18,7 +18,7 @@ import com.powsybl.iidm.network.Line;
 import java.util.List;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class StandardLine extends AbstractEquipmentBlackBoxModel<Line> implements LineModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/AbstractLoad.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/AbstractLoad.java
@@ -15,8 +15,8 @@ import com.powsybl.iidm.network.Load;
 import java.util.List;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public abstract class AbstractLoad extends AbstractEquipmentBlackBoxModel<Load> implements LoadModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/BaseLoad.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/BaseLoad.java
@@ -16,8 +16,8 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class BaseLoad extends AbstractLoad {
     protected static final List<VarMapping> VAR_MAPPING = Arrays.asList(

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/BaseLoadControllable.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/BaseLoadControllable.java
@@ -11,7 +11,7 @@ import com.powsybl.dynawaltz.models.events.ControllableEquipment;
 import com.powsybl.iidm.network.Load;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class BaseLoadControllable extends BaseLoad implements ControllableEquipment {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/DefaultLoad.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/DefaultLoad.java
@@ -11,7 +11,7 @@ import com.powsybl.dynawaltz.models.defaultmodels.AbstractInjectionDefaultModel;
 import com.powsybl.dynawaltz.models.events.ControllableEquipment;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class DefaultLoad extends AbstractInjectionDefaultModel implements LoadModel, ControllableEquipment {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/LoadModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/LoadModel.java
@@ -10,7 +10,7 @@ package com.powsybl.dynawaltz.models.loads;
 import com.powsybl.dynawaltz.models.InjectionModel;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public interface LoadModel extends InjectionModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/LoadOneTransformer.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/LoadOneTransformer.java
@@ -20,8 +20,8 @@ import java.util.List;
 import static com.powsybl.dynawaltz.models.TransformerSide.NONE;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class LoadOneTransformer extends AbstractLoad implements LoadWithTransformers {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/LoadOneTransformerTapChanger.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/LoadOneTransformerTapChanger.java
@@ -19,7 +19,7 @@ import java.util.List;
 import static com.powsybl.dynawaltz.models.TransformerSide.NONE;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class LoadOneTransformerTapChanger extends LoadOneTransformer implements TapChangerModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/LoadTwoTransformers.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/LoadTwoTransformers.java
@@ -21,7 +21,7 @@ import java.util.List;
 import static com.powsybl.dynawaltz.models.TransformerSide.*;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class LoadTwoTransformers extends AbstractLoad implements LoadWithTransformers {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/LoadTwoTransformersTapChangers.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/LoadTwoTransformersTapChangers.java
@@ -20,7 +20,7 @@ import static com.powsybl.dynawaltz.models.TransformerSide.HIGH_VOLTAGE;
 import static com.powsybl.dynawaltz.models.TransformerSide.LOW_VOLTAGE;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class LoadTwoTransformersTapChangers extends LoadTwoTransformers implements TapChangerModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/LoadWithTransformers.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/loads/LoadWithTransformers.java
@@ -14,7 +14,7 @@ import com.powsybl.dynawaltz.models.VarConnection;
 import java.util.List;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public interface LoadWithTransformers extends Model {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/macroconnections/MacroConnect.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/macroconnections/MacroConnect.java
@@ -14,7 +14,7 @@ import java.util.List;
 import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_URI;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public final class MacroConnect {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/macroconnections/MacroConnectAttribute.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/macroconnections/MacroConnectAttribute.java
@@ -8,7 +8,7 @@
 package com.powsybl.dynawaltz.models.macroconnections;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public record MacroConnectAttribute(String name, String value) {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/macroconnections/MacroConnectionSuffix.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/macroconnections/MacroConnectionSuffix.java
@@ -8,7 +8,7 @@
 package com.powsybl.dynawaltz.models.macroconnections;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public interface MacroConnectionSuffix {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/macroconnections/MacroConnector.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/macroconnections/MacroConnector.java
@@ -17,8 +17,8 @@ import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_URI;
 import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.MACRO_CONNECTOR_PREFIX;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public final class MacroConnector {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/shunts/DefaultShunt.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/shunts/DefaultShunt.java
@@ -10,7 +10,7 @@ package com.powsybl.dynawaltz.models.shunts;
 import com.powsybl.dynawaltz.models.defaultmodels.AbstractInjectionDefaultModel;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class DefaultShunt extends AbstractInjectionDefaultModel implements ShuntModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/shunts/ShuntModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/shunts/ShuntModel.java
@@ -10,7 +10,7 @@ package com.powsybl.dynawaltz.models.shunts;
 import com.powsybl.dynawaltz.models.InjectionModel;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public interface ShuntModel extends InjectionModel {
     String getStateVarName();

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/svarcs/DefaultStaticVarCompensator.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/svarcs/DefaultStaticVarCompensator.java
@@ -10,7 +10,7 @@ package com.powsybl.dynawaltz.models.svarcs;
 import com.powsybl.dynawaltz.models.defaultmodels.AbstractInjectionDefaultModel;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class DefaultStaticVarCompensator extends AbstractInjectionDefaultModel implements StaticVarCompensatorModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/svarcs/StaticVarCompensator.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/svarcs/StaticVarCompensator.java
@@ -17,7 +17,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class StaticVarCompensator extends AbstractEquipmentBlackBoxModel<com.powsybl.iidm.network.StaticVarCompensator> implements StaticVarCompensatorModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/transformers/DefaultTransformer.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/transformers/DefaultTransformer.java
@@ -16,7 +16,7 @@ import java.util.List;
 import static com.powsybl.dynawaltz.models.TransformerSide.NONE;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class DefaultTransformer extends AbstractDefaultModel implements TransformerModel, TapChangerModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/transformers/TapChangerModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/transformers/TapChangerModel.java
@@ -17,7 +17,7 @@ import static com.powsybl.dynawaltz.models.TransformerSide.HIGH_VOLTAGE;
 import static com.powsybl.dynawaltz.models.TransformerSide.NONE;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public interface TapChangerModel extends Model {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/transformers/TransformerFixedRatio.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/transformers/TransformerFixedRatio.java
@@ -20,7 +20,7 @@ import java.util.List;
 import static com.powsybl.dynawaltz.models.TransformerSide.NONE;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class TransformerFixedRatio extends AbstractEquipmentBlackBoxModel<TwoWindingsTransformer> implements TransformerModel, TapChangerModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/transformers/TransformerModel.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/transformers/TransformerModel.java
@@ -10,7 +10,7 @@ package com.powsybl.dynawaltz.models.transformers;
 import com.powsybl.dynawaltz.models.automatons.QuadripoleModel;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public interface TransformerModel extends QuadripoleModel {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/utils/BusUtils.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/utils/BusUtils.java
@@ -10,7 +10,7 @@ package com.powsybl.dynawaltz.models.utils;
 import com.powsybl.iidm.network.*;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public final class BusUtils {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/utils/SideConverter.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/models/utils/SideConverter.java
@@ -12,7 +12,7 @@ import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.HvdcLine;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public final class SideConverter {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/parameters/Parameter.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/parameters/Parameter.java
@@ -12,9 +12,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public record Parameter(String name, ParameterType type, String value) {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/parameters/ParameterType.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/parameters/ParameterType.java
@@ -8,8 +8,8 @@
 package com.powsybl.dynawaltz.parameters;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public enum ParameterType {
     DOUBLE,

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/parameters/ParametersSet.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/parameters/ParametersSet.java
@@ -16,8 +16,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class ParametersSet {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/parameters/Reference.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/parameters/Reference.java
@@ -12,8 +12,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public record Reference(String name, ParameterType type, String origData, String origName, String componentId) {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/CurvesXml.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/CurvesXml.java
@@ -20,7 +20,7 @@ import static com.powsybl.dynawaltz.xml.DynaWaltzConstants.CRV_FILENAME;
 import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_URI;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 public final class CurvesXml {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/DydXml.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/DydXml.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 import static com.powsybl.dynawaltz.xml.DynaWaltzConstants.DYD_FILENAME;
 
 /**
- * @author Mathieu Bague <mathieu.bague@rte-france.com>
+ * @author Mathieu Bague {@literal <mathieu.bague@rte-france.com>}
  */
 public final class DydXml {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/DynaWaltzConstants.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/DynaWaltzConstants.java
@@ -7,7 +7,7 @@
 package com.powsybl.dynawaltz.xml;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 public final class DynaWaltzConstants {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/DynaWaltzXmlConstants.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/DynaWaltzXmlConstants.java
@@ -7,7 +7,7 @@
 package com.powsybl.dynawaltz.xml;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 public final class DynaWaltzXmlConstants {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/JobsXml.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/JobsXml.java
@@ -20,7 +20,7 @@ import static com.powsybl.dynawaltz.xml.DynaWaltzConstants.*;
 import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_URI;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 public final class JobsXml {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/MacroStaticReference.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/MacroStaticReference.java
@@ -17,7 +17,7 @@ import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_URI;
 import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.MACRO_STATIC_REFERENCE_PREFIX;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 public final class MacroStaticReference {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/ParametersXml.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/ParametersXml.java
@@ -32,8 +32,8 @@ import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_PREFIX;
 import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_URI;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public final class ParametersXml {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/XmlStreamWriterFactory.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/XmlStreamWriterFactory.java
@@ -15,7 +15,7 @@ import javax.xml.stream.XMLStreamWriter;
 import java.io.Writer;
 
 /**
- * @author Mathieu Bague <mathieu.bague@rte-france.com>
+ * @author Mathieu Bague {@literal <mathieu.bague@rte-france.com>}
  */
 public final class XmlStreamWriterFactory {
 

--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/XmlUtil.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/xml/XmlUtil.java
@@ -22,7 +22,7 @@ import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_PREFIX;
 import static com.powsybl.dynawaltz.xml.DynaWaltzXmlConstants.DYN_URI;
 
 /**
- * @author Mathieu Bague <mathieu.bague@rte-france.com>
+ * @author Mathieu Bague {@literal <mathieu.bague@rte-france.com>}
  */
 public final class XmlUtil {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/AbstractLocalCommandExecutor.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/AbstractLocalCommandExecutor.java
@@ -15,7 +15,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 abstract class AbstractLocalCommandExecutor implements LocalCommandExecutor {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzConfigTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzConfigTest.java
@@ -20,7 +20,7 @@ import java.nio.file.FileSystem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 class DynaWaltzConfigTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzCurveTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzCurveTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 class DynaWaltzCurveTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzParametersDatabaseTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzParametersDatabaseTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 class DynaWaltzParametersDatabaseTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzParametersTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzParametersTest.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 class DynaWaltzParametersTest extends AbstractConverterTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzProviderTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/DynaWaltzProviderTest.java
@@ -33,8 +33,8 @@ import java.util.concurrent.ForkJoinPool;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 class DynaWaltzProviderTest extends AbstractConverterTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/models/buses/StandardBusTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/models/buses/StandardBusTest.java
@@ -27,8 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * @author Dimitri Baudrier <dimitri.baudrier at rte-france.com>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Dimitri Baudrier {@literal <dimitri.baudrier at rte-france.com>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class StandardBusTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/models/lines/StandardLineTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/models/lines/StandardLineTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class StandardLineTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/AbstractDynamicModelXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/AbstractDynamicModelXmlTest.java
@@ -35,7 +35,7 @@ import java.util.Objects;
 import static com.powsybl.commons.test.ComparisonUtils.compareTxt;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public abstract class AbstractDynamicModelXmlTest extends AbstractConverterTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/AbstractParametrizedDynamicModelXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/AbstractParametrizedDynamicModelXmlTest.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 import static com.powsybl.commons.test.ComparisonUtils.compareTxt;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 abstract class AbstractParametrizedDynamicModelXmlTest extends AbstractConverterTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/ActivePowerVariationEventXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/ActivePowerVariationEventXmlTest.java
@@ -19,7 +19,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class ActivePowerVariationEventXmlTest extends AbstractDynamicModelXmlTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/CurrentLimitModelXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/CurrentLimitModelXmlTest.java
@@ -18,7 +18,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class CurrentLimitModelXmlTest extends AbstractDynamicModelXmlTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/CurrentLimitTwoLevelsModelXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/CurrentLimitTwoLevelsModelXmlTest.java
@@ -17,7 +17,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class CurrentLimitTwoLevelsModelXmlTest extends AbstractDynamicModelXmlTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/CurvesXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/CurvesXmlTest.java
@@ -16,7 +16,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 class CurvesXmlTest extends DynaWaltzTestUtil {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/CustomParameterResolver.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/CustomParameterResolver.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class CustomParameterResolver implements BeforeEachMethodAdapter, ParameterResolver {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/DisconnectEventXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/DisconnectEventXmlTest.java
@@ -20,7 +20,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class DisconnectEventXmlTest extends AbstractDynamicModelXmlTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/DisconnectHvdcEventXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/DisconnectHvdcEventXmlTest.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @ExtendWith(CustomParameterResolver.class)
 class DisconnectHvdcEventXmlTest extends AbstractParametrizedDynamicModelXmlTest {

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/DisconnectQuadripoleEventXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/DisconnectQuadripoleEventXmlTest.java
@@ -16,7 +16,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class DisconnectQuadripoleEventXmlTest extends AbstractDynamicModelXmlTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/DisconnectionExceptionXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/DisconnectionExceptionXmlTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @ExtendWith(CustomParameterResolver.class)
 class DisconnectionExceptionXmlTest extends AbstractParametrizedDynamicModelXmlTest {

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/DynaWaltzTestUtil.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/DynaWaltzTestUtil.java
@@ -41,7 +41,7 @@ import java.util.Objects;
 import static com.powsybl.commons.test.ComparisonUtils.compareTxt;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 public class DynaWaltzTestUtil extends AbstractConverterTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/DynamicModelsXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/DynamicModelsXmlTest.java
@@ -28,8 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class DynamicModelsXmlTest extends DynaWaltzTestUtil {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/EmptyTapChangerAutomatonXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/EmptyTapChangerAutomatonXmlTest.java
@@ -17,7 +17,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class EmptyTapChangerAutomatonXmlTest extends AbstractDynamicModelXmlTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/EmptyTapChangerBlockingAutomatonXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/EmptyTapChangerBlockingAutomatonXmlTest.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class EmptyTapChangerBlockingAutomatonXmlTest extends AbstractDynamicModelXmlTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/EventXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/EventXmlTest.java
@@ -20,7 +20,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 class EventXmlTest extends DynaWaltzTestUtil {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/HvdcXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/HvdcXmlTest.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @ExtendWith(CustomParameterResolver.class)
 class HvdcXmlTest extends AbstractParametrizedDynamicModelXmlTest {

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/JobsXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/JobsXmlTest.java
@@ -16,7 +16,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 class JobsXmlTest extends DynaWaltzTestUtil {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/LoadsModelXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/LoadsModelXmlTest.java
@@ -24,7 +24,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @ExtendWith(CustomParameterResolver.class)
 class LoadsModelXmlTest extends AbstractParametrizedDynamicModelXmlTest {

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/MappedParameterContext.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/MappedParameterContext.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public class MappedParameterContext implements ParameterContext {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/NodeFaultEventXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/NodeFaultEventXmlTest.java
@@ -16,7 +16,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class NodeFaultEventXmlTest extends AbstractDynamicModelXmlTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/OmegaRefModelXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/OmegaRefModelXmlTest.java
@@ -17,7 +17,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class OmegaRefModelXmlTest extends AbstractDynamicModelXmlTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/ParametersXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/ParametersXmlTest.java
@@ -17,7 +17,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 
 /**
- * @author Marcos de Miguel <demiguelm at aia.es>
+ * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
 class ParametersXmlTest extends DynaWaltzTestUtil {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/PhaseShiftersXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/PhaseShiftersXmlTest.java
@@ -26,7 +26,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @ExtendWith(CustomParameterResolver.class)
 class PhaseShiftersXmlTest extends AbstractParametrizedDynamicModelXmlTest {

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/SetPointInfiniteBusModelXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/SetPointInfiniteBusModelXmlTest.java
@@ -18,7 +18,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class SetPointInfiniteBusModelXmlTest extends AbstractDynamicModelXmlTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/SvarcModelXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/SvarcModelXmlTest.java
@@ -16,7 +16,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class SvarcModelXmlTest extends AbstractDynamicModelXmlTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/TapChangerAutomatonExceptionsXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/TapChangerAutomatonExceptionsXmlTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @ExtendWith(CustomParameterResolver.class)
 class TapChangerAutomatonExceptionsXmlTest extends AbstractParametrizedDynamicModelXmlTest {

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/TapChangerAutomatonXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/TapChangerAutomatonXmlTest.java
@@ -20,7 +20,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class TapChangerAutomatonXmlTest extends AbstractDynamicModelXmlTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/TapChangerBlockingAutomatonXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/TapChangerBlockingAutomatonXmlTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class TapChangerBlockingAutomatonXmlTest extends AbstractDynamicModelXmlTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/TapChangerBlockingToTapChangerAutomatonXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/TapChangerBlockingToTapChangerAutomatonXmlTest.java
@@ -17,7 +17,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class TapChangerBlockingToTapChangerAutomatonXmlTest extends TapChangerAutomatonXmlTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/TransformerModelXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/TransformerModelXmlTest.java
@@ -16,7 +16,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class TransformerModelXmlTest extends AbstractDynamicModelXmlTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/UnderVoltageAutomatonXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/UnderVoltageAutomatonXmlTest.java
@@ -16,7 +16,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 class UnderVoltageAutomatonXmlTest extends AbstractDynamicModelXmlTest {
 

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/WeccGenXmlTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/xml/WeccGenXmlTest.java
@@ -26,7 +26,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
- * @author Laurent Issertial <laurent.issertial at rte-france.com>
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 @ExtendWith(CustomParameterResolver.class)
 class WeccGenXmlTest extends AbstractParametrizedDynamicModelXmlTest {

--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/AbstractDynawoTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/AbstractDynawoTest.java
@@ -18,7 +18,7 @@ import java.nio.file.Path;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractDynawoTest {
 

--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynaFlowTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynaFlowTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class DynaFlowTest extends AbstractDynawoTest {
 

--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynaWaltzTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynaWaltzTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class DynaWaltzTest extends AbstractDynawoTest {
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem?**
No, but similar to https://github.com/powsybl/powsybl-core/pull/2753

**What kind of change does this PR introduce?**
Bug fix for javadoc generation

**What is the current behavior?**
Errors related to the author's email address formatting occur when generating the javadoc.
Email addresses were written as `@author Name Surname <email>`

**What is the new behavior (if this is a feature change)?**
No more errors related to that when generating the javadoc.
Email addresses are written as `@author Name Surname {@literal <email> }`
