### PR TITLE
Build PreContingencyResult from Dynawo result

### DIFF
--- a/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysisHandler.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowSecurityAnalysisHandler.java
@@ -26,18 +26,17 @@ import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.security.LimitViolationFilter;
 import com.powsybl.security.SecurityAnalysisParameters;
 import com.powsybl.security.SecurityAnalysisReport;
-import com.powsybl.security.SecurityAnalysisResult;
 import com.powsybl.security.interceptors.SecurityAnalysisInterceptor;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import static com.powsybl.dynaflow.DynaFlowConstants.CONFIG_FILENAME;
 import static com.powsybl.dynaflow.SecurityAnalysisConstants.CONTINGENCIES_FILENAME;
+import static com.powsybl.dynaflow.results.ContingencyResultsUtils.createSecurityAnalysisResult;
 import static com.powsybl.dynawo.commons.DynawoConstants.NETWORK_FILENAME;
 import static com.powsybl.dynawo.commons.DynawoConstants.TIMELINE_FOLDER;
 import static com.powsybl.dynawo.commons.DynawoUtil.getCommandExecutions;
@@ -85,12 +84,7 @@ public final class DynaFlowSecurityAnalysisHandler extends AbstractExecutionHand
         super.after(workingDir, report);
         network.getVariantManager().setWorkingVariant(workingVariantId);
         ContingencyResultsUtils.reportContingenciesTimelines(contingencies, workingDir.resolve(TIMELINE_FOLDER), reportNode);
