### PR TITLE
Set locale to en_US in maven surefire plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,18 @@
             <modules>
                 <module>dynawo-integration-tests</module>
             </modules>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <!-- Argument added to set the default locale as en_US for unit tests run to be independent of the JVM locale -->
+                            <argLine>-Duser.language=en -Duser.region=US</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Maven plugin configuration


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Locale is not set in maven-surefire-plugin


**What is the new behavior (if this is a feature change)?**
Set locale to en_US in maven-surefire-plugin


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
