### PR TITLE
Add alternative Tap Changer Builder side setter

### DIFF
--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/automationsystems/TapChangerAutomationSystemBuilder.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/models/automationsystems/TapChangerAutomationSystemBuilder.java
@@ -79,6 +79,11 @@ public class TapChangerAutomationSystemBuilder extends AbstractAutomationSystemM
         return self();
     }
 
+    public TapChangerAutomationSystemBuilder side(String side) {
+        this.side = TransformerSide.valueOf(side);
+        return self();
+    }
+
     @Override
     protected void checkData() {
         super.checkData();

--- a/dynawo-simulation/src/test/java/com/powsybl/dynawo/suppliers/DynawoModelsSupplierTest.java
+++ b/dynawo-simulation/src/test/java/com/powsybl/dynawo/suppliers/DynawoModelsSupplierTest.java
@@ -10,6 +10,8 @@ package com.powsybl.dynawo.suppliers;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
 import com.powsybl.dynamicsimulation.DynamicModel;
+import com.powsybl.dynawo.models.TransformerSide;
+import com.powsybl.dynawo.models.automationsystems.TapChangerAutomationSystemBuilder;
 import com.powsybl.dynawo.models.automationsystems.TapChangerBlockingAutomationSystemBuilder;
 import com.powsybl.dynawo.models.generators.SynchronizedGeneratorBuilder;
 import com.powsybl.dynawo.suppliers.dynamicmodels.DynamicModelConfig;
@@ -46,6 +48,12 @@ class DynawoModelsSupplierTest {
                 .staticId("GEN")
                 .parameterSetId("DM_GEN")
                 .build();
+        DynamicModel tc = TapChangerAutomationSystemBuilder.of(network)
+                .dynamicModelId("TC")
+                .parameterSetId("tc_par")
+                .staticId("LOAD")
+                .side(TransformerSide.LOW_VOLTAGE)
+                .build();
         DynamicModel tcb = TapChangerBlockingAutomationSystemBuilder.of(network)
                 .dynamicModelId("TCB1")
                 .parameterSetId("tcb_par")
@@ -59,10 +67,11 @@ class DynawoModelsSupplierTest {
                 .uMeasurements("NHV2")
                 .build();
 
-        assertEquals(3, models.size());
+        assertEquals(4, models.size());
         assertThat(models.get(0)).usingRecursiveComparison().isEqualTo(gen);
-        assertThat(models.get(1)).usingRecursiveComparison().isEqualTo(tcb);
-        assertThat(models.get(2)).usingRecursiveComparison().isEqualTo(tcb2);
+        assertThat(models.get(1)).usingRecursiveComparison().isEqualTo(tc);
+        assertThat(models.get(2)).usingRecursiveComparison().isEqualTo(tcb);
+        assertThat(models.get(3)).usingRecursiveComparison().isEqualTo(tcb2);
     }
 
     @Test
@@ -130,6 +139,22 @@ class DynawoModelsSupplierTest {
                         new PropertyBuilder()
                                 .name("staticId")
                                 .value("GEN")
+                                .type(PropertyType.STRING)
+                                .build())),
+                new DynamicModelConfig("TapChangerAutomaton", "tc_par", SetGroupType.FIXED, List.of(
+                        new PropertyBuilder()
+                                .name("dynamicModelId")
+                                .value("TC")
+                                .type(PropertyType.STRING)
+                                .build(),
+                        new PropertyBuilder()
+                                .name("staticId")
+                                .value("LOAD")
+                                .type(PropertyType.STRING)
+                                .build(),
+                        new PropertyBuilder()
+                                .name("side")
+                                .value("LOW_VOLTAGE")
                                 .type(PropertyType.STRING)
                                 .build())),
                 getTcbConfig(),

--- a/dynawo-simulation/src/test/java/com/powsybl/dynawo/xml/TapChangerAutomationSystemXmlTest.java
+++ b/dynawo-simulation/src/test/java/com/powsybl/dynawo/xml/TapChangerAutomationSystemXmlTest.java
@@ -66,7 +66,7 @@ class TapChangerAutomationSystemXmlTest extends AbstractDynamicModelXmlTest {
                 .dynamicModelId("BBM_TC3")
                 .parameterSetId("tc")
                 .staticId("LOAD3")
-                .side(TransformerSide.HIGH_VOLTAGE)
+                .side("HIGH_VOLTAGE")
                 .build());
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix / feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
`TapChangerAutomationSystemBuilder` has only one setter `side` taking an`TransformerSide` enum as argument.
This setting work with Groovy DSL supplier but the `DynawoModelsSupplier` cannot use it since the type of each property  has to be specified with an `PropertyType`.


**What is the new behavior (if this is a feature change)?**
Since the `TransformerSide`enum is rather specific,  we add a new `TapChangerAutomationSystemBuilder::side` with String argument.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
