### PR TITLE
Return curves, fsv and timeline even if the simulation diverged

### DIFF
--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynawoSimulationTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynawoSimulationTest.java
@@ -222,10 +222,12 @@ class DynawoSimulationTest extends AbstractDynawoTest {
         GroovyDynamicModelsSupplier dynamicModelsSupplier = new GroovyDynamicModelsSupplier(
                 getResourceAsStream("/error/models.groovy"),
                 GroovyExtension.find(DynamicModelGroovyExtension.class, DynawoSimulationProvider.NAME));
-
         GroovyEventModelsSupplier eventModelsSupplier = new GroovyEventModelsSupplier(
                 getResourceAsStream("/error/eventModels.groovy"),
                 GroovyExtension.find(EventModelGroovyExtension.class, DynawoSimulationProvider.NAME));
+        GroovyOutputVariablesSupplier outputVariablesSupplier = new GroovyOutputVariablesSupplier(
+                getResourceAsStream("/ieee14/disconnectline/outputVariables.groovy"),
+                GroovyExtension.find(OutputVariableGroovyExtension.class, DynawoSimulationProvider.NAME));
 
         parameters.setStopTime(200);
         dynawoSimulationParameters.setModelsParameters(ParametersXml.load(getResourceAsStream("/error/models.par")))
@@ -233,14 +235,15 @@ class DynawoSimulationTest extends AbstractDynawoTest {
                 .setSolverParameters(ParametersXml.load(getResourceAsStream("/error/solvers.par"), "3"))
                 .setSolverType(DynawoSimulationParameters.SolverType.SIM);
 
-        DynamicSimulationResult result = provider.run(network, dynamicModelsSupplier, eventModelsSupplier, OutputVariablesSupplier.empty(),
+        DynamicSimulationResult result = provider.run(network, dynamicModelsSupplier, eventModelsSupplier, outputVariablesSupplier,
                         VariantManagerConstants.INITIAL_VARIANT_ID, computationManager, parameters, NO_OP)
                 .join();
 
         assertEquals(DynamicSimulationResult.Status.FAILURE, result.getStatus());
         assertThat(result.getStatusText()).contains("time step <= 0.1 s for more than 10 iterations");
-        assertThat(result.getTimeLine()).isEmpty();
-        assertThat(result.getCurves()).isEmpty();
+        assertThat(result.getTimeLine()).isNotEmpty();
+        assertThat(result.getCurves()).isNotEmpty();
+        assertThat(result.getFinalStateValues()).isNotEmpty();
     }
 
     @Test

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/DynawoSimulationHandler.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/DynawoSimulationHandler.java
@@ -90,6 +90,13 @@ public final class DynawoSimulationHandler extends AbstractExecutionHandler<Dyna
         Path outputsFolder = workingDir.resolve(OUTPUTS_FOLDER);
         context.getNetwork().getVariantManager().setWorkingVariant(context.getWorkingVariantId());
         setDynawoLog(outputsFolder, context.getDynawoSimulationParameters().getSpecificLogs());
+        setTimeline(outputsFolder);
+        if (context.withCurveVariables()) {
+            setCurves(outputsFolder);
+        }
+        if (context.withFsvVariables()) {
+            setFinalStateValues(outputsFolder);
+        }
         Path errorFile = workingDir.resolve(ERROR_FILENAME);
         if (Files.exists(errorFile)) {
             Matcher errorMatcher = Pattern.compile(DYNAWO_ERROR_PATTERN + "(.*)").matcher(Files.readString(errorFile));
@@ -104,23 +111,14 @@ public final class DynawoSimulationHandler extends AbstractExecutionHandler<Dyna
             status = DynamicSimulationResult.Status.FAILURE;
             statusText = "Dynawo error log file not found";
         }
-
         return new DynamicSimulationResultImpl(status, statusText, curves, fsv, timeline);
     }
 
     private void setSuccessOutputs(Path workingDir, Path outputsFolder) throws IOException {
-        DynawoSimulationParameters parameters = context.getDynawoSimulationParameters();
         updateNetwork(workingDir);
-        DumpFileParameters dumpFileParameters = parameters.getDumpFileParameters();
+        DumpFileParameters dumpFileParameters = context.getDynawoSimulationParameters().getDumpFileParameters();
         if (dumpFileParameters.exportDumpFile()) {
             setDumpFile(outputsFolder, dumpFileParameters.dumpFileFolder(), workingDir.getFileName());
-        }
-        setTimeline(outputsFolder);
-        if (context.withCurveVariables()) {
-            setCurves(outputsFolder);
-        }
-        if (context.withFsvVariables()) {
-            setFinalStateValues(outputsFolder);
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #403


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix

**What is the current behavior?**
<!-- You can also link to an open issue here -->
When the simulation fails, only status and status text are returned


**What is the new behavior (if this is a feature change)?**
Return curves, fsv and timeline even if the simulation fails


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
This PR depends on [3281](https://github.com/powsybl/powsybl-core/pull/3281)