### PR TITLE
Fix MarginCalculationParameters load in tool

### DIFF
--- a/dynawo-algorithms/dynawo-margin-calculation/src/main/java/com/powsybl/dynawo/margincalculation/tool/MarginCalculationTool.java
+++ b/dynawo-algorithms/dynawo-margin-calculation/src/main/java/com/powsybl/dynawo/margincalculation/tool/MarginCalculationTool.java
@@ -152,7 +152,7 @@ public class MarginCalculationTool implements Tool {
         LoadsVariationSupplier loadsVariationSupplier = LoadsVariationSupplier.getLoadsVariationSupplierForJson(loadVariationsFile);
         MarginCalculationParameters parameters = line.hasOption(PARAMETERS_FILE) ?
                 JsonMarginCalculationParameters.read(context.getFileSystem().getPath(line.getOptionValue(PARAMETERS_FILE)))
-                : MarginCalculationParameters.builder().build();
+                : MarginCalculationParameters.load();
         MarginCalculationRunParameters runParameters = new MarginCalculationRunParameters()
                 .setMarginCalculationParameters(parameters)
                 .setComputationManager(context.getShortTimeExecutionComputationManager())

--- a/dynawo-integration-tests/pom.xml
+++ b/dynawo-integration-tests/pom.xml
@@ -72,8 +72,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-config-classic</artifactId>
+            <artifactId>powsybl-config-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/AbstractDynawoTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/AbstractDynawoTest.java
@@ -45,4 +45,8 @@ public abstract class AbstractDynawoTest {
     protected static InputStream getResourceAsStream(String name) {
         return Objects.requireNonNull(AbstractDynawoTest.class.getResourceAsStream(name));
     }
+
+    protected static String getResource(String resourceName) {
+        return Objects.requireNonNull(AbstractDynawoTest.class.getResource(resourceName)).getPath();
+    }
 }

--- a/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/IToolsTest.java
+++ b/dynawo-integration-tests/src/test/java/com/powsybl/dynawo/it/IToolsTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.dynawo.it;
+
+import com.powsybl.commons.test.ComparisonUtils;
+import com.powsybl.computation.ComputationManager;
+import com.powsybl.dynawo.margincalculation.tool.MarginCalculationTool;
+import com.powsybl.tools.CommandLineTools;
+import com.powsybl.tools.ToolInitializationContext;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
+ */
+class IToolsTest extends AbstractDynawoTest {
+
+    private static CommandLineTools TOOLS;
+    private ToolInitializationContext toolContext;
+    private ByteArrayOutputStream bout;
+    private ByteArrayOutputStream berr;
+
+    @BeforeAll
+    static void beforeAll() {
+        TOOLS = new CommandLineTools(List.of(new MarginCalculationTool()));
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        super.setUp();
+        bout = new ByteArrayOutputStream();
+        berr = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(bout);
+        PrintStream err = new PrintStream(berr);
+        toolContext = new ToolInitializationContext() {
+
+            @Override
+            public PrintStream getOutputStream() {
+                return out;
+            }
+
+            @Override
+            public PrintStream getErrorStream() {
+                return err;
+            }
+
+            @Override
+            public FileSystem getFileSystem() {
+                return FileSystems.getDefault();
+            }
+
+            @Override
+            public Options getAdditionalOptions() {
+                return new Options();
+            }
+
+            @Override
+            public ComputationManager createShortTimeExecutionComputationManager(CommandLine commandLine) {
+                return computationManager;
+            }
+
+            @Override
+            public ComputationManager createLongTimeExecutionComputationManager(CommandLine commandLine) {
+                return computationManager;
+            }
+        };
+    }
+
+    @Test
+    void testIeee14Itools() {
+
+        String[] args = {"margin-calculation", "--case-file", getResource("/ieee14/IEEE14.iidm"),
+            "--dynamic-models-file", getResource("/ieee14/dynamicModels.groovy"),
+            "--contingencies-file", getResource("/ieee14/contingencies.groovy"),
+            "--load-variations-file", getResource("/ieee14/loadsVariations.json")};
+        int status = TOOLS.run(args, toolContext);
+
+        assertEquals(CommandLineTools.COMMAND_OK_STATUS, status);
+        ComparisonUtils.assertTxtEquals(getResourceAsStream("/itools/mc_out.txt"), getOutputString());
+        assertThat(getErrorString()).isEmpty();
+    }
+
+    private String getOutputString() {
+        return bout.toString(StandardCharsets.UTF_8);
+    }
+
+    private String getErrorString() {
+        return berr.toString(StandardCharsets.UTF_8);
+    }
+}

--- a/dynawo-integration-tests/src/test/resources/com/powsybl/config/test/config.yml
+++ b/dynawo-integration-tests/src/test/resources/com/powsybl/config/test/config.yml
@@ -1,0 +1,22 @@
+dynamic-simulation-default-parameters:
+  startTime: 1
+  stopTime: 100
+
+dynawo:
+  homeDir: /dynaflow-launcher
+  debug: false
+
+dynawo-algorithms:
+  homeDir: /dynaflow-launcher
+  debug: false
+
+dynawo-simulation-default-parameters:
+  parametersFile: /work/unittests/models.par
+  network.parametersFile: /work/unittests/network.par
+  network.parametersId: "8"
+  solver.type: IDA
+  solver.parametersFile: /work/unittests/solvers.par
+  solver.parametersId: "2"
+
+table-formatter:
+  language: en-US

--- a/dynawo-integration-tests/src/test/resources/com/powsybl/config/test/filelist.txt
+++ b/dynawo-integration-tests/src/test/resources/com/powsybl/config/test/filelist.txt
@@ -1,0 +1,4 @@
+config.yml
+models.par
+network.par
+solvers.par

--- a/dynawo-integration-tests/src/test/resources/com/powsybl/config/test/models.par
+++ b/dynawo-integration-tests/src/test/resources/com/powsybl/config/test/models.par
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parametersSet xmlns="http://www.rte-france.com/dynawo">
+     <set id="LAB">
+        <par type="DOUBLE" name="load_alpha" value="1.5"/>
+        <par type="DOUBLE" name="load_beta" value="2.5"/>
+        <reference type="DOUBLE" name="load_P0Pu" origData="IIDM" origName="p_pu"/>
+        <reference type="DOUBLE" name="load_Q0Pu" origData="IIDM" origName="q_pu"/>
+        <reference type="DOUBLE" name="load_U0Pu" origData="IIDM" origName="v_pu"/>
+        <reference type="DOUBLE" name="load_UPhase0" origData="IIDM" origName="angle_pu"/>
+    </set>
+    <set id="GSFWPR_GEN____1_SM">
+        <par type="BOOL" name="generator_UseApproximation" value="false"/>
+        <par type="INT" name="generator_ExcitationPu" value="1"/>
+        <par type="DOUBLE" name="generator_md" value="0.215"/>
+        <par type="DOUBLE" name="generator_mq" value="0.215"/>
+        <par type="DOUBLE" name="generator_nd" value="6.995"/>
+        <par type="DOUBLE" name="generator_nq" value="6.995"/>
+        <par type="DOUBLE" name="generator_MdPuEfd" value="0"/>
+        <par type="DOUBLE" name="generator_DPu" value="0"/>
+        <par type="DOUBLE" name="generator_H" value="5.4000000000000004"/>
+        <par type="DOUBLE" name="generator_RaPu" value="0.0027959999999999999"/>
+        <par type="DOUBLE" name="generator_XlPu" value="0.20200000000000001"/>
+        <par type="DOUBLE" name="generator_XdPu" value="2.2200000000000002"/>
+        <par type="DOUBLE" name="generator_XpdPu" value="0.38400000000000001"/>
+        <par type="DOUBLE" name="generator_XppdPu" value="0.26400000000000001"/>
+        <par type="DOUBLE" name="generator_Tpd0" value="8.0939999999999994"/>
+        <par type="DOUBLE" name="generator_Tppd0" value="0.080000000000000002"/>
+        <par type="DOUBLE" name="generator_XqPu" value="2.2200000000000002"/>
+        <par type="DOUBLE" name="generator_XpqPu" value="0.39300000000000002"/>
+        <par type="DOUBLE" name="generator_XppqPu" value="0.26200000000000001"/>
+        <par type="DOUBLE" name="generator_Tpq0" value="1.5720000000000001"/>
+        <par type="DOUBLE" name="generator_Tppq0" value="0.084000000000000005"/>
+        <par type="DOUBLE" name="generator_UNom" value="24"/>
+        <par type="DOUBLE" name="generator_SNom" value="1211"/>
+        <par type="DOUBLE" name="generator_PNomTurb" value="1090"/>
+        <par type="DOUBLE" name="generator_PNomAlt" value="1090"/>
+        <par type="DOUBLE" name="generator_SnTfo" value="1211"/>
+        <par type="DOUBLE" name="generator_UNomHV" value="69"/>
+        <par type="DOUBLE" name="generator_UNomLV" value="24"/>
+        <par type="DOUBLE" name="generator_UBaseHV" value="69"/>
+        <par type="DOUBLE" name="generator_UBaseLV" value="24"/>
+        <par type="DOUBLE" name="generator_RTfPu" value="0.0"/>
+        <par type="DOUBLE" name="generator_XTfPu" value="0.1"/>
+        <par type="DOUBLE" name="PmPu_ValueIn" value="0"/>
+        <par type="DOUBLE" name="EfdPu_ValueIn" value="0"/>
+        <par type="DOUBLE" name="voltageRegulator_LagEfdMax" value="0"/>
+        <par type="DOUBLE" name="voltageRegulator_LagEfdMin" value="0"/>
+        <par type="DOUBLE" name="voltageRegulator_EfdMinPu" value="-5"/>
+        <par type="DOUBLE" name="voltageRegulator_EfdMaxPu" value="5"/>
+        <par type="DOUBLE" name="voltageRegulator_UsRefMinPu" value="0.8"/>
+        <par type="DOUBLE" name="voltageRegulator_UsRefMaxPu" value="1.2"/>
+        <par type="DOUBLE" name="voltageRegulator_Gain" value="20"/>
+        <par type="DOUBLE" name="governor_KGover" value="5"/>
+        <par type="DOUBLE" name="governor_PMin" value="0"/>
+        <par type="DOUBLE" name="governor_PMax" value="1090"/>
+        <par type="DOUBLE" name="governor_PNom" value="1090"/>
+        <par type="DOUBLE" name="URef_ValueIn" value="0"/>
+        <par type="DOUBLE" name="Pm_ValueIn" value="0"/>
+        <reference name="generator_P0Pu" origData="IIDM" origName="p_pu" type="DOUBLE"/>
+        <reference name="generator_Q0Pu" origData="IIDM" origName="q_pu" type="DOUBLE"/>
+        <reference name="generator_U0Pu" origData="IIDM" origName="v_pu" type="DOUBLE"/>
+        <reference name="generator_UPhase0" origData="IIDM" origName="angle_pu" type="DOUBLE"/>
+    </set>
+    <set id="GSFWPR_GEN____2_SM">
+        <par type="BOOL" name="generator_UseApproximation" value="false"/>
+        <par type="INT" name="generator_ExcitationPu" value="1"/>
+        <par type="DOUBLE" name="generator_md" value="0.084"/>
+        <par type="DOUBLE" name="generator_mq" value="0.084"/>
+        <par type="DOUBLE" name="generator_nd" value="5.57"/>
+        <par type="DOUBLE" name="generator_nq" value="5.57"/>
+        <par type="DOUBLE" name="generator_MdPuEfd" value="0"/>
+        <par type="DOUBLE" name="generator_DPu" value="0"/>
+        <par type="DOUBLE" name="generator_H" value="6.2999999999999998"/>
+        <par type="DOUBLE" name="generator_RaPu" value="0.0035699999999999998"/>
+        <par type="DOUBLE" name="generator_XlPu" value="0.219"/>
+        <par type="DOUBLE" name="generator_XdPu" value="2.5699999999999998"/>
+        <par type="DOUBLE" name="generator_XpdPu" value="0.40699999999999997"/>
+        <par type="DOUBLE" name="generator_XppdPu" value="0.29999999999999999"/>
+        <par type="DOUBLE" name="generator_Tpd0" value="9.6509999999999998"/>
+        <par type="DOUBLE" name="generator_Tppd0" value="0.058000000000000003"/>
+        <par type="DOUBLE" name="generator_XqPu" value="2.5699999999999998"/>
+        <par type="DOUBLE" name="generator_XpqPu" value="0.45400000000000001"/>
+        <par type="DOUBLE" name="generator_XppqPu" value="0.30099999999999999"/>
+        <par type="DOUBLE" name="generator_Tpq0" value="1.0089999999999999"/>
+        <par type="DOUBLE" name="generator_Tppq0" value="0.059999999999999998"/>
+        <par type="DOUBLE" name="generator_UNom" value="24"/>
+        <par type="DOUBLE" name="generator_SNom" value="1120"/>
+        <par type="DOUBLE" name="generator_PNomTurb" value="1008"/>
+        <par type="DOUBLE" name="generator_PNomAlt" value="1008"/>
+        <par type="DOUBLE" name="generator_SnTfo" value="1120"/>
+        <par type="DOUBLE" name="generator_UNomHV" value="69"/>
+        <par type="DOUBLE" name="generator_UNomLV" value="24"/>
+        <par type="DOUBLE" name="generator_UBaseHV" value="69"/>
+        <par type="DOUBLE" name="generator_UBaseLV" value="24"/>
+        <par type="DOUBLE" name="generator_RTfPu" value="0.0"/>
+        <par type="DOUBLE" name="generator_XTfPu" value="0.1"/>
+        <par type="DOUBLE" name="PmPu_ValueIn" value="0"/>
+        <par type="DOUBLE" name="EfdPu_ValueIn" value="0"/>
+        <par type="DOUBLE" name="voltageRegulator_LagEfdMax" value="0"/>
+        <par type="DOUBLE" name="voltageRegulator_LagEfdMin" value="0"/>
+        <par type="DOUBLE" name="voltageRegulator_EfdMinPu" value="-5"/>
+        <par type="DOUBLE" name="voltageRegulator_EfdMaxPu" value="5"/>
+        <par type="DOUBLE" name="voltageRegulator_UsRefMinPu" value="0.8"/>
+        <par type="DOUBLE" name="voltageRegulator_UsRefMaxPu" value="1.2"/>
+        <par type="DOUBLE" name="voltageRegulator_Gain" value="20"/>
+        <par type="DOUBLE" name="governor_KGover" value="5"/>
+        <par type="DOUBLE" name="governor_PMin" value="0"/>
+        <par type="DOUBLE" name="governor_PMax" value="1008"/>
+        <par type="DOUBLE" name="governor_PNom" value="1008"/>
+        <par type="DOUBLE" name="URef_ValueIn" value="0"/>
+        <par type="DOUBLE" name="Pm_ValueIn" value="0"/>
+        <reference name="generator_P0Pu" origData="IIDM" origName="p_pu" type="DOUBLE"/>
+        <reference name="generator_Q0Pu" origData="IIDM" origName="q_pu" type="DOUBLE"/>
+        <reference name="generator_U0Pu" origData="IIDM" origName="v_pu" type="DOUBLE"/>
+        <reference name="generator_UPhase0" origData="IIDM" origName="angle_pu" type="DOUBLE"/>
+    </set>
+    <set id="GSFWPR_GEN____3_SM">
+        <par type="BOOL" name="generator_UseApproximation" value="false"/>
+        <par type="INT" name="generator_ExcitationPu" value="1"/>
+        <par type="DOUBLE" name="generator_md" value="0.05"/>
+        <par type="DOUBLE" name="generator_mq" value="0.05"/>
+        <par type="DOUBLE" name="generator_nd" value="9.285"/>
+        <par type="DOUBLE" name="generator_nq" value="9.285"/>
+        <par type="DOUBLE" name="generator_MdPuEfd" value="0"/>
+        <par type="DOUBLE" name="generator_DPu" value="0"/>
+        <par type="DOUBLE" name="generator_H" value="5.625"/>
+        <par type="DOUBLE" name="generator_RaPu" value="0.00316"/>
+        <par type="DOUBLE" name="generator_XlPu" value="0.25600000000000001"/>
+        <par type="DOUBLE" name="generator_XdPu" value="2.8100000000000001"/>
+        <par type="DOUBLE" name="generator_XpdPu" value="0.50900000000000001"/>
+        <par type="DOUBLE" name="generator_XppdPu" value="0.35399999999999998"/>
+        <par type="DOUBLE" name="generator_Tpd0" value="10.041"/>
+        <par type="DOUBLE" name="generator_Tppd0" value="0.065000000000000002"/>
+        <par type="DOUBLE" name="generator_XqPu" value="2.6200000000000001"/>
+        <par type="DOUBLE" name="generator_XpqPu" value="0.60099999999999998"/>
+        <par type="DOUBLE" name="generator_XppqPu" value="0.377"/>
+        <par type="DOUBLE" name="generator_Tpq0" value="1.22"/>
+        <par type="DOUBLE" name="generator_Tppq0" value="0.094"/>
+        <par type="DOUBLE" name="generator_UNom" value="20"/>
+        <par type="DOUBLE" name="generator_PNomTurb" value="1485"/>
+        <par type="DOUBLE" name="generator_PNomAlt" value="1485"/>
+        <par type="DOUBLE" name="generator_SNom" value="1650"/>
+        <par type="DOUBLE" name="generator_SnTfo" value="1650"/>
+        <par type="DOUBLE" name="generator_UNomHV" value="69"/>
+        <par type="DOUBLE" name="generator_UNomLV" value="20"/>
+        <par type="DOUBLE" name="generator_UBaseHV" value="69"/>
+        <par type="DOUBLE" name="generator_UBaseLV" value="20"/>
+        <par type="DOUBLE" name="generator_RTfPu" value="0.0"/>
+        <par type="DOUBLE" name="generator_XTfPu" value="0.1"/>
+        <par type="DOUBLE" name="PmPu_ValueIn" value="0"/>
+        <par type="DOUBLE" name="EfdPu_ValueIn" value="0"/>
+        <par type="DOUBLE" name="voltageRegulator_LagEfdMax" value="0"/>
+        <par type="DOUBLE" name="voltageRegulator_LagEfdMin" value="0"/>
+        <par type="DOUBLE" name="voltageRegulator_EfdMinPu" value="-5"/>
+        <par type="DOUBLE" name="voltageRegulator_EfdMaxPu" value="5"/>
+        <par type="DOUBLE" name="voltageRegulator_UsRefMinPu" value="0.8"/>
+        <par type="DOUBLE" name="voltageRegulator_UsRefMaxPu" value="1.2"/>
+        <par type="DOUBLE" name="voltageRegulator_Gain" value="20"/>
+        <par type="DOUBLE" name="governor_KGover" value="5"/>
+        <par type="DOUBLE" name="governor_PMin" value="0"/>
+        <par type="DOUBLE" name="governor_PMax" value="1485"/>
+        <par type="DOUBLE" name="governor_PNom" value="1485"/>
+        <par type="DOUBLE" name="URef_ValueIn" value="0"/>
+        <par type="DOUBLE" name="Pm_ValueIn" value="0"/>
+        <reference name="generator_P0Pu" origData="IIDM" origName="p_pu" type="DOUBLE"/>
+        <reference name="generator_Q0Pu" origData="IIDM" origName="q_pu" type="DOUBLE"/>
+        <reference name="generator_U0Pu" origData="IIDM" origName="v_pu" type="DOUBLE"/>
+        <reference name="generator_UPhase0" origData="IIDM" origName="angle_pu" type="DOUBLE"/>
+    </set>
+    <set id="GSTWPR_GEN____6_SM">
+        <par type="BOOL" name="generator_UseApproximation" value="false"/>
+        <par type="INT" name="generator_ExcitationPu" value="1"/>
+        <par type="DOUBLE" name="generator_md" value="0.16"/>
+        <par type="DOUBLE" name="generator_mq" value="0.16"/>
+        <par type="DOUBLE" name="generator_nd" value="5.7"/>
+        <par type="DOUBLE" name="generator_nq" value="5.7"/>
+        <par type="DOUBLE" name="generator_MdPuEfd" value="0"/>
+        <par type="DOUBLE" name="generator_DPu" value="0"/>
+        <par type="DOUBLE" name="generator_H" value="4.9750000000000001"/>
+        <par type="DOUBLE" name="generator_RaPu" value="0.004"/>
+        <par type="DOUBLE" name="generator_XlPu" value="0.102"/>
+        <par type="DOUBLE" name="generator_XdPu" value="0.75"/>
+        <par type="DOUBLE" name="generator_XpdPu" value="0.225"/>
+        <par type="DOUBLE" name="generator_XppdPu" value="0.154"/>
+        <par type="DOUBLE" name="generator_Tpd0" value="3"/>
+        <par type="DOUBLE" name="generator_Tppd0" value="0.04"/>
+        <par type="DOUBLE" name="generator_XqPu" value="0.45"/>
+        <par type="DOUBLE" name="generator_XppqPu" value="0.2"/>
+        <par type="DOUBLE" name="generator_Tppq0" value="0.04"/>
+        <par type="DOUBLE" name="generator_UNom" value="15"/>
+        <par type="DOUBLE" name="generator_PNomTurb" value="74.4"/>
+        <par type="DOUBLE" name="generator_PNomAlt" value="74.4"/>
+        <par type="DOUBLE" name="generator_SNom" value="80"/>
+        <par type="DOUBLE" name="generator_SnTfo" value="80"/>
+        <par type="DOUBLE" name="generator_UNomHV" value="15"/>
+        <par type="DOUBLE" name="generator_UNomLV" value="15"/>
+        <par type="DOUBLE" name="generator_UBaseHV" value="15"/>
+        <par type="DOUBLE" name="generator_UBaseLV" value="15"/>
+        <par type="DOUBLE" name="generator_RTfPu" value="0.0"/>
+        <par type="DOUBLE" name="generator_XTfPu" value="0.0"/>
+        <par type="DOUBLE" name="PmPu_ValueIn" value="0"/>
+        <par type="DOUBLE" name="EfdPu_ValueIn" value="0"/>
+        <par type="DOUBLE" name="voltageRegulator_LagEfdMax" value="0"/>
+        <par type="DOUBLE" name="voltageRegulator_LagEfdMin" value="0"/>
+        <par type="DOUBLE" name="voltageRegulator_EfdMinPu" value="-5"/>
+        <par type="DOUBLE" name="voltageRegulator_EfdMaxPu" value="5"/>
+        <par type="DOUBLE" name="voltageRegulator_UsRefMinPu" value="0.8"/>
+        <par type="DOUBLE" name="voltageRegulator_UsRefMaxPu" value="1.2"/>
+        <par type="DOUBLE" name="voltageRegulator_Gain" value="20"/>
+        <par type="DOUBLE" name="governor_KGover" value="5"/>
+        <par type="DOUBLE" name="governor_PMin" value="0"/>
+        <par type="DOUBLE" name="governor_PMax" value="74.4"/>
+        <par type="DOUBLE" name="governor_PNom" value="74.4"/>
+        <par type="DOUBLE" name="URef_ValueIn" value="0"/>
+        <par type="DOUBLE" name="Pm_ValueIn" value="0"/>
+        <reference name="generator_P0Pu" origData="IIDM" origName="p_pu" type="DOUBLE"/>
+        <reference name="generator_Q0Pu" origData="IIDM" origName="q_pu" type="DOUBLE"/>
+        <reference name="generator_U0Pu" origData="IIDM" origName="v_pu" type="DOUBLE"/>
+        <reference name="generator_UPhase0" origData="IIDM" origName="angle_pu" type="DOUBLE"/>
+    </set>
+    <set id="GSTWPR_GEN____8_SM">
+        <par type="BOOL" name="generator_UseApproximation" value="false"/>
+        <par type="INT" name="generator_ExcitationPu" value="1"/>
+        <par type="DOUBLE" name="generator_md" value="0"/>
+        <par type="DOUBLE" name="generator_mq" value="0"/>
+        <par type="DOUBLE" name="generator_nd" value="0"/>
+        <par type="DOUBLE" name="generator_nq" value="0"/>
+        <par type="DOUBLE" name="generator_MdPuEfd" value="0"/>
+        <par type="DOUBLE" name="generator_DPu" value="0"/>
+        <par type="DOUBLE" name="generator_H" value="2.748"/>
+        <par type="DOUBLE" name="generator_RaPu" value="0.0040000000000000001"/>
+        <par type="DOUBLE" name="generator_XlPu" value="0.11"/>
+        <par type="DOUBLE" name="generator_XdPu" value="1.53"/>
+        <par type="DOUBLE" name="generator_XpdPu" value="0.31"/>
+        <par type="DOUBLE" name="generator_XppdPu" value="0.275"/>
+        <par type="DOUBLE" name="generator_Tpd0" value="8.4"/>
+        <par type="DOUBLE" name="generator_Tppd0" value="0.096"/>
+        <par type="DOUBLE" name="generator_XqPu" value="0.99"/>
+        <par type="DOUBLE" name="generator_XppqPu" value="0.58"/>
+        <par type="DOUBLE" name="generator_Tppq0" value="0.56"/>
+        <par type="DOUBLE" name="generator_UNom" value="18"/>
+        <par type="DOUBLE" name="generator_PNomTurb" value="228"/>
+        <par type="DOUBLE" name="generator_PNomAlt" value="228"/>
+        <par type="DOUBLE" name="generator_SNom" value="250"/>
+        <par type="DOUBLE" name="generator_SnTfo" value="250"/>
+        <par type="DOUBLE" name="generator_UNomHV" value="13.8"/>
+        <par type="DOUBLE" name="generator_UNomLV" value="18"/>
+        <par type="DOUBLE" name="generator_UBaseHV" value="13.8"/>
+        <par type="DOUBLE" name="generator_UBaseLV" value="18"/>
+        <par type="DOUBLE" name="generator_RTfPu" value="0.0"/>
+        <par type="DOUBLE" name="generator_XTfPu" value="0.1"/>
+        <par type="DOUBLE" name="PmPu_ValueIn" value="0"/>
+        <par type="DOUBLE" name="EfdPu_ValueIn" value="0"/>
+        <par type="DOUBLE" name="voltageRegulator_LagEfdMax" value="0"/>
+        <par type="DOUBLE" name="voltageRegulator_LagEfdMin" value="0"/>
+        <par type="DOUBLE" name="voltageRegulator_EfdMinPu" value="-5"/>
+        <par type="DOUBLE" name="voltageRegulator_EfdMaxPu" value="5"/>
+        <par type="DOUBLE" name="voltageRegulator_UsRefMinPu" value="0.8"/>
+        <par type="DOUBLE" name="voltageRegulator_UsRefMaxPu" value="1.2"/>
+        <par type="DOUBLE" name="voltageRegulator_Gain" value="20"/>
+        <par type="DOUBLE" name="governor_KGover" value="5"/>
+        <par type="DOUBLE" name="governor_PMin" value="0"/>
+        <par type="DOUBLE" name="governor_PMax" value="228"/>
+        <par type="DOUBLE" name="governor_PNom" value="228"/>
+        <par type="DOUBLE" name="URef_ValueIn" value="0"/>
+        <par type="DOUBLE" name="Pm_ValueIn" value="0"/>
+        <reference name="generator_P0Pu" origData="IIDM" origName="p_pu" type="DOUBLE"/>
+        <reference name="generator_Q0Pu" origData="IIDM" origName="q_pu" type="DOUBLE"/>
+        <reference name="generator_U0Pu" origData="IIDM" origName="v_pu" type="DOUBLE"/>
+        <reference name="generator_UPhase0" origData="IIDM" origName="angle_pu" type="DOUBLE"/>
+    </set>
+    <set id="Disconnect__BUS____1-BUS____5-1_AC">
+        <par type="DOUBLE" name="event_tEvent" value="1"/>
+        <par type="BOOL" name="event_disconnectOrigin" value="false"/>
+        <par type="BOOL" name="event_disconnectExtremity" value="true"/>
+    </set>
+</parametersSet>

--- a/dynawo-integration-tests/src/test/resources/com/powsybl/config/test/network.par
+++ b/dynawo-integration-tests/src/test/resources/com/powsybl/config/test/network.par
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parametersSet xmlns="http://www.rte-france.com/dynawo">
+    <set id="8">
+        <par type="DOUBLE" name="capacitor_no_reclosing_delay" value="300"/>
+        <par type="DOUBLE" name="dangling_line_currentLimit_maxTimeOperation" value="90"/>
+        <par type="DOUBLE" name="line_currentLimit_maxTimeOperation" value="90"/>
+        <par type="DOUBLE" name="load_Tp" value="90"/>
+        <par type="DOUBLE" name="load_Tq" value="90"/>
+        <par type="DOUBLE" name="load_alpha" value="1"/>
+        <par type="DOUBLE" name="load_alphaLong" value="0"/>
+        <par type="DOUBLE" name="load_beta" value="2"/>
+        <par type="DOUBLE" name="load_betaLong" value="0"/>
+        <par type="BOOL" name="load_isControllable" value="false"/>
+        <par type="BOOL" name="load_isRestorative" value="false"/>
+        <par type="DOUBLE" name="load_zPMax" value="100"/>
+        <par type="DOUBLE" name="load_zQMax" value="100"/>
+        <par type="DOUBLE" name="reactance_no_reclosing_delay" value="0"/>
+        <par type="DOUBLE" name="transformer_currentLimit_maxTimeOperation" value="90"/>
+        <par type="DOUBLE" name="transformer_t1st_HT" value="60"/>
+        <par type="DOUBLE" name="transformer_t1st_THT" value="30"/>
+        <par type="DOUBLE" name="transformer_tNext_HT" value="10"/>
+        <par type="DOUBLE" name="transformer_tNext_THT" value="10"/>
+        <par type="DOUBLE" name="transformer_tolV" value="0.014999999700000001"/>
+    </set>
+</parametersSet>

--- a/dynawo-integration-tests/src/test/resources/com/powsybl/config/test/solvers.par
+++ b/dynawo-integration-tests/src/test/resources/com/powsybl/config/test/solvers.par
@@ -1,0 +1,54 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<parametersSet xmlns="http://www.rte-france.com/dynawo">
+    <!-- IDA order 1 solver-->
+    <set id="1">
+        <par type="INT" name="order" value="1"/>
+        <par type="DOUBLE" name="initStep" value="0.000001"/>
+        <par type="DOUBLE" name="minStep" value="0.000001"/>
+        <par type="DOUBLE" name="maxStep" value="10"/>
+        <par type="DOUBLE" name="absAccuracy" value="1e-4"/>
+        <par type="DOUBLE" name="relAccuracy" value="1e-4"/>
+    </set>
+    <!-- IDA order 2 solver -->
+    <set id="2">
+        <par type="INT" name="order" value="2"/>
+        <par type="DOUBLE" name="initStep" value="0.000001"/>
+        <par type="DOUBLE" name="minStep" value="0.000001"/>
+        <par type="DOUBLE" name="maxStep" value="10"/>
+        <par type="DOUBLE" name="absAccuracy" value="1e-4"/>
+        <par type="DOUBLE" name="relAccuracy" value="1e-4"/>
+    </set>
+    <!-- Simplified solver without step recalculation -->
+    <set id="3">
+        <par type="DOUBLE" name="hMin" value="0.000001"/>
+        <par type="DOUBLE" name="hMax" value="1"/>
+        <par type="DOUBLE" name="kReduceStep" value="0.5"/>
+        <par type="INT" name="nEff" value="10"/>
+        <par type="INT" name="nDeadband" value="2"/>
+        <par type="INT" name="maxRootRestart" value="3"/>
+        <par type="INT" name="maxNewtonTry" value="10"/>
+        <par type="STRING" name="linearSolverName" value="KLU"/>
+        <par type="BOOL" name="recalculateStep" value="false"/>
+    </set>
+    <!-- Simplified solver with step recalculation -->
+    <set id="4">
+        <par type="DOUBLE" name="hMin" value="0.000001"/>
+        <par type="DOUBLE" name="hMax" value="1"/>
+        <par type="DOUBLE" name="kReduceStep" value="0.5"/>
+        <par type="INT" name="nEff" value="10"/>
+        <par type="INT" name="nDeadband" value="2"/>
+        <par type="INT" name="maxRootRestart" value="3"/>
+        <par type="INT" name="maxNewtonTry" value="10"/>
+        <par type="STRING" name="linearSolverName" value="KLU"/>
+        <par type="BOOL" name="recalculateStep" value="true"/>
+    </set>
+    <!-- IDA order 2 solver with higher accuracy requirements -->
+    <set id="5">
+        <par type="INT" name="order" value="2"/>
+        <par type="DOUBLE" name="initStep" value="0.000001"/>
+        <par type="DOUBLE" name="minStep" value="0.000001"/>
+        <par type="DOUBLE" name="maxStep" value="10"/>
+        <par type="DOUBLE" name="absAccuracy" value="1e-6"/>
+        <par type="DOUBLE" name="relAccuracy" value="1e-6"/>
+    </set>
+</parametersSet>

--- a/dynawo-integration-tests/src/test/resources/ieee14/contingencies.groovy
+++ b/dynawo-integration-tests/src/test/resources/ieee14/contingencies.groovy
@@ -1,0 +1,5 @@
+package ieee14
+
+contingency('GEN') {
+    equipments '_GEN____2_SM'
+}

--- a/dynawo-integration-tests/src/test/resources/ieee14/loadsVariations.json
+++ b/dynawo-integration-tests/src/test/resources/ieee14/loadsVariations.json
@@ -1,0 +1,8 @@
+{
+  "variations": [
+    {
+      "loadsIds": ["_LOAD___6_EC"],
+      "variationValue": 10
+    }
+  ]
+}

--- a/dynawo-integration-tests/src/test/resources/itools/mc_out.txt
+++ b/dynawo-integration-tests/src/test/resources/itools/mc_out.txt
@@ -1,0 +1,40 @@
+Loading network '/home/issertiallau/projects/PowSyBl/powsybl-dynawo/dynawo-integration-tests/target/test-classes/ieee14/IEEE14.iidm'
++ Margin Calculation Tool
+   + Dynawo margin calculation on network 'ieee14bus'
+      + Groovy Dynamic Models Supplier
+         Model LoadAlphaBeta _LOAD__10_EC instantiation OK
+         Model LoadAlphaBeta _LOAD__11_EC instantiation OK
+         Model LoadAlphaBeta _LOAD__12_EC instantiation OK
+         Model LoadAlphaBeta _LOAD__13_EC instantiation OK
+         Model LoadAlphaBeta _LOAD__14_EC instantiation OK
+         Model LoadAlphaBeta _LOAD___2_EC instantiation OK
+         Model LoadAlphaBeta _LOAD___3_EC instantiation OK
+         Model LoadAlphaBeta _LOAD___9_EC instantiation OK
+         Model LoadAlphaBeta _LOAD___4_EC instantiation OK
+         Model LoadAlphaBeta _LOAD___6_EC instantiation OK
+         Model LoadAlphaBeta _LOAD___5_EC instantiation OK
+         Model GeneratorSynchronousFourWindingsProportionalRegulations _GEN____1_SM instantiation OK
+         Model GeneratorSynchronousFourWindingsProportionalRegulations _GEN____2_SM instantiation OK
+         Model GeneratorSynchronousFourWindingsProportionalRegulations _GEN____3_SM instantiation OK
+         Model GeneratorSynchronousThreeWindingsProportionalRegulations _GEN____6_SM instantiation OK
+         Model GeneratorSynchronousThreeWindingsProportionalRegulations _GEN____8_SM instantiation OK
+      Dynawo models processing
+Margin calculation results:
++------------+-------------+-----------------+----------------------+---------------+------------------+---------------------------+--------------------------------+
+| Load level | Status      | Failed criteria | Failed criteria time | Scenarios     | Scenarios Status | Scenarios failed criteria | Scenarios failed criteria time |
++------------+-------------+-----------------+----------------------+---------------+------------------+---------------------------+--------------------------------+
+| 0.00000    | CONVERGENCE |                 |                      | Scenarios (1) |                  |                           |                                |
+|            |             |                 |                      | GEN           | CONVERGENCE      |                           |                                |
+| 50.0000    | CONVERGENCE |                 |                      | Scenarios (1) |                  |                           |                                |
+|            |             |                 |                      | GEN           | CONVERGENCE      |                           |                                |
+| 75.0000    | CONVERGENCE |                 |                      | Scenarios (1) |                  |                           |                                |
+|            |             |                 |                      | GEN           | CONVERGENCE      |                           |                                |
+| 88.0000    | CONVERGENCE |                 |                      | Scenarios (1) |                  |                           |                                |
+|            |             |                 |                      | GEN           | CONVERGENCE      |                           |                                |
+| 94.0000    | CONVERGENCE |                 |                      | Scenarios (1) |                  |                           |                                |
+|            |             |                 |                      | GEN           | CONVERGENCE      |                           |                                |
+| 97.0000    | CONVERGENCE |                 |                      | Scenarios (1) |                  |                           |                                |
+|            |             |                 |                      | GEN           | CONVERGENCE      |                           |                                |
+| 99.0000    | CONVERGENCE |                 |                      | Scenarios (1) |                  |                           |                                |
+|            |             |                 |                      | GEN           | CONVERGENCE      |                           |                                |
++------------+-------------+-----------------+----------------------+---------------+------------------+---------------------------+--------------------------------+


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When launching margin calculation in itools the `MarginCalculationParameters` are not loaded from the config.


**What is the new behavior (if this is a feature change)?**
Fix `MarginCalculationParameters` loading.
Add itools integration test for MC.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
