### PR TITLE
Replace univocity with FastCSV

### DIFF
--- a/commons/src/main/java/com/powsybl/dynawo/commons/AbstractCsvParser.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/AbstractCsvParser.java
@@ -30,17 +30,17 @@ public abstract class AbstractCsvParser<T> {
 
     protected static final char DEFAULT_SEPARATOR = '|';
 
-    private char separator = DEFAULT_SEPARATOR;
-    private boolean skipHeader = false;
-    private int maxColumns = -1;
+    private final char separator;
+    private final boolean skipHeader;
+    private final int maxColumns;
 
     protected AbstractCsvParser(char separator, boolean skipHeader) {
-        this.separator = separator;
-        this.skipHeader = skipHeader;
+        this(separator, skipHeader, -1);
     }
 
     protected AbstractCsvParser(char separator, boolean skipHeader, int maxColumns) {
-        this(separator, skipHeader);
+        this.separator = separator;
+        this.skipHeader = skipHeader;
         this.maxColumns = maxColumns;
     }
 
@@ -60,30 +60,32 @@ public abstract class AbstractCsvParser<T> {
             if (skipHeader) {
                 csvReader.skipLines(1);
             }
-            List<T> logs = new ArrayList<>();
+            List<T> results = new ArrayList<>();
             AtomicInteger lineIndex = new AtomicInteger(0);
-            csvReader.forEach(csvRecord -> {
-                int iLine = lineIndex.incrementAndGet();
-                int size = maxColumns >= 0 && maxColumns < csvRecord.getFieldCount() ?
-                        maxColumns : csvRecord.getFieldCount();
-                if (hasCorrectNbColumns(size)) {
-                    List<String> fields = csvRecord.getFields();
-                    String[] tokens = new String[size];
-                    for (int i = 0; i < fields.size(); i++) {
-                        tokens[i] = fields.get(i).trim();
-                        if (tokens[i].isEmpty()) {
-                            tokens[i] = null;
-                        }
-                    }
-                    createEntry(tokens).ifPresent(logs::add);
-                } else {
-                    LOGGER.warn("Columns of line {} are inconsistent, the line will be skipped", iLine);
-                }
-            });
-            return logs;
+            csvReader.forEach(csvRecord ->
+                    parseRecord(csvRecord, lineIndex.incrementAndGet()).ifPresent(results::add));
+            return results;
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    private Optional<T> parseRecord(CsvRecord csvRecord, int iLine) {
+        int size = maxColumns >= 0 && maxColumns < csvRecord.getFieldCount() ?
+                maxColumns : csvRecord.getFieldCount();
+        if (!hasCorrectNbColumns(size)) {
+            LOGGER.warn("Columns of line {} are inconsistent, the line will be skipped", iLine);
+            return Optional.empty();
+        }
+        List<String> fields = csvRecord.getFields();
+        String[] tokens = new String[size];
+        for (int i = 0; i < fields.size(); i++) {
+            tokens[i] = fields.get(i).trim();
+            if (tokens[i].isEmpty()) {
+                tokens[i] = null;
+            }
+        }
+        return createEntry(tokens);
     }
 
     protected abstract Optional<T> createEntry(String[] tokens);

--- a/commons/src/main/java/com/powsybl/dynawo/commons/AbstractCsvParser.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/AbstractCsvParser.java
@@ -7,10 +7,8 @@
  */
 package com.powsybl.dynawo.commons;
 
-import com.univocity.parsers.common.ParsingContext;
-import com.univocity.parsers.common.ResultIterator;
-import com.univocity.parsers.csv.CsvParser;
-import com.univocity.parsers.csv.CsvParserSettings;
+import de.siegmar.fastcsv.reader.CsvReader;
+import de.siegmar.fastcsv.reader.CsvRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
@@ -31,42 +30,60 @@ public abstract class AbstractCsvParser<T> {
 
     protected static final char DEFAULT_SEPARATOR = '|';
 
-    protected CsvParser csvParser;
+    private char separator = DEFAULT_SEPARATOR;
+    private boolean skipHeader = false;
+    private int maxColumns = -1;
 
-    protected static CsvParserSettings setupSettings(char separator, boolean skipHeader) {
-        CsvParserSettings settings = new CsvParserSettings();
-        settings.getFormat().setDelimiter(separator);
-        settings.getFormat().setQuoteEscape('"');
-        settings.getFormat().setLineSeparator(System.lineSeparator());
-        settings.setHeaderExtractionEnabled(skipHeader);
-        return settings;
+    protected AbstractCsvParser(char separator, boolean skipHeader) {
+        this.separator = separator;
+        this.skipHeader = skipHeader;
+    }
+
+    protected AbstractCsvParser(char separator, boolean skipHeader, int maxColumns) {
+        this(separator, skipHeader);
+        this.maxColumns = maxColumns;
     }
 
     public List<T> parse(Path file) {
         if (!Files.exists(file)) {
             return Collections.emptyList();
         }
-        try (BufferedReader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
-            Objects.requireNonNull(reader);
-            return read(csvParser.iterate(reader).iterator());
+        try (BufferedReader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8);
+             CsvReader<CsvRecord> csvReader = CsvReader.builder()
+                     .fieldSeparator(separator)
+                     .quoteCharacter('"')
+                     .allowMissingFields(true)
+                     .allowExtraFields(true)
+                     .trimWhitespacesAroundQuotes(true)
+                     .skipEmptyLines(true)
+                     .ofCsvRecord(reader)) {
+            if (skipHeader) {
+                csvReader.skipLines(1);
+            }
+            List<T> logs = new ArrayList<>();
+            AtomicInteger lineIndex = new AtomicInteger(0);
+            csvReader.forEach(csvRecord -> {
+                int iLine = lineIndex.incrementAndGet();
+                int size = maxColumns >= 0 && maxColumns < csvRecord.getFieldCount() ?
+                        maxColumns : csvRecord.getFieldCount();
+                if (hasCorrectNbColumns(size)) {
+                    List<String> fields = csvRecord.getFields();
+                    String[] tokens = new String[size];
+                    for (int i = 0; i < fields.size(); i++) {
+                        tokens[i] = fields.get(i).trim();
+                        if (tokens[i].isEmpty()) {
+                            tokens[i] = null;
+                        }
+                    }
+                    createEntry(tokens).ifPresent(logs::add);
+                } else {
+                    LOGGER.warn("Columns of line {} are inconsistent, the line will be skipped", iLine);
+                }
+            });
+            return logs;
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-    }
-
-    protected List<T> read(ResultIterator<String[], ParsingContext> iterator) {
-        List<T> logs = new ArrayList<>();
-        int iLine = 0;
-        while (iterator.hasNext()) {
-            iLine++;
-            String[] tokens = iterator.next();
-            if (hasCorrectNbColumns(tokens.length)) {
-                createEntry(tokens).ifPresent(logs::add);
-            } else {
-                LOGGER.warn("Columns of line {} are inconsistent, the line will be skipped", iLine);
-            }
-        }
-        return logs;
     }
 
     protected abstract Optional<T> createEntry(String[] tokens);

--- a/commons/src/main/java/com/powsybl/dynawo/commons/dynawologs/CsvLogParser.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/dynawologs/CsvLogParser.java
@@ -8,8 +8,6 @@
 package com.powsybl.dynawo.commons.dynawologs;
 
 import com.powsybl.dynawo.commons.AbstractCsvParser;
-import com.univocity.parsers.csv.CsvParser;
-import com.univocity.parsers.csv.CsvParserSettings;
 
 import java.util.Optional;
 
@@ -27,8 +25,7 @@ public final class CsvLogParser extends AbstractCsvParser<LogEntry> {
     }
 
     public CsvLogParser(char separator) {
-        CsvParserSettings settings = setupSettings(separator, false);
-        this.csvParser = new CsvParser(settings);
+        super(separator, false);
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/dynawo/commons/timeline/CsvTimeLineParser.java
+++ b/commons/src/main/java/com/powsybl/dynawo/commons/timeline/CsvTimeLineParser.java
@@ -8,8 +8,6 @@
 package com.powsybl.dynawo.commons.timeline;
 
 import com.powsybl.dynawo.commons.AbstractCsvParser;
-import com.univocity.parsers.csv.CsvParser;
-import com.univocity.parsers.csv.CsvParserSettings;
 
 import java.util.Optional;
 
@@ -25,9 +23,7 @@ public final class CsvTimeLineParser extends AbstractCsvParser<TimelineEntry> im
     }
 
     public CsvTimeLineParser(char separator) {
-        CsvParserSettings settings = setupSettings(separator, false);
-        settings.setMaxColumns(NB_COLUMNS);
-        this.csvParser = new CsvParser(settings);
+        super(separator, false, NB_COLUMNS);
     }
 
     @Override

--- a/dynawo-simulation/src/main/java/com/powsybl/dynawo/outputvariables/CsvFsvParser.java
+++ b/dynawo-simulation/src/main/java/com/powsybl/dynawo/outputvariables/CsvFsvParser.java
@@ -8,8 +8,6 @@
 package com.powsybl.dynawo.outputvariables;
 
 import com.powsybl.dynawo.commons.AbstractCsvParser;
-import com.univocity.parsers.csv.CsvParser;
-import com.univocity.parsers.csv.CsvParserSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,9 +27,7 @@ public final class CsvFsvParser extends AbstractCsvParser<FsvEntry> {
     }
 
     public CsvFsvParser(char separator) {
-        CsvParserSettings settings = setupSettings(separator, true);
-        settings.setMaxColumns(NB_COLUMNS);
-        this.csvParser = new CsvParser(settings);
+        super(separator, true, NB_COLUMNS);
     }
 
     @Override


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
Change of dependency

**What is the current behavior?**
powsybl-dynawo uses univocity-parsers for handling CSV files (parsing and writing), but [this lib is abandoned since 2021](https://github.com/uniVocity/univocity-parsers/issues/534).

**What is the new behavior (if this is a feature change)?**
powsybl-dynawo now uses [FastCSV](https://fastcsv.org/) for handling CSV files.



**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [X] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

If you implement `AbstractCsvParser`, you should call one of its constructors:
- `AbstractCsvParser(char separator, boolean skipHeader)`
- `AbstractCsvParser(char separator, boolean skipHeader, int maxColumns)`
in your subclass' constructor.

This call should replace calls to `AbstractCsvParser.setupSettings(char separator, boolean skipHeader)` which was removed.

In addition, the protected method `AbstractCsvParser.read(ResultIterator<String[], ParsingContext> iterator)` was removed.

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