-        return new SecurityAnalysisReport(
-                new SecurityAnalysisResult(
-                        ContingencyResultsUtils.getPreContingencyResult(network, violationFilter),
-                        ContingencyResultsUtils.getPostContingencyResults(network, violationFilter, workingDir, contingencies),
-                        Collections.emptyList())
-        );
+        return new SecurityAnalysisReport(createSecurityAnalysisResult(network, violationFilter, workingDir, contingencies));
     }
 
     private static void writeContingencies(List<Contingency> contingencies, Path workingDir) throws IOException {

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/SecurityAnalysisConstants.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/SecurityAnalysisConstants.java
@@ -16,6 +16,8 @@ public final class SecurityAnalysisConstants {
 
     public static final String CONTINGENCIES_FILENAME = "contingencies.json";
 
+    public static final String BASE_SCENARIO_NAME = "Base";
+
     private SecurityAnalysisConstants() {
     }
 

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/results/ResultsUtil.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/results/ResultsUtil.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.dynaflow.results;
 
+import com.powsybl.loadflow.LoadFlowResult;
 import com.powsybl.security.PostContingencyComputationStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,7 +17,6 @@ import java.util.Optional;
 
 import static com.powsybl.dynaflow.results.Status.CONVERGENCE;
 import static com.powsybl.dynaflow.results.Status.CRITERIA_NON_RESPECTED;
-import static com.powsybl.security.PostContingencyComputationStatus.*;
 
 /**
  * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
@@ -28,11 +28,18 @@ public final class ResultsUtil {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResultsUtil.class);
 
-    public static PostContingencyComputationStatus convertStatus(Status status) {
+    public static PostContingencyComputationStatus convertToPostStatus(Status status) {
         return switch (status) {
-            case CONVERGENCE -> CONVERGED;
-            case DIVERGENCE -> SOLVER_FAILED;
-            case EXECUTION_PROBLEM, CRITERIA_NON_RESPECTED -> FAILED;
+            case CONVERGENCE -> PostContingencyComputationStatus.CONVERGED;
+            case DIVERGENCE -> PostContingencyComputationStatus.SOLVER_FAILED;
+            case EXECUTION_PROBLEM, CRITERIA_NON_RESPECTED -> PostContingencyComputationStatus.FAILED;
+        };
+    }
+
+    public static LoadFlowResult.ComponentResult.Status convertToPreStatus(Status status) {
+        return switch (status) {
+            case CONVERGENCE -> LoadFlowResult.ComponentResult.Status.CONVERGED;
+            case DIVERGENCE, EXECUTION_PROBLEM, CRITERIA_NON_RESPECTED -> LoadFlowResult.ComponentResult.Status.FAILED;
         };
     }
 

--- a/dynaflow/src/main/java/com/powsybl/dynaflow/xml/ConstraintsReader.java
+++ b/dynaflow/src/main/java/com/powsybl/dynaflow/xml/ConstraintsReader.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 /**
  * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
@@ -53,6 +54,7 @@ public final class ConstraintsReader {
 
     private static final Supplier<XMLInputFactory> XML_INPUT_FACTORY_SUPPLIER = Suppliers.memoize(XMLInputFactory::newInstance);
     public static final String DYN_CALCULATED_BUS_PREFIX = "calculatedBus_";
+    public static final Pattern DYN_CALCULATED_BUS_PATTERN = Pattern.compile("calculatedBus_" + ".*_\\d*");
 
     public static List<LimitViolation> read(Network network, Path xmlFile) {
         try (InputStream is = Files.newInputStream(xmlFile)) {
@@ -130,7 +132,7 @@ public final class ConstraintsReader {
     }
 
     private static Optional<Identifiable<?>> getLimitViolationIdentifiable(Network network, String name) {
-        if (name.matches(DYN_CALCULATED_BUS_PREFIX + ".*_\\d*")) {
+        if (DYN_CALCULATED_BUS_PATTERN.matcher(name).matches()) {
             // FIXME: the voltage level information should be directly referenced
             // The naming corresponds to buses which are calculated in dynawo: https://github.com/dynawo/dynawo/blob/8f1e20e43db7ec4d2e4982deac8307dfa8d0dbec/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNVoltageLevelInterfaceIIDM.cpp#L290
             String vlId = name.substring(DYN_CALCULATED_BUS_PREFIX.length(), name.lastIndexOf("_"));

--- a/dynawo-integration-tests/src/test/resources/ieee14/dynamic-security-analysis/convergence/results.json
+++ b/dynawo-integration-tests/src/test/resources/ieee14/dynamic-security-analysis/convergence/results.json
@@ -7,10 +7,10 @@
         "subjectId" : "_BUS____1-BUS____2-1_AC",
         "subjectName" : "BUS    1-BUS    2-1",
         "limitType" : "CURRENT",
-        "limitName" : "permanent",
+        "limitName" : "PATL",
         "limit" : 836.74,
         "limitReduction" : 1.0,
-        "value" : 1248.0773003764798,
+        "value" : 1248.100487597837,
         "side" : "ONE"
       } ],
       "actionsTaken" : [ ]

--- a/dynawo-integration-tests/src/test/resources/ieee14/dynamic-security-analysis/divergence/results.json
+++ b/dynawo-integration-tests/src/test/resources/ieee14/dynamic-security-analysis/divergence/results.json
@@ -1,16 +1,16 @@
 {
   "version" : "1.7",
   "preContingencyResult" : {
-    "status" : "CONVERGED",
+    "status" : "FAILED",
     "limitViolationsResult" : {
       "limitViolations" : [ {
         "subjectId" : "_BUS____1-BUS____2-1_AC",
         "subjectName" : "BUS    1-BUS    2-1",
         "limitType" : "CURRENT",
-        "limitName" : "permanent",
+        "limitName" : "PATL",
         "limit" : 836.74,
         "limitReduction" : 1.0,
-        "value" : 1248.0773003764798,
+        "value" : 1248.100487597837,
         "side" : "ONE"
       } ],
       "actionsTaken" : [ ]

--- a/dynawo-integration-tests/src/test/resources/ieee14/dynamic-security-analysis/failed-criteria/results.json
+++ b/dynawo-integration-tests/src/test/resources/ieee14/dynamic-security-analysis/failed-criteria/results.json
@@ -1,16 +1,16 @@
 {
   "version" : "1.7",
   "preContingencyResult" : {
-    "status" : "CONVERGED",
+    "status" : "FAILED",
     "limitViolationsResult" : {
       "limitViolations" : [ {
         "subjectId" : "_BUS____1-BUS____2-1_AC",
         "subjectName" : "BUS    1-BUS    2-1",
         "limitType" : "CURRENT",
-        "limitName" : "permanent",
+        "limitName" : "PATL",
         "limit" : 836.74,
         "limitReduction" : 1.0,
-        "value" : 1248.0773003764798,
+        "value" : 1248.100487597837,
         "side" : "ONE"
       } ],
       "actionsTaken" : [ ]

--- a/dynawo-security-analysis/src/main/java/com/powsybl/dynawo/security/DynawoSecurityAnalysisHandler.java
+++ b/dynawo-security-analysis/src/main/java/com/powsybl/dynawo/security/DynawoSecurityAnalysisHandler.java
@@ -24,7 +24,6 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.serde.NetworkSerDe;
 import com.powsybl.security.LimitViolationFilter;
 import com.powsybl.security.SecurityAnalysisReport;
-import com.powsybl.security.SecurityAnalysisResult;
 import com.powsybl.security.interceptors.SecurityAnalysisInterceptor;
 
 import javax.xml.stream.XMLStreamException;
@@ -32,9 +31,9 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
+import static com.powsybl.dynaflow.results.ContingencyResultsUtils.createSecurityAnalysisResult;
 import static com.powsybl.dynawo.DynawoFilesUtils.deleteExistingFile;
 import static com.powsybl.dynawo.commons.DynawoConstants.*;
 import static com.powsybl.dynawo.commons.DynawoUtil.getCommandExecutions;
@@ -79,13 +78,7 @@ public final class DynawoSecurityAnalysisHandler extends AbstractExecutionHandle
             NetworkResultsUpdater.update(context.getNetwork(), NetworkSerDe.read(outputNetworkFile), context.getDynawoSimulationParameters().isMergeLoads());
         }
         ContingencyResultsUtils.reportContingenciesTimelines(context.getContingencies(), workingDir.resolve(TIMELINE_FOLDER), reportNode);
-
-        return new SecurityAnalysisReport(
-                new SecurityAnalysisResult(
-                        ContingencyResultsUtils.getPreContingencyResult(network, violationFilter),
-                        ContingencyResultsUtils.getPostContingencyResults(network, violationFilter, workingDir, context.getContingencies()),
-                        Collections.emptyList())
-        );
+        return new SecurityAnalysisReport(createSecurityAnalysisResult(network, violationFilter, workingDir, context.getContingencies()));
     }
 
     private void writeInputFiles(Path workingDir) {

--- a/dynawo-security-analysis/src/main/java/com/powsybl/dynawo/security/xml/MultipleJobsXml.java
+++ b/dynawo-security-analysis/src/main/java/com/powsybl/dynawo/security/xml/MultipleJobsXml.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Objects;
 
+import static com.powsybl.dynaflow.SecurityAnalysisConstants.BASE_SCENARIO_NAME;
 import static com.powsybl.dynawo.DynawoSimulationConstants.JOBS_FILENAME;
 import static com.powsybl.dynawo.DynawoSimulationConstants.MULTIPLE_JOBS_FILENAME;
 
@@ -52,6 +53,6 @@ public final class MultipleJobsXml {
 
     private static void writeBaseScenario(XMLStreamWriter writer) throws XMLStreamException {
         writer.writeEmptyElement("scenario");
-        writer.writeAttribute("id", "Base");
+        writer.writeAttribute("id", BASE_SCENARIO_NAME);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
In dynamic SA a base scenario is always launched before the contingencies' ones, but its result is never used for `PreContingencyResult` creation.
Instead, the limit violations are checked via the Security API and `PreContingencyResult::status` is always set to `CONVERGED`.


**What is the new behavior (if this is a feature change)?**
Build `PreContingencyResult` from the base dynamic SA scenario results (`aggregatedResults.xml `and constraints files)


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
