### PR TITLE
Remove curves sanitizer

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,37 +18,25 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
-        with:
-          path: main
-
-      - name: Checkout powsybl-core branch
-        uses: actions/checkout@v4
-        with:
-          repository: powsybl/powsybl-core
-          ref: refs/heads/optional_duplicate_timeseries_index
-          path: powsybl-core
+        uses: actions/checkout@v1
 
       - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
           java-version: 17
 
-      - name: Build and install powsybl-core with Maven
-        run: mvn --batch-mode -DskipTests=true --file ./powsybl-core/pom.xml install
-
       - name: Build with Maven
         if: matrix.os == 'ubuntu-latest'
-        run: mvn --batch-mode -Pintegration-tests,jacoco --file ./main/pom.xml install
+        run: mvn --batch-mode -Pintegration-tests,jacoco install
 
       - name: Build with Maven
         if: matrix.os != 'ubuntu-latest'
-        run: mvn --batch-mode --file ./main/pom.xml install
+        run: mvn --batch-mode install
 
       - name: Run SonarCloud analysis
         if: matrix.os == 'ubuntu-latest'
         run: >
-          mvn --batch-mode -DskipTests --file ./main/pom.xml sonar:sonar
+          mvn --batch-mode -DskipTests sonar:sonar
           -Dsonar.host.url=https://sonarcloud.io
           -Dsonar.organization=powsybl-ci-github
           -Dsonar.projectKey=com.powsybl:powsybl-dynawo

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,25 +18,37 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
+        with:
+          path: main
+
+      - name: Checkout powsybl-core branch
+        uses: actions/checkout@v4
+        with:
+          repository: powsybl/powsybl-core
+          ref: refs/heads/optional_duplicate_timeseries_index
+          path: powsybl-core
 
       - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
           java-version: 17
 
+      - name: Build and install powsybl-core with Maven
+        run: mvn --batch-mode -DskipTests=true --file ./powsybl-core/pom.xml install
+
       - name: Build with Maven
         if: matrix.os == 'ubuntu-latest'
-        run: mvn --batch-mode -Pintegration-tests,jacoco install
+        run: mvn --batch-mode -Pintegration-tests,jacoco --file ./main/pom.xml install
 
       - name: Build with Maven
         if: matrix.os != 'ubuntu-latest'
-        run: mvn --batch-mode install
+        run: mvn --batch-mode --file ./main/pom.xml install
 
       - name: Run SonarCloud analysis
         if: matrix.os == 'ubuntu-latest'
         run: >
-          mvn --batch-mode -DskipTests sonar:sonar
+          mvn --batch-mode -DskipTests --file ./main/pom.xml sonar:sonar
           -Dsonar.host.url=https://sonarcloud.io
           -Dsonar.organization=powsybl-ci-github
           -Dsonar.projectKey=com.powsybl:powsybl-dynawo

