### PR TITLE
Change HvdcBuilder variable access level 

### DIFF
--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/AbstractHvdcBuilder.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/hvdc/AbstractHvdcBuilder.java
@@ -18,10 +18,10 @@ import com.powsybl.iidm.network.*;
  */
 public abstract class AbstractHvdcBuilder<R extends AbstractEquipmentModelBuilder<HvdcLine, R>> extends AbstractEquipmentModelBuilder<HvdcLine, R> {
 
-    private static final TwoSides DEFAULT_DANGLING_SIDE = TwoSides.TWO;
+    protected static final TwoSides DEFAULT_DANGLING_SIDE = TwoSides.TWO;
 
     protected TwoSides danglingSide;
-    private final HvdcVarNameHandler varNameHandler;
+    protected final HvdcVarNameHandler varNameHandler;
 
     protected AbstractHvdcBuilder(Network network, ModelConfig modelConfig, IdentifiableType identifiableType,
                                   ReportNode reportNode, HvdcVarNameHandler varNameHandler) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**
Change `AbstractHvdcBuilder` `varNameHandler` and `DEFAULT_DANGLING_SIDE` access level to protected


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No