### PR TITLE
Hvdc var name handler

### DIFF
--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/AbstractHvdcBuilder.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/AbstractHvdcBuilder.java
@@ -13,26 +13,24 @@ import com.powsybl.dynawo.builders.ModelConfig;
 import com.powsybl.dynawo.builders.BuilderReports;
 import com.powsybl.iidm.network.*;
 
-import java.util.function.Function;
-
 /**
  * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
 public abstract class AbstractHvdcBuilder<R extends AbstractEquipmentModelBuilder<HvdcLine, R>> extends AbstractEquipmentModelBuilder<HvdcLine, R> {
 
     protected TwoSides danglingSide;
-    private final Function<TwoSides, String> eventVarNameSupplier;
+    private final HvdcVarNameHandler varNameHandler;
 
     protected AbstractHvdcBuilder(Network network, ModelConfig modelConfig, IdentifiableType identifiableType,
-                                  ReportNode reportNode, Function<TwoSides, String> eventVarNameSupplier) {
+                                  ReportNode reportNode, HvdcVarNameHandler varNameHandler) {
         super(network, modelConfig, identifiableType, reportNode);
-        this.eventVarNameSupplier = eventVarNameSupplier;
+        this.varNameHandler = varNameHandler;
     }
 
     protected AbstractHvdcBuilder(Network network, ModelConfig modelConfig, String equipmentType, ReportNode reportNode,
-                                  Function<TwoSides, String> eventVarNameSupplier) {
+                                  HvdcVarNameHandler varNameHandler) {
         super(network, modelConfig, equipmentType, reportNode);
-        this.eventVarNameSupplier = eventVarNameSupplier;
+        this.varNameHandler = varNameHandler;
     }
 
     public R dangling(TwoSides danglingSide) {
@@ -57,9 +55,9 @@ public abstract class AbstractHvdcBuilder<R extends AbstractEquipmentModelBuilde
     public BaseHvdc build() {
         if (isInstantiable()) {
             if (modelConfig.isDangling()) {
-                return new HvdcDangling(dynamicModelId, getEquipment(), parameterSetId, modelConfig, eventVarNameSupplier, danglingSide);
+                return new HvdcDangling(dynamicModelId, getEquipment(), parameterSetId, modelConfig, varNameHandler, danglingSide);
             } else {
-                return new BaseHvdc(dynamicModelId, getEquipment(), parameterSetId, modelConfig, eventVarNameSupplier);
+                return new BaseHvdc(dynamicModelId, getEquipment(), parameterSetId, modelConfig, varNameHandler);
             }
         }
         return null;

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/BaseHvdc.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/BaseHvdc.java
@@ -13,7 +13,6 @@ import com.powsybl.dynawo.models.macroconnections.MacroConnectionsAdder;
 import com.powsybl.dynawo.models.AbstractEquipmentBlackBoxModel;
 import com.powsybl.dynawo.models.VarConnection;
 import com.powsybl.dynawo.models.VarMapping;
-import com.powsybl.dynawo.models.utils.SideUtils;
 import com.powsybl.iidm.network.HvdcConverterStation;
 import com.powsybl.iidm.network.HvdcLine;
 import com.powsybl.iidm.network.TwoSides;
@@ -21,7 +20,6 @@ import com.powsybl.iidm.network.TwoSides;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Function;
 
 /**
  * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
@@ -38,11 +36,11 @@ public class BaseHvdc extends AbstractEquipmentBlackBoxModel<HvdcLine> implement
 
     protected static final String TERMINAL_PREFIX = "hvdc_terminal";
 
-    private final Function<TwoSides, String> eventVarNameSupplier;
+    private final HvdcVarNameHandler varNameHandler;
 
-    protected BaseHvdc(String dynamicModelId, HvdcLine hvdc, String parameterSetId, ModelConfig modelConfig, Function<TwoSides, String> eventVarNameSupplier) {
+    protected BaseHvdc(String dynamicModelId, HvdcLine hvdc, String parameterSetId, ModelConfig modelConfig, HvdcVarNameHandler varNameHandler) {
         super(dynamicModelId, parameterSetId, hvdc, modelConfig);
-        this.eventVarNameSupplier = eventVarNameSupplier;
+        this.varNameHandler = varNameHandler;
     }
 
     @Override
@@ -60,7 +58,7 @@ public class BaseHvdc extends AbstractEquipmentBlackBoxModel<HvdcLine> implement
         List<VarConnection> varConnections = new ArrayList<>(2);
         varConnections.add(getSimpleVarConnectionWithBus(connected, side));
         connected.getSwitchOffSignalVarName(side)
-                .map(switchOff -> new VarConnection("hvdc_switchOffSignal1" + SideUtils.getSideSuffix(side), switchOff))
+                .map(switchOff -> new VarConnection(varNameHandler.getConnectionPointVarName(side), switchOff))
                 .ifPresent(varConnections::add);
         return varConnections;
     }
@@ -75,6 +73,6 @@ public class BaseHvdc extends AbstractEquipmentBlackBoxModel<HvdcLine> implement
 
     @Override
     public String getSwitchOffSignalEventVarName(TwoSides side) {
-        return eventVarNameSupplier.apply(side);
+        return varNameHandler.getEventVarName(side);
     }
 }

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/HvdcDangling.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/HvdcDangling.java
@@ -18,7 +18,6 @@ import com.powsybl.iidm.network.HvdcLine;
 import com.powsybl.iidm.network.TwoSides;
 
 import java.util.List;
-import java.util.function.Function;
 
 /**
  * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
@@ -28,8 +27,8 @@ public class HvdcDangling extends BaseHvdc {
     private final TwoSides danglingSide;
 
     protected HvdcDangling(String dynamicModelId, HvdcLine hvdc, String parameterSetId, ModelConfig modelConfig,
-                           Function<TwoSides, String> eventVarNameSupplier, TwoSides danglingSide) {
-        super(dynamicModelId, hvdc, parameterSetId, modelConfig, eventVarNameSupplier);
+                           HvdcVarNameHandler varNameHandler, TwoSides danglingSide) {
+        super(dynamicModelId, hvdc, parameterSetId, modelConfig, varNameHandler);
         this.danglingSide = danglingSide;
     }
 

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/HvdcPBuilder.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/HvdcPBuilder.java
@@ -10,14 +10,11 @@ package com.powsybl.dynawo.models.hvdc;
 import com.powsybl.commons.report.ReportNode;
 import com.powsybl.dynawo.builders.*;
 import com.powsybl.dynawo.commons.DynawoVersion;
-import com.powsybl.dynawo.models.utils.SideUtils;
 import com.powsybl.iidm.network.HvdcLine;
 import com.powsybl.iidm.network.IdentifiableType;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.TwoSides;
 
 import java.util.Collection;
-import java.util.function.Function;
 
 /**
  * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
@@ -26,7 +23,7 @@ public class HvdcPBuilder extends AbstractHvdcBuilder<HvdcPBuilder> {
 
     public static final String CATEGORY = "HVDC_P";
     private static final ModelConfigs MODEL_CONFIGS = ModelConfigsHandler.getInstance().getModelConfigs(CATEGORY);
-    private static final Function<TwoSides, String> EVENT_VAR_NAME_SUPPLIER = ts -> String.format("hvdc_switchOffSignal2%s", SideUtils.getSideSuffix(ts));
+    private static final HvdcVarNameHandler P_NAME_HANDLER = new PVarNameHandler();
 
     public static HvdcPBuilder of(Network network) {
         return of(network, ReportNode.NO_OP);
@@ -61,7 +58,7 @@ public class HvdcPBuilder extends AbstractHvdcBuilder<HvdcPBuilder> {
     }
 
     protected HvdcPBuilder(Network network, ModelConfig modelConfig, ReportNode reportNode) {
-        super(network, modelConfig, IdentifiableType.HVDC_LINE, reportNode, EVENT_VAR_NAME_SUPPLIER);
+        super(network, modelConfig, IdentifiableType.HVDC_LINE, reportNode, P_NAME_HANDLER);
     }
 
     @Override

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/HvdcPBuilder.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/HvdcPBuilder.java
@@ -23,7 +23,7 @@ public class HvdcPBuilder extends AbstractHvdcBuilder<HvdcPBuilder> {
 
     public static final String CATEGORY = "HVDC_P";
     private static final ModelConfigs MODEL_CONFIGS = ModelConfigsHandler.getInstance().getModelConfigs(CATEGORY);
-    private static final HvdcVarNameHandler P_NAME_HANDLER = new PVarNameHandler();
+    private static final HvdcVarNameHandler P_NAME_HANDLER = new HvdcPVarNameHandler();
 
     public static HvdcPBuilder of(Network network) {
         return of(network, ReportNode.NO_OP);

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/HvdcPVarNameHandler.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/HvdcPVarNameHandler.java
@@ -13,7 +13,7 @@ import com.powsybl.iidm.network.TwoSides;
 /**
  * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
  */
