### PR TITLE
Use side in Branch VarConnection

### DIFF
--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/lines/StandardLine.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/lines/StandardLine.java
@@ -26,7 +26,7 @@ public class StandardLine extends AbstractEquipmentBlackBoxModel<Line> implement
     }
 
     private List<VarConnection> getVarConnectionsWith(EquipmentConnectionPoint connected, TwoSides side) {
-        return List.of(new VarConnection(getTerminalVarName(side), connected.getTerminalVarName()));
+        return List.of(new VarConnection(getTerminalVarName(side), connected.getTerminalVarName(side)));
     }
 
     private String getTerminalVarName(TwoSides side) {

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/transformers/TransformerFixedRatio.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/transformers/TransformerFixedRatio.java
@@ -29,7 +29,7 @@ public class TransformerFixedRatio extends AbstractEquipmentBlackBoxModel<TwoWin
     }
 
     private List<VarConnection> getVarConnectionsWith(EquipmentConnectionPoint connected, TwoSides side) {
-        return List.of(new VarConnection(getTerminalVarName(side), connected.getTerminalVarName()));
+        return List.of(new VarConnection(getTerminalVarName(side), connected.getTerminalVarName(side)));
     }
 
     private String getTerminalVarName(TwoSides side) {

--- a/dynawo-simulation/src/test/resources/cla_dyd.xml
+++ b/dynawo-simulation/src/test/resources/cla_dyd.xml
@@ -19,10 +19,10 @@
         <dyn:connect var1="currentLimitAutomaton_order" var2="@NAME@_state"/>
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_TransformerFixedRatioSide1-DefaultEquipmentConnectionPoint">
-        <dyn:connect var1="transformer_terminal1" var2="@STATIC_ID@@NODE@_ACPIN"/>
+        <dyn:connect var1="transformer_terminal1" var2="@STATIC_ID@@NODE1@_ACPIN"/>
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_TransformerFixedRatioSide2-DefaultEquipmentConnectionPoint">
-        <dyn:connect var1="transformer_terminal2" var2="@STATIC_ID@@NODE@_ACPIN"/>
+        <dyn:connect var1="transformer_terminal2" var2="@STATIC_ID@@NODE2@_ACPIN"/>
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_CurrentLimitAutomatonMeasureSide2-TransformerFixedRatio">
         <dyn:connect var1="currentLimitAutomaton_IMonitored" var2="transformer_iSide2"/>

--- a/dynawo-simulation/src/test/resources/dyd.xml
+++ b/dynawo-simulation/src/test/resources/dyd.xml
@@ -67,10 +67,10 @@
         <dyn:connect var1="generator_switchOffSignal1" var2="@STATIC_ID@@NODE@_switchOff"/>
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_Line_NHV1_NHV2_1Side1-DefaultEquipmentConnectionPoint">
-        <dyn:connect var1="line_terminal1" var2="@STATIC_ID@@NODE@_ACPIN"/>
+        <dyn:connect var1="line_terminal1" var2="@STATIC_ID@@NODE1@_ACPIN"/>
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_Line_NHV1_NHV2_1Side2-DefaultEquipmentConnectionPoint">
-        <dyn:connect var1="line_terminal2" var2="@STATIC_ID@@NODE@_ACPIN"/>
+        <dyn:connect var1="line_terminal2" var2="@STATIC_ID@@NODE2@_ACPIN"/>
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_CurrentLimitAutomatonMeasureSide1-DefaultLine">
         <dyn:connect var1="currentLimitAutomaton_IMonitored" var2="@NAME@_iSide1"/>

--- a/dynawo-simulation/src/test/resources/phase_shifter_i_dyd.xml
+++ b/dynawo-simulation/src/test/resources/phase_shifter_i_dyd.xml
@@ -9,10 +9,10 @@
         <dyn:connect var1="phaseShifter_AutomatonExists" var2="transformer_disable_internal_tapChanger"/>
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_TransformerFixedRatioSide1-DefaultEquipmentConnectionPoint">
-        <dyn:connect var1="transformer_terminal1" var2="@STATIC_ID@@NODE@_ACPIN"/>
+        <dyn:connect var1="transformer_terminal1" var2="@STATIC_ID@@NODE1@_ACPIN"/>
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_TransformerFixedRatioSide2-DefaultEquipmentConnectionPoint">
-        <dyn:connect var1="transformer_terminal2" var2="@STATIC_ID@@NODE@_ACPIN"/>
+        <dyn:connect var1="transformer_terminal2" var2="@STATIC_ID@@NODE2@_ACPIN"/>
     </dyn:macroConnector>
     <dyn:macroConnect connector="MC_PhaseShifterI-TransformerFixedRatio" id1="BBM_phase_shifter" id2="BBM_NGEN_NHV1"/>
     <dyn:macroConnect connector="MC_TransformerFixedRatioSide1-DefaultEquipmentConnectionPoint" id1="BBM_NGEN_NHV1" id2="NETWORK"/>

--- a/dynawo-simulation/src/test/resources/set_point_inf_bus_dyd.xml
+++ b/dynawo-simulation/src/test/resources/set_point_inf_bus_dyd.xml
@@ -13,7 +13,7 @@
         <dyn:connect var1="transformer_terminal1" var2="infiniteBus_terminal"/>
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_TransformerFixedRatioSide2-DefaultEquipmentConnectionPoint">
-        <dyn:connect var1="transformer_terminal2" var2="@STATIC_ID@@NODE@_ACPIN"/>
+        <dyn:connect var1="transformer_terminal2" var2="@STATIC_ID@@NODE2@_ACPIN"/>
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_SetPoint-GeneratorPQ">
         <dyn:connect var1="setPoint_setPoint" var2="generator_omegaRefPu"/>

--- a/dynawo-simulation/src/test/resources/tap_changer_blocking_dyd.xml
+++ b/dynawo-simulation/src/test/resources/tap_changer_blocking_dyd.xml
@@ -9,10 +9,10 @@
     </dyn:blackBoxModel>
     <dyn:blackBoxModel id="BBM_TapChangerBlocking" lib="TapChangerBlockingAutomaton2" parFile="models.par" parId="TapChangerPar"/>
     <dyn:macroConnector id="MC_TransformerFixedRatioSide1-DefaultEquipmentConnectionPoint">
-        <dyn:connect var1="transformer_terminal1" var2="@STATIC_ID@@NODE@_ACPIN"/>
+        <dyn:connect var1="transformer_terminal1" var2="@STATIC_ID@@NODE1@_ACPIN"/>
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_TransformerFixedRatioSide2-DefaultEquipmentConnectionPoint">
-        <dyn:connect var1="transformer_terminal2" var2="@STATIC_ID@@NODE@_ACPIN"/>
+        <dyn:connect var1="transformer_terminal2" var2="@STATIC_ID@@NODE2@_ACPIN"/>
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_LoadOneTransformerTapChanger-DefaultEquipmentConnectionPoint">
         <dyn:connect var1="transformer_terminal1" var2="@STATIC_ID@@NODE@_ACPIN"/>

--- a/dynawo-simulation/src/test/resources/tfr_dyd.xml
+++ b/dynawo-simulation/src/test/resources/tfr_dyd.xml
@@ -2,10 +2,10 @@
 <dyn:dynamicModelsArchitecture xmlns:dyn="http://www.rte-france.com/dynawo">
     <dyn:blackBoxModel id="BBM_NGEN_NHV1" lib="TransformerFixedRatio" parFile="models.par" parId="TFR" staticId="NGEN_NHV1"/>
     <dyn:macroConnector id="MC_TransformerFixedRatioSide1-DefaultEquipmentConnectionPoint">
-        <dyn:connect var1="transformer_terminal1" var2="@STATIC_ID@@NODE@_ACPIN"/>
+        <dyn:connect var1="transformer_terminal1" var2="@STATIC_ID@@NODE1@_ACPIN"/>
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_TransformerFixedRatioSide2-DefaultEquipmentConnectionPoint">
-        <dyn:connect var1="transformer_terminal2" var2="@STATIC_ID@@NODE@_ACPIN"/>
+        <dyn:connect var1="transformer_terminal2" var2="@STATIC_ID@@NODE2@_ACPIN"/>
     </dyn:macroConnector>
     <dyn:macroConnect connector="MC_TransformerFixedRatioSide1-DefaultEquipmentConnectionPoint" id1="BBM_NGEN_NHV1" id2="NETWORK"/>
     <dyn:macroConnect connector="MC_TransformerFixedRatioSide2-DefaultEquipmentConnectionPoint" id1="BBM_NGEN_NHV1" id2="NETWORK"/>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Side is not used in branch connection with Connection point (bus & bus bar section).
The side can not be used to retrieve the connection point when the default implementation is used.

**What is the new behavior (if this is a feature change)?**
Use side in Line and Transformer VarConnection with Connection Point


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

