### PR TITLE
Fix test locale

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,20 +117,21 @@
             <modules>
                 <module>dynawo-integration-tests</module>
             </modules>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <!-- Argument added to set the default locale as en_US for unit tests run to be independent of the JVM locale -->
-                            <argLine>@{argLine} -Duser.language=en -Duser.region=US ${enable-dynamic-agent-loading.argLine}</argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Argument added to set the default locale as en_US for unit tests run to be independent of the JVM locale -->
+                    <argLine>@{argLine} -Duser.language=en -Duser.region=US ${enable-dynamic-agent-loading.argLine}</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
maven-surefire-plugin configuration for setting locale to US is inside integration-tests profile
Thus some tests fails when running maven with a locale different from US.

**What is the new behavior (if this is a feature change)?**
maven-surefire-plugin configuration for setting locale to US is outside integration-tests profile


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