--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynawoSimulationTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynawoSimulationTest.java
@@ -331,7 +331,6 @@ class DynawoSimulationTest extends AbstractDynawoTest {
                 .setNetworkParameters(networkParameters)
                 .setSolverParameters(solverParameters)
                 .setSolverType(DynawoSimulationParameters.SolverType.IDA)
-//                .setPrecision(1.0E-3)
                 .setTimelineExportMode(ExportMode.XML);
 
         return () -> provider.run(network, dynamicModelsSupplier, eventModelsSupplier, outputVariablesSupplier,

--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynawoSimulationTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynawoSimulationTest.java
@@ -72,7 +72,7 @@ class DynawoSimulationTest extends AbstractDynawoTest {
         assertEquals(27, result.getCurves().size());
         DoubleTimeSeries ts1 = result.getCurve("_GEN____1_SM_generator_UStatorPu");
         assertEquals("_GEN____1_SM_generator_UStatorPu", ts1.getMetadata().getName());
-        assertEquals(192, ts1.toArray().length);
+        assertEquals(258, ts1.toArray().length);
         assertEquals(14, result.getFinalStateValues().size());
         assertEquals(1.046227, result.getFinalStateValues().get("NETWORK__BUS___10_TN_Upu_value"));
         List<TimelineEvent> timeLine = result.getTimeLine();
@@ -331,6 +331,7 @@ class DynawoSimulationTest extends AbstractDynawoTest {
                 .setNetworkParameters(networkParameters)
                 .setSolverParameters(solverParameters)
                 .setSolverType(DynawoSimulationParameters.SolverType.IDA)
+//                .setPrecision(1.0E-3)
                 .setTimelineExportMode(ExportMode.XML);
 
         return () -> provider.run(network, dynamicModelsSupplier, eventModelsSupplier, outputVariablesSupplier,

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/DynawoSimulationHandler.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/DynawoSimulationHandler.java
@@ -182,8 +182,9 @@ public final class DynawoSimulationHandler extends AbstractExecutionHandler<Dyna
     private void setCurves(Path workingDir) {
         Path curvesPath = workingDir.resolve(CURVES_OUTPUT_PATH).resolve(CURVES_FILENAME);
         if (Files.exists(curvesPath)) {
-            TimeSeries.parseCsv(curvesPath, new TimeSeriesCsvConfig(TimeSeriesConstants.DEFAULT_SEPARATOR, false, TimeSeries.TimeFormat.FRACTIONS_OF_SECOND))
-                    .values().forEach(l -> l.forEach(curve -> curves.put(curve.getMetadata().getName(), (DoubleTimeSeries) curve)));
+            TimeSeries.parseCsv(curvesPath, new TimeSeriesCsvConfig(TimeSeriesConstants.DEFAULT_SEPARATOR, false,
+                            TimeSeries.TimeFormat.FRACTIONS_OF_SECOND, true, true))
+                    .values().forEach(l -> l.forEach(curve -> curves.put(curve.getMetadata().getName(),(DoubleTimeSeries) curve)));
         } else {
             LOGGER.warn("Curves folder not found");
             status = DynamicSimulationResult.Status.FAILURE;

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/DynawoSimulationHandler.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/DynawoSimulationHandler.java
@@ -183,20 +183,12 @@ public final class DynawoSimulationHandler extends AbstractExecutionHandler<Dyna
         Path curvesPath = workingDir.resolve(CURVES_OUTPUT_PATH).resolve(CURVES_FILENAME);
         if (Files.exists(curvesPath)) {
             TimeSeries.parseCsv(curvesPath, new TimeSeriesCsvConfig(TimeSeriesConstants.DEFAULT_SEPARATOR, false, TimeSeries.TimeFormat.FRACTIONS_OF_SECOND))
-                    .values().forEach(l -> l.forEach(curve -> curves.put(curve.getMetadata().getName(), sanitizeDoubleTimeSeries((DoubleTimeSeries) curve))));
+                    .values().forEach(l -> l.forEach(curve -> curves.put(curve.getMetadata().getName(), (DoubleTimeSeries) curve)));
         } else {
             LOGGER.warn("Curves folder not found");
             status = DynamicSimulationResult.Status.FAILURE;
             statusText = "Dynawo curves folder not found";
         }
-    }
-
-    private DoubleTimeSeries sanitizeDoubleTimeSeries(DoubleTimeSeries series) {
-        Set<Long> times = new LinkedHashSet<>();
-        double[] values = series.stream().filter(dp -> times.add(dp.getTime())).mapToDouble(DoublePoint::getValue).toArray();
-        return TimeSeries.createDouble(series.getMetadata().getName(),
-                new IrregularTimeSeriesIndex(times.stream().mapToLong(l -> l).toArray()),
-                values);
     }
 
     private void setFinalStateValues(Path workingDir) {

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/DynawoSimulationHandler.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/DynawoSimulationHandler.java
@@ -184,7 +184,7 @@ public final class DynawoSimulationHandler extends AbstractExecutionHandler<Dyna
         if (Files.exists(curvesPath)) {
             TimeSeries.parseCsv(curvesPath, new TimeSeriesCsvConfig(TimeSeriesConstants.DEFAULT_SEPARATOR, false,
                             TimeSeries.TimeFormat.FRACTIONS_OF_SECOND, true, true))
-                    .values().forEach(l -> l.forEach(curve -> curves.put(curve.getMetadata().getName(),(DoubleTimeSeries) curve)));
+                    .values().forEach(l -> l.forEach(curve -> curves.put(curve.getMetadata().getName(), (DoubleTimeSeries) curve)));
         } else {
             LOGGER.warn("Curves folder not found");
             status = DynamicSimulationResult.Status.FAILURE;

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <powsybl-core.version>6.6.0</powsybl-core.version>
+        <powsybl-core.version>6.7.0-SNAPSHOT</powsybl-core.version>
         <groovy.version>4.0.14</groovy.version> <!-- used for groovy-json but also for groovydoc (dynawo-dsl) -->
         <asciitable.version>0.3.2</asciitable.version>
         <jackson.version>2.17.1</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <powsybl-core.version>6.7.0-SNAPSHOT</powsybl-core.version>
+        <powsybl-core.version>6.6.1</powsybl-core.version>
         <groovy.version>4.0.14</groovy.version> <!-- used for groovy-json but also for groovydoc (dynawo-dsl) -->
         <asciitable.version>0.3.2</asciitable.version>
         <jackson.version>2.17.1</jackson.version>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Use `DynawoSimulationHandler::sanitizeDoubleTimeSeries` method to handle duplicate times in curves


**What is the new behavior (if this is a feature change)?**
Remove `sanitizeDoubleTimeSeries` method and use core [PR 3243](https://github.com/powsybl/powsybl-core/pull/3243l) with `TimeSeriesCsvConfig::skipDuplicateTimeEntry` instead.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
