### PR TITLE
use new parent to have gmavenplus groovydoc attach instead of buildhelper-maven-plugin

### DIFF
--- a/dynawaltz-dsl/pom.xml
+++ b/dynawaltz-dsl/pom.xml
@@ -21,6 +21,7 @@
     <description>DSL for DynaWaltz</description>
 
     <properties>
+        <groovydoc.attach>true</groovydoc.attach>
         <groovydoc.classifier>javadoc</groovydoc.classifier>
     </properties>
 

--- a/dynawaltz-dsl/pom.xml
+++ b/dynawaltz-dsl/pom.xml
@@ -30,10 +30,6 @@
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent</artifactId>
-        <version>15</version>
+        <version>18</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
NO


**What kind of change does this PR introduce?**
code cleanup


**What is the current behavior?**
using build-helper-maven-plugin to attach groovydoc


**What is the new behavior (if this is a feature change)?**
using gmaven-plus:groovydoc-jar to attach groovydoc


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**