### PR TITLE
Remove final state option from DynawoSimulationParameters

### DIFF
--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynawoSimulationTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynawoSimulationTest.java
@@ -201,8 +201,7 @@ class DynawoSimulationTest extends AbstractDynawoTest {
         dynawoSimulationParameters.setModelsParameters(modelsParameters)
                 .setNetworkParameters(networkParameters)
                 .setSolverParameters(solverParameters)
-                .setSolverType(DynawoSimulationParameters.SolverType.IDA)
-                .setWriteFinalState(false);
+                .setSolverType(DynawoSimulationParameters.SolverType.IDA);
 
         DynamicSimulationResult result = provider.run(network, dynamicModelsSupplier, eventModelsSupplier, outputVariablesSupplier,
                         VariantManagerConstants.INITIAL_VARIANT_ID, computationManager, parameters, NO_OP)

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/DynawoSimulationHandler.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/DynawoSimulationHandler.java
@@ -122,9 +122,7 @@ public final class DynawoSimulationHandler extends AbstractExecutionHandler<Dyna
 
     private void setSuccessOutputs(Path workingDir, Path outputsFolder) throws IOException {
         DynawoSimulationParameters parameters = context.getDynawoSimulationParameters();
-        if (parameters.isWriteFinalState()) {
-            updateNetwork(outputsFolder);
-        }
+        updateNetwork(outputsFolder);
         DumpFileParameters dumpFileParameters = parameters.getDumpFileParameters();
         if (dumpFileParameters.exportDumpFile()) {
             setDumpFile(outputsFolder, dumpFileParameters.dumpFileFolder(), workingDir.getFileName());

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/DynawoSimulationParameters.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/DynawoSimulationParameters.java
@@ -41,7 +41,6 @@ public class DynawoSimulationParameters extends AbstractExtension<DynamicSimulat
     public static final String MODELS_OUTPUT_PARAMETERS_FILE = "models.par";
     public static final String NETWORK_OUTPUT_PARAMETERS_FILE = "network.par";
     public static final String SOLVER_OUTPUT_PARAMETERS_FILE = "solvers.par";
-    private static final boolean DEFAULT_WRITE_FINAL_STATE = true;
     public static final boolean DEFAULT_USE_MODEL_SIMPLIFIERS = false;
     public static final double DEFAULT_PRECISION = 1e-6;
     public static final ExportMode DEFAULT_TIMELINE_EXPORT_MODE = ExportMode.TXT;
@@ -110,7 +109,6 @@ public class DynawoSimulationParameters extends AbstractExtension<DynamicSimulat
     private ParametersSet solverParameters;
     private SolverType solverType = DEFAULT_SOLVER_TYPE;
     private boolean mergeLoads = DEFAULT_MERGE_LOADS;
-    private boolean writeFinalState = DEFAULT_WRITE_FINAL_STATE;
     private boolean useModelSimplifiers = DEFAULT_USE_MODEL_SIMPLIFIERS;
     private DumpFileParameters dumpFileParameters = DumpFileParameters.createDefaultDumpFileParameters();
     private double precision = DEFAULT_PRECISION;
@@ -154,7 +152,6 @@ public class DynawoSimulationParameters extends AbstractExtension<DynamicSimulat
             c.getOptionalEnumProperty("solver.type", SolverType.class).ifPresent(parameters::setSolverType);
             // If merging loads on each bus to simplify dynawo's analysis
             c.getOptionalBooleanProperty("mergeLoads").ifPresent(parameters::setMergeLoads);
-            c.getOptionalBooleanProperty("writeFinalState").ifPresent(parameters::setWriteFinalState);
             c.getOptionalBooleanProperty("useModelSimplifiers").ifPresent(parameters::setUseModelSimplifiers);
             c.getOptionalDoubleProperty("precision").ifPresent(parameters::setPrecision);
             c.getOptionalEnumProperty("timeline.exportMode", ExportMode.class).ifPresent(parameters::setTimelineExportMode);
@@ -240,15 +237,6 @@ public class DynawoSimulationParameters extends AbstractExtension<DynamicSimulat
     public DynawoSimulationParameters setMergeLoads(boolean mergeLoads) {
         this.mergeLoads = mergeLoads;
         return this;
-    }
-
-    public DynawoSimulationParameters setWriteFinalState(boolean writeFinalState) {
-        this.writeFinalState = writeFinalState;
-        return this;
-    }
-
-    public boolean isWriteFinalState() {
-        return writeFinalState;
     }
 
     public boolean isUseModelSimplifiers() {

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/xml/JobsXml.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/xml/JobsXml.java
@@ -112,7 +112,7 @@ public final class JobsXml extends AbstractXmlDynawoSimulationWriter {
         writer.writeAttribute(EXPORT_MODE, parameters.getTimelineExportMode().toString());
 
         writer.writeEmptyElement(DYN_URI, "finalState");
-        writer.writeAttribute("exportIIDMFile", Boolean.toString(parameters.isWriteFinalState()));
+        writer.writeAttribute("exportIIDMFile", Boolean.toString(true));
         writer.writeAttribute("exportDumpFile", Boolean.toString(parameters.getDumpFileParameters().exportDumpFile()));
 
         if (context.withCurveVariables()) {

--- a/dynawo-simulation/src/test/resources/DynawoSimulationParameters.json
+++ b/dynawo-simulation/src/test/resources/DynawoSimulationParameters.json
@@ -38,7 +38,6 @@
       },
       "solverType" : "IDA",
       "mergeLoads" : false,
-      "writeFinalState" : true,
       "useModelSimplifiers" : false,
       "dumpFileParameters" : {
         "exportDumpFile" : false,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #260

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
`DynawoSimulationParameters` `writeFinalState` option can no longer be used. The value is always set to `true`.


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
