### PR TITLE
Fix EventModelBuilder getter

### DIFF
--- a/dynawaltz/src/main/java/com/powsybl/dynawaltz/builders/ModelConfigsHandler.java
+++ b/dynawaltz/src/main/java/com/powsybl/dynawaltz/builders/ModelConfigsHandler.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.stream.Collectors;
 
 /**
  * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
@@ -37,11 +38,8 @@ public final class ModelConfigsHandler {
             new EventBuilderConfig(EventDisconnectionBuilder::of, EventDisconnectionBuilder.TAG),
             new EventBuilderConfig(NodeFaultEventBuilder::of, NodeFaultEventBuilder.TAG));
 
-    private final Map<String, EventBuilderConfig.EventModelBuilderConstructor> eventBuilderConstructorByName = Map.of(
-            EventDisconnectionBuilder.TAG, EventDisconnectionBuilder::of,
-            NodeFaultEventBuilder.TAG, EventDisconnectionBuilder::of,
-            EventActivePowerVariationBuilder.TAG, EventActivePowerVariationBuilder::of
-    );
+    private final Map<String, EventBuilderConfig.EventModelBuilderConstructor> eventBuilderConstructorByName =
+            eventBuilderConfigs.stream().collect(Collectors.toMap(EventBuilderConfig::getTag, EventBuilderConfig::getBuilderConstructor));
 
     private ModelConfigsHandler() {
         List<ModelConfigLoader> modelConfigLoaders = Lists.newArrayList(ServiceLoader.load(ModelConfigLoader.class));

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/builders/BuilderConfigTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/builders/BuilderConfigTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com/)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.dynawaltz.builders;
+
+import com.powsybl.commons.report.ReportNode;
+import com.powsybl.dynamicsimulation.DynamicModel;
+import com.powsybl.dynamicsimulation.EventModel;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
+ */
+public class BuilderConfigTest {
+
+    private static Network NETWORK;
+    private static ModelConfigsHandler MODEL_CONFIGS_HANDLER;
+
+    @BeforeAll
+    static void setup() {
+        NETWORK = EurostagTutorialExample1Factory.create();
+        MODEL_CONFIGS_HANDLER = ModelConfigsHandler.getInstance();
+    }
+
+    @Test
+    void testModelBuilders() {
+        for (BuilderConfig builderConfig : MODEL_CONFIGS_HANDLER.getBuilderConfigs()) {
+            String lib = builderConfig.getLibs().iterator().next();
+            ModelBuilder<DynamicModel> tagBuilder = MODEL_CONFIGS_HANDLER.getModelBuilder(NETWORK, lib, ReportNode.NO_OP);
+            ModelBuilder<DynamicModel> configBuilder = builderConfig.getBuilderConstructor().createBuilder(NETWORK, lib, ReportNode.NO_OP);
+            assertNotNull(tagBuilder);
+            assertEquals(tagBuilder.getClass(), configBuilder.getClass());
+        }
+    }
+
+    @Test
+    void testEventBuilders() {
+        for (EventBuilderConfig eventBuilderConfig : MODEL_CONFIGS_HANDLER.getEventBuilderConfigs()) {
+            ModelBuilder<EventModel> tagBuilder = MODEL_CONFIGS_HANDLER.getEventModelBuilder(NETWORK, eventBuilderConfig.getTag(), ReportNode.NO_OP);
+            ModelBuilder<EventModel> configBuilder = eventBuilderConfig.getBuilderConstructor().createBuilder(NETWORK, ReportNode.NO_OP);
+            assertNotNull(tagBuilder);
+            assertEquals(tagBuilder.getClass(), configBuilder.getClass());
+        }
+    }
+}

--- a/dynawaltz/src/test/java/com/powsybl/dynawaltz/builders/BuilderConfigTest.java
+++ b/dynawaltz/src/test/java/com/powsybl/dynawaltz/builders/BuilderConfigTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
-public class BuilderConfigTest {
+class BuilderConfigTest {
 
     private static Network NETWORK;
     private static ModelConfigsHandler MODEL_CONFIGS_HANDLER;


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
`ModelConfigsHandler::getEventModelBuilder` returns an `EventDisconnectionBuilder` when a `NodeFaultEventBuilder` is requested.


**What is the new behavior (if this is a feature change)?**
Fix `ModelConfigsHandler.eventBuilderConstructorByName` setup
Add UT for `BuilderConfig` and `EventBuilderConfig` instantiation

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

