### PR TITLE
Fix unit tests: load i18n resource bundles

### DIFF
--- a/dynawo-dsl/src/test/java/com/powsybl/dynawo/dsl/AbstractModelSupplierTest.java
+++ b/dynawo-dsl/src/test/java/com/powsybl/dynawo/dsl/AbstractModelSupplierTest.java
@@ -22,7 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 abstract class AbstractModelSupplierTest {
 
-    protected final ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("dslTests", "DSL tests").build();
+    protected final ReportNode reportNode = ReportNode.newRootReportNode()
+            .withAllResourceBundlesFromClasspath()
+            .withMessageTemplate("dslTests", "DSL tests").build();
 
     protected InputStream getResourceAsStream(String name) {
         return Objects.requireNonNull(AbstractModelSupplierTest.class.getResourceAsStream(name));

--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynaFlowTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynaFlowTest.java
@@ -74,7 +74,9 @@ class DynaFlowTest extends AbstractDynawoTest {
                 .setPermanentLimit(200)
                 .add();
 
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("root", "testLf root report").build();
+        ReportNode reportNode = ReportNode.newRootReportNode()
+                .withAllResourceBundlesFromClasspath()
+                .withMessageTemplate("root", "testLf root report").build();
         LoadFlowResult result = loadFlowProvider.run(network, computationManager, VariantManagerConstants.INITIAL_VARIANT_ID, loadFlowParameters, reportNode)
                 .join();
 
@@ -107,7 +109,9 @@ class DynaFlowTest extends AbstractDynawoTest {
         network.getVoltageLevelStream().forEach(vl -> vl.setLowVoltageLimit(vl.getNominalV() * 0.97));
 
         // Launching a load flow before the security analysis is required
-        ReportNode reportNodeLf = ReportNode.newRootReportNode().withMessageTemplate("root", "Root message").build();
+        ReportNode reportNodeLf = ReportNode.newRootReportNode()
+                .withAllResourceBundlesFromClasspath()
+                .withMessageTemplate("root", "Root message").build();
         loadFlowProvider.run(network, computationManager, VariantManagerConstants.INITIAL_VARIANT_ID, loadFlowParameters, reportNodeLf).join();
 
         StringWriter swReportNodeLf = new StringWriter();
@@ -121,7 +125,9 @@ class DynaFlowTest extends AbstractDynawoTest {
                 .map(l -> Contingency.line(l.getId()))
                 .toList();
 
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("root", "Root message").build();
+        ReportNode reportNode = ReportNode.newRootReportNode()
+                .withAllResourceBundlesFromClasspath()
+                .withMessageTemplate("root", "Root message").build();
         SecurityAnalysisRunParameters runParameters = new SecurityAnalysisRunParameters()
                 .setComputationManager(computationManager)
                 .setSecurityAnalysisParameters(securityAnalysisParameters)

--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynawoSecurityAnalysisTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynawoSecurityAnalysisTest.java
@@ -85,6 +85,7 @@ class DynawoSecurityAnalysisTest extends AbstractDynawoTest {
                         .getResource(criteriaPath)).getPath()));
 
         ReportNode reportNode = ReportNode.newRootReportNode()
+                .withAllResourceBundlesFromClasspath()
                 .withMessageTemplate("root", "Root message")
                 .build();
 

--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynawoSimulationTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/DynawoSimulationTest.java
@@ -108,7 +108,9 @@ class DynawoSimulationTest extends AbstractDynawoTest {
 
     @Test
     void testIeee14WithSimulationCriteria() {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("integrationTest", "Integration test").build();
+        ReportNode reportNode = ReportNode.newRootReportNode()
+                .withAllResourceBundlesFromClasspath()
+                .withMessageTemplate("integrationTest", "Integration test").build();
         Supplier<DynamicSimulationResult> resultSupplier = setupIEEE14Simulation(reportNode);
         dynawoSimulationParameters.setCriteriaFilePath(Path.of(Objects.requireNonNull(getClass().getResource("/ieee14/criteria.crt")).getPath()));
         DynamicSimulationResult result = resultSupplier.get();

--- a/dynawo-simulation/src/test/java/com/powsybl/dynawo/builders/OutputVariablesBuilderTest.java
+++ b/dynawo-simulation/src/test/java/com/powsybl/dynawo/builders/OutputVariablesBuilderTest.java
@@ -24,7 +24,9 @@ class OutputVariablesBuilderTest {
 
     @BeforeEach
     void setup() {
-        reporter = ReportNode.newRootReportNode().withMessageTemplate("builderTests", "Builder tests").build();
+        reporter = ReportNode.newRootReportNode()
+                .withAllResourceBundlesFromClasspath()
+                .withMessageTemplate("builderTests", "Builder tests").build();
     }
 
     @Test

--- a/dynawo-simulation/src/test/java/com/powsybl/dynawo/models/BuilderEquipmentSetterTest.java
+++ b/dynawo-simulation/src/test/java/com/powsybl/dynawo/models/BuilderEquipmentSetterTest.java
@@ -33,7 +33,9 @@ class BuilderEquipmentSetterTest {
         Line ln1 = network.getLine("L1");
         Network network2 = PhaseShifterTestCaseFactory.create();
         Line ln2 = network2.getLine("L1");
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("builderTests", "Builder tests").build();
+        ReportNode reportNode = ReportNode.newRootReportNode()
+                .withAllResourceBundlesFromClasspath()
+                .withMessageTemplate("builderTests", "Builder tests").build();
 
         BlackBoxModel bbm1 = LineBuilder.of(network)
                 .dynamicModelId("BBM_LINE_NETWORK_1")

--- a/dynawo-simulation/src/test/java/com/powsybl/dynawo/models/HvdcTest.java
+++ b/dynawo-simulation/src/test/java/com/powsybl/dynawo/models/HvdcTest.java
@@ -65,6 +65,7 @@ class HvdcTest {
     @Test
     void testDefaultDanglingSide() {
         ReportNode reportNode = ReportNode.newRootReportNode()
+                .withAllResourceBundlesFromClasspath()
                 .withMessageTemplate("hvdcBuilder", "HVDC builder")
                 .build();
         Network network = HvdcTestNetwork.createVsc();

--- a/dynawo-simulation/src/test/java/com/powsybl/dynawo/xml/AbstractDynamicModelXmlTest.java
+++ b/dynawo-simulation/src/test/java/com/powsybl/dynawo/xml/AbstractDynamicModelXmlTest.java
@@ -49,7 +49,9 @@ public abstract class AbstractDynamicModelXmlTest extends AbstractSerDeTest {
     protected List<BlackBoxModel> eventModels = new ArrayList<>();
     protected List<OutputVariable> outputVariables = new ArrayList<>();
     protected DynawoSimulationContext context;
-    protected ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("testDyd", "Test DYD").build();
+    protected ReportNode reportNode = ReportNode.newRootReportNode()
+            .withAllResourceBundlesFromClasspath()
+            .withMessageTemplate("testDyd", "Test DYD").build();
 
     @BeforeEach
     void setup() {

--- a/dynawo-simulation/src/test/java/com/powsybl/dynawo/xml/AbstractParametrizedDynamicModelXmlTest.java
+++ b/dynawo-simulation/src/test/java/com/powsybl/dynawo/xml/AbstractParametrizedDynamicModelXmlTest.java
@@ -47,7 +47,9 @@ public abstract class AbstractParametrizedDynamicModelXmlTest extends AbstractSe
     protected List<BlackBoxModel> eventModels = new ArrayList<>();
     protected List<OutputVariable> outputVariables = new ArrayList<>();
     protected DynawoSimulationContext context;
-    protected ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("testDyd", "Test DYD").build();
+    protected ReportNode reportNode = ReportNode.newRootReportNode()
+            .withAllResourceBundlesFromClasspath()
+            .withMessageTemplate("testDyd", "Test DYD").build();
 
     public void validate(String schemaDefinition, String expectedResourceName, Path xmlFile) throws SAXException, IOException {
         InputStream expected = Objects.requireNonNull(getClass().getResourceAsStream("/" + expectedResourceName));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Some unit tests are failing because the i18n bundles are not loaded in their `ReportNode` roots.


**What is the new behavior (if this is a feature change)?**
The i18n bundles are loaded. Therefore, the unit tests end successfully.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

Adapt to powsybl/powsybl-core#3354 (ReportNode v3).