-public final class PVarNameHandler implements HvdcVarNameHandler {
+public final class HvdcPVarNameHandler implements HvdcVarNameHandler {
 
     @Override
     public String getConnectionPointVarName(TwoSides side) {

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/HvdcVarNameHandler.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/HvdcVarNameHandler.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com/)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.dynawo.models.hvdc;
+
+import com.powsybl.iidm.network.TwoSides;
+
+/**
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
+ */
+public interface HvdcVarNameHandler {
+
+    String getConnectionPointVarName(TwoSides side);
+
+    String getEventVarName(TwoSides side);
+}

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/HvdcVscBuilder.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/HvdcVscBuilder.java
@@ -13,7 +13,6 @@ import com.powsybl.dynawo.commons.DynawoVersion;
 import com.powsybl.iidm.network.*;
 
 import java.util.Collection;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
@@ -23,7 +22,7 @@ public class HvdcVscBuilder extends AbstractHvdcBuilder<HvdcVscBuilder> {
 
     public static final String CATEGORY = "HVDC_VSC";
     private static final ModelConfigs MODEL_CONFIGS = ModelConfigsHandler.getInstance().getModelConfigs(CATEGORY);
-    private static final Function<TwoSides, String> EVENT_VAR_NAME_SUPPLIER = ts -> String.format("hvdc_Conv%s_switchOffSignal2", ts.getNum());
+    private static final HvdcVarNameHandler VSC_NAME_HANDLER = new VscVarNameHandler();
     private static final Predicate<HvdcLine> IS_VSC = eq -> HvdcConverterStation.HvdcType.VSC == eq.getConverterStation1().getHvdcType();
 
     public static HvdcVscBuilder of(Network network) {
@@ -59,7 +58,7 @@ public class HvdcVscBuilder extends AbstractHvdcBuilder<HvdcVscBuilder> {
     }
 
     protected HvdcVscBuilder(Network network, ModelConfig modelConfig, ReportNode reportNode) {
-        super(network, modelConfig, "VSC " + IdentifiableType.HVDC_LINE, reportNode, EVENT_VAR_NAME_SUPPLIER);
+        super(network, modelConfig, "VSC " + IdentifiableType.HVDC_LINE, reportNode, VSC_NAME_HANDLER);
         addEquipmentPredicate(IS_VSC);
     }
 

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/PVarNameHandler.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/PVarNameHandler.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com/)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.dynawo.models.hvdc;
+
+import com.powsybl.dynawo.models.utils.SideUtils;
+import com.powsybl.iidm.network.TwoSides;
+
+/**
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
+ */
+public final class PVarNameHandler implements HvdcVarNameHandler {
+
+    @Override
+    public String getConnectionPointVarName(TwoSides side) {
+        return String.format("hvdc_switchOffSignal1%s", SideUtils.getSideSuffix(side));
+    }
+
+    @Override
+    public String getEventVarName(TwoSides side) {
+        return String.format("hvdc_switchOffSignal2%s", SideUtils.getSideSuffix(side));
+    }
+}

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/VscVarNameHandler.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/VscVarNameHandler.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com/)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.dynawo.models.hvdc;
+
+import com.powsybl.iidm.network.TwoSides;
+
+/**
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
+ */
+public final class VscVarNameHandler implements HvdcVarNameHandler {
+
+    @Override
+    public String getConnectionPointVarName(TwoSides side) {
+        return String.format("hvdc_Conv%s_switchOffSignal1", side.getNum());
+    }
+
+    @Override
+    public String getEventVarName(TwoSides side) {
+        return String.format("hvdc_Conv%s_switchOffSignal2", side.getNum());
+    }
+}

--- a/dynawo-simulation/src/test/resources/disconnect_hvdc_vsc_dangling_dyd.xml
+++ b/dynawo-simulation/src/test/resources/disconnect_hvdc_vsc_dangling_dyd.xml
@@ -9,7 +9,7 @@
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_HvdcVscDanglingUdcSide2-DefaultEquipmentConnectionPoint">
         <dyn:connect var1="hvdc_terminal2" var2="@STATIC_ID@@NODE2@_ACPIN"/>
-        <dyn:connect var1="hvdc_switchOffSignal1Side2" var2="@STATIC_ID@@NODE2@_switchOff"/>
+        <dyn:connect var1="hvdc_Conv2_switchOffSignal1" var2="@STATIC_ID@@NODE2@_switchOff"/>
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_EventHvdcDisconnectionSide2-HvdcVscDanglingUdc">
         <dyn:connect var1="event_state1" var2="hvdc_Conv2_switchOffSignal2"/>

--- a/dynawo-simulation/src/test/resources/disconnect_hvdc_vsc_dyd.xml
+++ b/dynawo-simulation/src/test/resources/disconnect_hvdc_vsc_dyd.xml
@@ -6,11 +6,11 @@
     <dyn:blackBoxModel id="Disconnect_L" lib="EventSetPointBoolean" parFile="hvdctest.par" parId="Disconnect_L"/>
     <dyn:macroConnector id="MC_HvdcVscSide1-DefaultEquipmentConnectionPoint">
         <dyn:connect var1="hvdc_terminal1" var2="@STATIC_ID@@NODE1@_ACPIN"/>
-        <dyn:connect var1="hvdc_switchOffSignal1Side1" var2="@STATIC_ID@@NODE1@_switchOff"/>
+        <dyn:connect var1="hvdc_Conv1_switchOffSignal1" var2="@STATIC_ID@@NODE1@_switchOff"/>
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_HvdcVscSide2-DefaultEquipmentConnectionPoint">
         <dyn:connect var1="hvdc_terminal2" var2="@STATIC_ID@@NODE2@_ACPIN"/>
-        <dyn:connect var1="hvdc_switchOffSignal1Side2" var2="@STATIC_ID@@NODE2@_switchOff"/>
+        <dyn:connect var1="hvdc_Conv2_switchOffSignal1" var2="@STATIC_ID@@NODE2@_switchOff"/>
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_EventHvdcDisconnectionSide2-HvdcVsc">
         <dyn:connect var1="event_state1" var2="hvdc_Conv2_switchOffSignal2"/>

--- a/dynawo-simulation/src/test/resources/hvdc_vsc_dangling_dyd.xml
+++ b/dynawo-simulation/src/test/resources/hvdc_vsc_dangling_dyd.xml
@@ -8,7 +8,7 @@
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_HvdcVscDanglingPSide1-DefaultEquipmentConnectionPoint">
         <dyn:connect var1="hvdc_terminal1" var2="@STATIC_ID@@NODE1@_ACPIN"/>
-        <dyn:connect var1="hvdc_switchOffSignal1Side1" var2="@STATIC_ID@@NODE1@_switchOff"/>
+        <dyn:connect var1="hvdc_Conv1_switchOffSignal1" var2="@STATIC_ID@@NODE1@_switchOff"/>
     </dyn:macroConnector>
     <dyn:macroStaticReference id="MSR_HvdcVscDanglingP">
         <dyn:staticRef var="hvdc_PInj1Pu" staticVar="p1"/>

--- a/dynawo-simulation/src/test/resources/hvdc_vsc_dyd.xml
+++ b/dynawo-simulation/src/test/resources/hvdc_vsc_dyd.xml
@@ -5,11 +5,11 @@
     </dyn:blackBoxModel>
     <dyn:macroConnector id="MC_HvdcVscSide1-DefaultEquipmentConnectionPoint">
         <dyn:connect var1="hvdc_terminal1" var2="@STATIC_ID@@NODE1@_ACPIN"/>
-        <dyn:connect var1="hvdc_switchOffSignal1Side1" var2="@STATIC_ID@@NODE1@_switchOff"/>
+        <dyn:connect var1="hvdc_Conv1_switchOffSignal1" var2="@STATIC_ID@@NODE1@_switchOff"/>
     </dyn:macroConnector>
     <dyn:macroConnector id="MC_HvdcVscSide2-DefaultEquipmentConnectionPoint">
         <dyn:connect var1="hvdc_terminal2" var2="@STATIC_ID@@NODE2@_ACPIN"/>
-        <dyn:connect var1="hvdc_switchOffSignal1Side2" var2="@STATIC_ID@@NODE2@_switchOff"/>
+        <dyn:connect var1="hvdc_Conv2_switchOffSignal1" var2="@STATIC_ID@@NODE2@_switchOff"/>
     </dyn:macroConnector>
     <dyn:macroStaticReference id="MSR_HvdcVsc">
         <dyn:staticRef var="hvdc_PInj1Pu" staticVar="p1"/>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Both Hvdc P and Vsc use an _event var name supplier_ returning var name specific to each model.
_Connection point var name_ should have the same system but at the moment Hvdc P var name is used by both models.


**What is the new behavior (if this is a feature change)?**
Replace Hvdc _event var name supplier_ with `HvdcVarNameHandler` class returning event and Connection point var name.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
